### PR TITLE
feat: interactive design workflow (feature 009)

### DIFF
--- a/.maina/features/009-interactive-design/plan.md
+++ b/.maina/features/009-interactive-design/plan.md
@@ -49,28 +49,28 @@ TDD: every implementation task must have a preceding test task.
 
 ### Part B: Interactive Spec Questions
 
-- [ ] Task 1: Create `spec-questions.md` prompt template
-- [ ] Task 2: Write failing tests for `generateSpecQuestions()`
-- [ ] Task 3: Implement `generateSpecQuestions()` in `core/ai/spec-questions.ts`
-- [ ] Task 4: Write failing tests for interactive spec flow in `spec.test.ts`
-- [ ] Task 5: Add question phase to `specAction()` — ask questions, append to spec.md
-- [ ] Task 6: Add `--no-interactive` flag to spec command
-- [ ] Task 7: Update MCP `suggestTests` to include questions
+- [ ] Task 1: Create `spec-questions.md` prompt template for clarifying questions (AC-6)
+- [ ] Task 2: Write failing tests for `generateSpecQuestions()` — clarifying questions from plan (AC-1, AC-6)
+- [ ] Task 3: Implement `generateSpecQuestions()` in `core/ai/spec-questions.ts` — derive questions from plan content (AC-1, AC-6)
+- [ ] Task 4: Write failing tests for spec clarifying questions flow, --no-interactive skip, answers recorded in Clarifications (AC-1, AC-2, AC-7)
+- [ ] Task 5: Add question phase to `specAction()` — ask clarifying questions, record answers in spec.md Clarifications (AC-1, AC-7)
+- [ ] Task 6: Add `--no-interactive` flag to spec command — skip questions, preserve current behavior (AC-2)
+- [ ] Task 7: Update MCP `suggestTests` to include questions when ambiguities detected (AC-5)
 
 ### Part C: Multi-Approach Design
 
-- [ ] Task 8: Create `design-approaches.md` prompt template
-- [ ] Task 9: Write failing tests for `generateDesignApproaches()`
-- [ ] Task 10: Implement `generateDesignApproaches()` in `core/ai/design-approaches.ts`
-- [ ] Task 11: Write failing tests for interactive design flow in `design.test.ts`
-- [ ] Task 12: Add approach phase to `designAction()` — propose, select, record in ADR
-- [ ] Task 13: Add `--no-interactive` flag to design command
+- [ ] Task 8: Create `design-approaches.md` prompt template for design approaches with tradeoffs (AC-3)
+- [ ] Task 9: Write failing tests for `generateDesignApproaches()` — propose approaches with pros/cons (AC-3, AC-8)
+- [ ] Task 10: Implement `generateDesignApproaches()` in `core/ai/design-approaches.ts` — approaches with recommendation (AC-3)
+- [ ] Task 11: Write failing tests for design approaches with pros/cons, --no-interactive skip, selection recorded in ADR Alternatives Considered (AC-3, AC-4, AC-8)
+- [ ] Task 12: Add approach phase to `designAction()` — propose approaches, select, record in ADR Alternatives Considered (AC-3, AC-8)
+- [ ] Task 13: Add `--no-interactive` flag to design command — skip proposals, preserve current behavior (AC-4)
 
 ### Integration
 
-- [ ] Task 14: Export new functions from `packages/core/src/index.ts`
-- [ ] Task 15: Run `maina verify --all`, fix any findings
-- [ ] Task 16: Run `maina analyze` to verify spec-plan consistency
+- [ ] Task 14: Export clarifying questions and design approaches functions for spec and design commands (AC-1, AC-3)
+- [ ] Task 15: Verify spec quality score improves — run full verification, fix findings (AC-9)
+- [ ] Task 16: Verify spec quality score improves above 67/100 baseline — run `maina analyze` for consistency (AC-9)
 
 ## Failure Modes
 

--- a/.maina/features/009-interactive-design/spec.md
+++ b/.maina/features/009-interactive-design/spec.md
@@ -2,10 +2,10 @@
 
 ## Problem Statement
 
-`maina spec` generates test stubs mechanically from plan.md — it doesn't explore requirements or surface ambiguity before implementation. `maina design` creates ADRs but doesn't help the user think through approaches. When building UI-heavy features (like the docs landing page), we had to use Superpowers brainstorming skill to iterate on design, then manually translate that into maina artifacts. This gap causes:
+The spec command generates test stubs mechanically without exploring requirements or surfacing ambiguity first. The design command creates ADRs but doesn't help the user think through alternative approaches. This forces developers to iterate on design outside of maina, then manually translate decisions back into artifacts. This gap causes:
 
-1. Specs that miss edge cases because requirements weren't explored through questions
-2. Designs that pick the first approach without considering alternatives
+1. Specs that miss edge cases because requirements weren't explored through clarifying questions
+2. Designs that pick the first approach without considering alternatives with tradeoffs
 3. No feedback loop between design exploration and spec/plan artifacts
 
 ## Target User
@@ -21,15 +21,15 @@
 
 ## Success Criteria
 
-- [ ] `maina spec` in interactive mode asks 3-5 clarifying questions derived from plan.md before generating stubs
-- [ ] `maina spec --no-interactive` skips questions and generates stubs directly (current behavior preserved)
-- [ ] `maina design` proposes 2-3 approaches with pros/cons/recommendation before writing the ADR
-- [ ] `maina design --no-interactive` skips proposals and writes ADR directly (current behavior preserved)
-- [ ] MCP `suggestTests` tool returns questions as part of its response when ambiguities are detected
-- [ ] Questions are derived from actual plan.md content, not generic templates
-- [ ] User answers are recorded in spec.md under a "Clarifications" section
-- [ ] Approach selection is recorded in the ADR under "Alternatives Considered"
-- [ ] Spec quality score improves (baseline: 67/100 average)
+- [ ] AC-1: `maina spec` in interactive mode asks 3-5 clarifying questions derived from plan.md before generating stubs
+- [ ] AC-2: `maina spec --no-interactive` skips questions and generates stubs directly (current behavior preserved)
+- [ ] AC-3: `maina design` proposes 2-3 approaches with pros/cons/recommendation before writing the ADR
+- [ ] AC-4: `maina design --no-interactive` skips proposals and writes ADR directly (current behavior preserved)
+- [ ] AC-5: MCP `suggestTests` tool returns questions as part of its response when ambiguities are detected
+- [ ] AC-6: Questions are derived from actual plan.md content, not generic templates
+- [ ] AC-7: User answers are recorded in spec.md under a "Clarifications" section
+- [ ] AC-8: Approach selection is recorded in the ADR under "Alternatives Considered"
+- [ ] AC-9: Spec quality score improves (baseline: 67/100 average)
 
 ## Scope
 

--- a/.maina/features/009-interactive-design/tasks.md
+++ b/.maina/features/009-interactive-design/tasks.md
@@ -4,28 +4,28 @@
 
 ### Part B: Interactive Spec Questions
 
-- [ ] Task 1: Create spec-questions.md prompt template
-- [ ] Task 2: Write failing tests for generateSpecQuestions()
-- [ ] Task 3: Implement generateSpecQuestions()
-- [ ] Task 4: Write failing tests for interactive spec flow
-- [ ] Task 5: Add question phase to specAction()
-- [ ] Task 6: Add --no-interactive flag to spec command
-- [ ] Task 7: Update MCP suggestTests to include questions
+- [ ] Task 1: Create spec-questions.md prompt template for clarifying questions (AC-6)
+- [ ] Task 2: Write failing tests for generateSpecQuestions() — clarifying questions from plan (AC-1, AC-6)
+- [ ] Task 3: Implement generateSpecQuestions() — derive questions from plan content (AC-1, AC-6)
+- [ ] Task 4: Write failing tests for spec clarifying questions flow, --no-interactive skip, answers recorded in Clarifications (AC-1, AC-2, AC-7)
+- [ ] Task 5: Add question phase to specAction() — ask questions, record answers in Clarifications (AC-1, AC-7)
+- [ ] Task 6: Add --no-interactive flag to spec command — skip questions, preserve current behavior (AC-2)
+- [ ] Task 7: Update MCP suggestTests to include questions when ambiguities detected (AC-5)
 
 ### Part C: Multi-Approach Design
 
-- [ ] Task 8: Create design-approaches.md prompt template
-- [ ] Task 9: Write failing tests for generateDesignApproaches()
-- [ ] Task 10: Implement generateDesignApproaches()
-- [ ] Task 11: Write failing tests for interactive design flow
-- [ ] Task 12: Add approach phase to designAction()
-- [ ] Task 13: Add --no-interactive flag to design command
+- [ ] Task 8: Create design-approaches.md prompt template for approaches with tradeoffs (AC-3)
+- [ ] Task 9: Write failing tests for generateDesignApproaches() — propose approaches with pros/cons (AC-3, AC-8)
+- [ ] Task 10: Implement generateDesignApproaches() — approaches with recommendation (AC-3)
+- [ ] Task 11: Write failing tests for design approaches with pros/cons, --no-interactive skip, selection recorded in ADR Alternatives Considered (AC-3, AC-4, AC-8)
+- [ ] Task 12: Add approach phase to designAction() — propose approaches, record in ADR Alternatives Considered (AC-3, AC-8)
+- [ ] Task 13: Add --no-interactive flag to design command — skip proposals, preserve current behavior (AC-4)
 
 ### Integration
 
-- [ ] Task 14: Export new functions from core/index.ts
-- [ ] Task 15: Run maina verify --all, fix findings
-- [ ] Task 16: Run maina analyze, verify consistency
+- [ ] Task 14: Export clarifying questions and design approaches functions for spec and design commands (AC-1, AC-3)
+- [ ] Task 15: Verify spec quality score improves — run full verification, fix findings (AC-9)
+- [ ] Task 16: Verify spec quality score improves above 67/100 baseline — run analyze for consistency (AC-9)
 
 ## Dependencies
 

--- a/packages/cli/src/commands/__tests__/design.test.ts
+++ b/packages/cli/src/commands/__tests__/design.test.ts
@@ -14,6 +14,15 @@ import { join } from "node:path";
 
 let mockClackTextResponses: string[] = [];
 let mockClackTextCallIndex = 0;
+let mockClackSelectResponses: string[] = [];
+let mockClackSelectCallIndex = 0;
+let mockDesignApproaches: Array<{
+	name: string;
+	description: string;
+	pros: string[];
+	cons: string[];
+	recommended: boolean;
+}> = [];
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -37,8 +46,23 @@ mock.module("@clack/prompts", () => ({
 		mockClackTextCallIndex++;
 		return response;
 	},
+	select: async () => {
+		const response = mockClackSelectResponses[mockClackSelectCallIndex] ?? "";
+		mockClackSelectCallIndex++;
+		return response;
+	},
 	confirm: async () => true,
 	isCancel: (v: unknown) => typeof v === "symbol",
+}));
+
+mock.module("@maina/core", () => ({
+	getNextAdrNumber: async () => ({ ok: true, value: "0001" }),
+	scaffoldAdr: async () => ({ ok: true, value: "" }),
+	listAdrs: async () => ({ ok: true, value: [] }),
+	generateDesignApproaches: async () => ({
+		ok: true,
+		value: mockDesignApproaches,
+	}),
 }));
 
 afterAll(() => {
@@ -64,6 +88,9 @@ beforeEach(() => {
 	// Reset mock state
 	mockClackTextResponses = [];
 	mockClackTextCallIndex = 0;
+	mockClackSelectResponses = [];
+	mockClackSelectCallIndex = 0;
+	mockDesignApproaches = [];
 });
 
 afterEach(() => {
@@ -227,5 +254,121 @@ describe("designAction", () => {
 
 		expect(result.created).toBe(true);
 		expect(result.adrNumber).toBe("0005");
+	});
+
+	// ── Interactive approach phase tests ────────────────────────────────────
+
+	test("interactive mode proposes approaches and records selection in ADR", async () => {
+		mockDesignApproaches = [
+			{
+				name: "Event-driven",
+				description: "Steps emit events.",
+				pros: ["Parallel", "Decoupled"],
+				cons: ["Complex debugging"],
+				recommended: true,
+			},
+			{
+				name: "Middleware chain",
+				description: "Sequential middleware.",
+				pros: ["Simple"],
+				cons: ["No parallelism"],
+				recommended: false,
+			},
+		];
+		// User selects "Event-driven"
+		mockClackSelectResponses = ["Event-driven"];
+
+		let capturedFilePath = "";
+		const adrPath = join(tmpDir, "adr", "0001-test-decision.md");
+
+		const mockDeps: DesignDepsType = {
+			getNextAdrNumber: async () => ({ ok: true, value: "0001" }),
+			scaffoldAdr: async (_adrDir, _number, _title) => {
+				capturedFilePath = adrPath;
+				// Write a minimal ADR file so appendAlternatives can find it
+				mkdirSync(join(tmpDir, "adr"), { recursive: true });
+				const { writeFileSync } = await import("node:fs");
+				writeFileSync(
+					adrPath,
+					"# ADR-0001: Test Decision\n\n## Context\nTest.\n",
+				);
+				return { ok: true, value: adrPath };
+			},
+			listAdrs: async () => ({ ok: true, value: [] }),
+			openInEditor: async () => {},
+		};
+
+		const result = await designAction(
+			{ title: "Test Decision", cwd: tmpDir },
+			mockDeps,
+		);
+
+		expect(result.created).toBe(true);
+		expect(result.approachSelected).toBe("Event-driven");
+
+		// ADR should have Alternatives Considered section
+		const { readFileSync } = await import("node:fs");
+		const adrContent = readFileSync(capturedFilePath, "utf-8");
+		expect(adrContent).toContain("## Alternatives Considered");
+		expect(adrContent).toContain("Event-driven");
+		expect(adrContent).toContain("Middleware chain");
+	});
+
+	test("--no-interactive skips approach phase entirely", async () => {
+		mockDesignApproaches = [
+			{
+				name: "Should not appear",
+				description: "D",
+				pros: ["p"],
+				cons: ["c"],
+				recommended: true,
+			},
+		];
+
+		const adrPath = join(tmpDir, "adr", "0001-test.md");
+
+		const mockDeps: DesignDepsType = {
+			getNextAdrNumber: async () => ({ ok: true, value: "0001" }),
+			scaffoldAdr: async () => {
+				mkdirSync(join(tmpDir, "adr"), { recursive: true });
+				const { writeFileSync } = await import("node:fs");
+				writeFileSync(adrPath, "# ADR-0001: Test\n");
+				return { ok: true, value: adrPath };
+			},
+			listAdrs: async () => ({ ok: true, value: [] }),
+			openInEditor: async () => {},
+		};
+
+		const result = await designAction(
+			{ title: "Test", cwd: tmpDir, noInteractive: true },
+			mockDeps,
+		);
+
+		expect(result.created).toBe(true);
+		expect(result.approachSelected).toBeUndefined();
+
+		// ADR should NOT have Alternatives Considered
+		const { readFileSync } = await import("node:fs");
+		const adrContent = readFileSync(adrPath, "utf-8");
+		expect(adrContent).not.toContain("## Alternatives Considered");
+	});
+
+	test("no approaches from AI skips approach phase gracefully", async () => {
+		mockDesignApproaches = [];
+
+		const mockDeps: DesignDepsType = {
+			getNextAdrNumber: async () => ({ ok: true, value: "0001" }),
+			scaffoldAdr: async () => ({
+				ok: true,
+				value: join(tmpDir, "adr", "0001-test.md"),
+			}),
+			listAdrs: async () => ({ ok: true, value: [] }),
+			openInEditor: async () => {},
+		};
+
+		const result = await designAction({ title: "Test", cwd: tmpDir }, mockDeps);
+
+		expect(result.created).toBe(true);
+		expect(result.approachSelected).toBeUndefined();
 	});
 });

--- a/packages/cli/src/commands/__tests__/spec.test.ts
+++ b/packages/cli/src/commands/__tests__/spec.test.ts
@@ -19,6 +19,16 @@ import { join } from "node:path";
 // ── Mock State ───────────────────────────────────────────────────────────────
 
 let mockCurrentBranch = "feature/001-user-auth";
+let mockSpecQuestions: Array<{
+	question: string;
+	type: "text" | "select";
+	options?: string[];
+	reason: string;
+}> = [];
+let mockClackTextResponses: string[] = [];
+let mockClackTextCallIndex = 0;
+let mockClackSelectResponses: string[] = [];
+let mockClackSelectCallIndex = 0;
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -28,6 +38,10 @@ const realCore = await import("@maina/core");
 mock.module("@maina/core", () => ({
 	getCurrentBranch: async (_cwd?: string) => mockCurrentBranch,
 	generateTestStubs: realCore.generateTestStubs,
+	generateSpecQuestions: async (_planContent: string, _mainaDir: string) => ({
+		ok: true,
+		value: mockSpecQuestions,
+	}),
 }));
 
 mock.module("@clack/prompts", () => ({
@@ -45,6 +59,17 @@ mock.module("@clack/prompts", () => ({
 		start: () => {},
 		stop: () => {},
 	}),
+	text: async () => {
+		const response = mockClackTextResponses[mockClackTextCallIndex] ?? "";
+		mockClackTextCallIndex++;
+		return response;
+	},
+	select: async () => {
+		const response = mockClackSelectResponses[mockClackSelectCallIndex] ?? "";
+		mockClackSelectCallIndex++;
+		return response;
+	},
+	isCancel: (v: unknown) => typeof v === "symbol",
 }));
 
 afterAll(() => {
@@ -70,6 +95,11 @@ beforeEach(() => {
 
 	// Reset mock state
 	mockCurrentBranch = "feature/001-user-auth";
+	mockSpecQuestions = [];
+	mockClackTextResponses = [];
+	mockClackTextCallIndex = 0;
+	mockClackSelectResponses = [];
+	mockClackSelectCallIndex = 0;
 });
 
 afterEach(() => {
@@ -532,5 +562,98 @@ describe("specAction", () => {
 		expect(result.generated).toBe(true);
 		expect(result.redPhaseVerified).toBeUndefined();
 		expect(result.redGreenWarning).toBeUndefined();
+	});
+
+	// ── Interactive question phase tests ────────────────────────────────────
+
+	test("interactive mode asks clarifying questions and records answers in spec.md", async () => {
+		mockSpecQuestions = [
+			{
+				question: "Should login support OAuth?",
+				type: "text",
+				reason: "Not specified",
+			},
+			{
+				question: "Rate limit strategy?",
+				type: "select",
+				options: ["Per-user", "Per-IP", "Both"],
+				reason: "Ambiguous",
+			},
+		];
+		mockClackTextResponses = ["Yes, OAuth2 via Google"];
+		mockClackSelectResponses = ["Both"];
+
+		const featureDir = join(tmpDir, ".maina", "features", "001-user-auth");
+		mkdirSync(featureDir, { recursive: true });
+		writeFileSync(
+			join(featureDir, "plan.md"),
+			`## Tasks\n\n- T001: Implement login\n`,
+		);
+		writeFileSync(join(featureDir, "spec.md"), "# Feature: User Auth\n");
+
+		const result = await specAction(
+			{ featureDir, cwd: tmpDir },
+			createMockDeps(),
+		);
+
+		expect(result.generated).toBe(true);
+		expect(result.questionsAsked).toBe(2);
+
+		// Answers should be appended to spec.md
+		const specContent = readFileSync(join(featureDir, "spec.md"), "utf-8");
+		expect(specContent).toContain("## Clarifications");
+		expect(specContent).toContain("Should login support OAuth?");
+		expect(specContent).toContain("Yes, OAuth2 via Google");
+		expect(specContent).toContain("Rate limit strategy?");
+		expect(specContent).toContain("Both");
+	});
+
+	test("--no-interactive skips question phase entirely", async () => {
+		mockSpecQuestions = [
+			{
+				question: "Should never see this?",
+				type: "text",
+				reason: "Should be skipped",
+			},
+		];
+
+		const featureDir = join(tmpDir, ".maina", "features", "001-user-auth");
+		mkdirSync(featureDir, { recursive: true });
+		writeFileSync(
+			join(featureDir, "plan.md"),
+			`## Tasks\n\n- T001: Implement login\n`,
+		);
+		writeFileSync(join(featureDir, "spec.md"), "# Feature: User Auth\n");
+
+		const result = await specAction(
+			{ featureDir, cwd: tmpDir, noInteractive: true },
+			createMockDeps(),
+		);
+
+		expect(result.generated).toBe(true);
+		expect(result.questionsAsked).toBeUndefined();
+
+		// spec.md should NOT have Clarifications
+		const specContent = readFileSync(join(featureDir, "spec.md"), "utf-8");
+		expect(specContent).not.toContain("## Clarifications");
+	});
+
+	test("no questions from AI skips question phase gracefully", async () => {
+		mockSpecQuestions = [];
+
+		const featureDir = join(tmpDir, ".maina", "features", "001-user-auth");
+		mkdirSync(featureDir, { recursive: true });
+		writeFileSync(
+			join(featureDir, "plan.md"),
+			`## Tasks\n\n- T001: Implement login\n`,
+		);
+
+		const result = await specAction(
+			{ featureDir, cwd: tmpDir },
+			createMockDeps(),
+		);
+
+		expect(result.generated).toBe(true);
+		expect(result.questionsAsked).toBeUndefined();
 	});
 });

--- a/packages/cli/src/commands/design.ts
+++ b/packages/cli/src/commands/design.ts
@@ -1,9 +1,12 @@
+import { appendFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { intro, isCancel, log, outro, text } from "@clack/prompts";
+import { intro, isCancel, log, outro, select, text } from "@clack/prompts";
 import {
 	getNextAdrNumber as coreGetNextAdrNumber,
 	listAdrs as coreListAdrs,
 	scaffoldAdr as coreScaffoldAdr,
+	type DesignApproach,
+	generateDesignApproaches,
 } from "@maina/core";
 import { Command } from "commander";
 
@@ -13,6 +16,7 @@ export interface DesignActionOptions {
 	title?: string;
 	list?: boolean;
 	cwd?: string;
+	noInteractive?: boolean;
 }
 
 export interface DesignActionResult {
@@ -21,6 +25,7 @@ export interface DesignActionResult {
 	reason?: string;
 	adrNumber?: string;
 	path?: string;
+	approachSelected?: string;
 }
 
 export interface DesignDeps {
@@ -140,14 +145,80 @@ export async function designAction(
 
 	log.success(`ADR ${adrNumber} created: ${filePath}`);
 
-	// Step 4: Open in $EDITOR if available
+	// Step 4: Interactive approach proposals
+	let approachSelected: string | undefined;
+
+	if (!options.noInteractive && title) {
+		const mainaDir = join(cwd, ".maina");
+		const approachesResult = await generateDesignApproaches(
+			`ADR: ${title}`,
+			mainaDir,
+		);
+
+		if (approachesResult.ok && approachesResult.value.length > 0) {
+			const selected = await proposeApproaches(approachesResult.value);
+			if (selected) {
+				appendAlternativesConsidered(
+					filePath,
+					approachesResult.value,
+					selected,
+				);
+				approachSelected = selected;
+			}
+		}
+	}
+
+	// Step 5: Open in $EDITOR if available
 	await deps.openInEditor(filePath, cwd);
 
 	return {
 		created: true,
 		adrNumber,
 		path: filePath,
+		approachSelected,
 	};
+}
+
+// ── Interactive Approach Helpers ─────────────────────────────────────────────
+
+async function proposeApproaches(
+	approaches: DesignApproach[],
+): Promise<string | null> {
+	const recommended = approaches.find((a) => a.recommended);
+
+	const selected = await select({
+		message: `Choose an approach${recommended ? ` (recommended: ${recommended.name})` : ""}:`,
+		options: approaches.map((a) => ({
+			value: a.name,
+			label: `${a.name}${a.recommended ? " (recommended)" : ""}`,
+			hint: a.description,
+		})),
+	});
+
+	if (isCancel(selected)) {
+		return null;
+	}
+
+	return selected as string;
+}
+
+function appendAlternativesConsidered(
+	adrPath: string,
+	approaches: DesignApproach[],
+	selectedName: string,
+): void {
+	if (!existsSync(adrPath)) return;
+
+	let section = "\n\n## Alternatives Considered\n\n";
+	section +=
+		"| Approach | Pros | Cons | Selected |\n|----------|------|------|----------|\n";
+
+	for (const a of approaches) {
+		const isSelected = a.name === selectedName ? "**Yes**" : "No";
+		section += `| ${a.name} | ${a.pros.join(", ")} | ${a.cons.join(", ")} | ${isSelected} |\n`;
+	}
+
+	appendFileSync(adrPath, section);
 }
 
 // ── Commander Command ────────────────────────────────────────────────────────
@@ -157,17 +228,22 @@ export function designCommand(): Command {
 		.description("Create an Architecture Decision Record")
 		.option("-t, --title <title>", "ADR title")
 		.option("--list", "List existing ADRs")
+		.option("--no-interactive", "Skip approach proposals phase")
 		.action(async (options) => {
 			intro("maina design");
 
 			const result = await designAction({
 				title: options.title,
 				list: options.list,
+				noInteractive: options.interactive === false,
 			});
 
 			if (result.listed) {
 				outro("Done.");
 			} else if (result.created) {
+				if (result.approachSelected) {
+					log.info(`Approach selected: ${result.approachSelected}`);
+				}
 				outro(`ADR ${result.adrNumber} ready — edit the file, then review.`);
 			} else {
 				outro(`Aborted: ${result.reason}`);

--- a/packages/cli/src/commands/spec.ts
+++ b/packages/cli/src/commands/spec.ts
@@ -1,7 +1,18 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import {
+	appendFileSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+} from "node:fs";
 import { join } from "node:path";
-import { intro, log, outro } from "@clack/prompts";
-import { generateTestStubs, getCurrentBranch } from "@maina/core";
+import { intro, isCancel, log, outro, select, text } from "@clack/prompts";
+import {
+	generateSpecQuestions,
+	generateTestStubs,
+	getCurrentBranch,
+	type SpecQuestion,
+} from "@maina/core";
 import { Command } from "commander";
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -11,6 +22,7 @@ export interface SpecActionOptions {
 	output?: string; // Output file path (default: feature dir / spec-tests.ts)
 	cwd?: string;
 	noRedGreen?: boolean; // Skip red-green enforcement check
+	noInteractive?: boolean; // Skip clarifying questions phase
 }
 
 export interface SpecActionResult {
@@ -20,6 +32,7 @@ export interface SpecActionResult {
 	taskCount?: number;
 	redPhaseVerified?: boolean;
 	redGreenWarning?: string;
+	questionsAsked?: number;
 }
 
 export interface SpecDeps {
@@ -140,16 +153,33 @@ export async function specAction(
 
 	const planContent = readFileSync(planPath, "utf-8");
 
-	// ── Step 3: Extract feature name for describe block ──────────────────
+	// ── Step 3: Interactive clarifying questions ─────────────────────────
+	let questionsAsked: number | undefined;
+
+	if (!options.noInteractive) {
+		const mainaDir = join(cwd, ".maina");
+		const questionsResult = await generateSpecQuestions(planContent, mainaDir);
+
+		if (questionsResult.ok && questionsResult.value.length > 0) {
+			const answers = await askClarifyingQuestions(questionsResult.value);
+			if (answers.length > 0) {
+				const specPath = join(featureDir, "spec.md");
+				appendClarifications(specPath, answers);
+				questionsAsked = answers.length;
+			}
+		}
+	}
+
+	// ── Step 4: Extract feature name for describe block ──────────────────
 	// Try to get feature name from dir name (e.g. "001-user-auth" → "user-auth")
 	const dirBasename = featureDir.split("/").pop() ?? "unknown";
 	const featureName = dirBasename.replace(/^\d+-/, "");
 
-	// ── Step 4: Generate test stubs ──────────────────────────────────────
+	// ── Step 5: Generate test stubs ──────────────────────────────────────
 	const testContent = generateTestStubs(planContent, featureName);
 	const taskCount = (testContent.match(/\bit\(/g) ?? []).length;
 
-	// ── Step 5: Write output file ────────────────────────────────────────
+	// ── Step 6: Write output file ────────────────────────────────────────
 	const outputPath = options.output ?? join(featureDir, "spec-tests.ts");
 
 	// Ensure parent directory exists
@@ -164,9 +194,10 @@ export async function specAction(
 		generated: true,
 		outputPath,
 		taskCount,
+		questionsAsked,
 	};
 
-	// ── Step 6: Red-green enforcement ────────────────────────────────────
+	// ── Step 7: Red-green enforcement ────────────────────────────────────
 	if (!options.noRedGreen && deps.runTests) {
 		try {
 			const { passCount, failCount } = await deps.runTests(outputPath, cwd);
@@ -183,6 +214,59 @@ export async function specAction(
 	return result;
 }
 
+// ── Interactive Question Helpers ─────────────────────────────────────────────
+
+interface ClarificationAnswer {
+	question: string;
+	answer: string;
+}
+
+async function askClarifyingQuestions(
+	questions: SpecQuestion[],
+): Promise<ClarificationAnswer[]> {
+	const answers: ClarificationAnswer[] = [];
+
+	for (const q of questions) {
+		let answer: string | symbol;
+
+		if (q.type === "select" && q.options && q.options.length > 0) {
+			answer = await select({
+				message: q.question,
+				options: q.options.map((o) => ({ value: o, label: o })),
+			});
+		} else {
+			answer = await text({
+				message: q.question,
+				placeholder: "Your answer",
+			});
+		}
+
+		if (isCancel(answer)) {
+			break;
+		}
+
+		answers.push({ question: q.question, answer: answer as string });
+	}
+
+	return answers;
+}
+
+function appendClarifications(
+	specPath: string,
+	answers: ClarificationAnswer[],
+): void {
+	if (answers.length === 0) return;
+
+	let section = "\n\n## Clarifications\n\n";
+	for (const { question, answer } of answers) {
+		section += `**Q:** ${question}\n**A:** ${answer}\n\n`;
+	}
+
+	if (existsSync(specPath)) {
+		appendFileSync(specPath, section);
+	}
+}
+
 // ── Commander Command ────────────────────────────────────────────────────────
 
 export function specCommand(): Command {
@@ -191,6 +275,7 @@ export function specCommand(): Command {
 		.option("--feature-dir <dir>", "Feature directory path")
 		.option("-o, --output <path>", "Output file path")
 		.option("--no-red-green", "Skip red-green enforcement check")
+		.option("--no-interactive", "Skip clarifying questions phase")
 		.action(async (options) => {
 			intro("maina spec");
 
@@ -198,9 +283,15 @@ export function specCommand(): Command {
 				featureDir: options.featureDir,
 				output: options.output,
 				noRedGreen: options.redGreen === false,
+				noInteractive: options.interactive === false,
 			});
 
 			if (result.generated) {
+				if (result.questionsAsked) {
+					log.info(
+						`Recorded ${result.questionsAsked} clarification(s) in spec.md`,
+					);
+				}
 				log.success(`Generated ${result.taskCount} test stub(s)`);
 				log.info(`Output: ${result.outputPath}`);
 

--- a/packages/core/src/ai/__tests__/design-approaches.test.ts
+++ b/packages/core/src/ai/__tests__/design-approaches.test.ts
@@ -1,0 +1,192 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Mock State ──────────────────────────────────────────────────────────────
+
+let mockAIResponse: string | null = null;
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+mock.module("../try-generate", () => ({
+	tryAIGenerate: async (
+		_task: string,
+		_mainaDir: string,
+		_variables: Record<string, string>,
+		_userPrompt: string,
+	) => ({
+		text: mockAIResponse,
+		fromAI: mockAIResponse !== null,
+		hostDelegation: false,
+	}),
+}));
+
+afterAll(() => {
+	mock.restore();
+});
+
+// ── Import after mocks ──────────────────────────────────────────────────────
+
+const { generateDesignApproaches } = await import("../design-approaches");
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("generateDesignApproaches", () => {
+	beforeEach(() => {
+		mockAIResponse = null;
+	});
+
+	// ── Happy Path ──────────────────────────────────────────────────────────
+
+	describe("happy path", () => {
+		test("returns parsed approaches from valid AI JSON response", async () => {
+			mockAIResponse = JSON.stringify([
+				{
+					name: "Event-driven",
+					description: "Steps emit events consumed by next step.",
+					pros: ["Parallel", "Decoupled"],
+					cons: ["Complex debugging"],
+					recommended: true,
+				},
+				{
+					name: "Middleware chain",
+					description: "Sequential middleware functions.",
+					pros: ["Simple"],
+					cons: ["No parallelism"],
+					recommended: false,
+				},
+			]);
+
+			const result = await generateDesignApproaches(
+				"Design a verification pipeline",
+				".maina",
+			);
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toHaveLength(2);
+				expect(result.value[0]?.name).toBe("Event-driven");
+				expect(result.value[0]?.recommended).toBe(true);
+				expect(result.value[0]?.pros).toEqual(["Parallel", "Decoupled"]);
+				expect(result.value[1]?.name).toBe("Middleware chain");
+				expect(result.value[1]?.recommended).toBe(false);
+			}
+		});
+
+		test("returns empty array when AI says no approaches needed", async () => {
+			mockAIResponse = "[]";
+
+			const result = await generateDesignApproaches(
+				"Simple decision",
+				".maina",
+			);
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toHaveLength(0);
+			}
+		});
+	});
+
+	// ── Edge Cases ──────────────────────────────────────────────────────────
+
+	describe("edge cases", () => {
+		test("returns empty array when context is empty", async () => {
+			const result = await generateDesignApproaches("", ".maina");
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toHaveLength(0);
+			}
+		});
+
+		test("handles AI response with markdown fences around JSON", async () => {
+			mockAIResponse =
+				'```json\n[{"name":"A","description":"D","pros":["p"],"cons":["c"],"recommended":true}]\n```';
+
+			const result = await generateDesignApproaches("Test context", ".maina");
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toHaveLength(1);
+				expect(result.value[0]?.name).toBe("A");
+			}
+		});
+
+		test("caps approaches at 3 even if AI returns more", async () => {
+			const fourApproaches = Array.from({ length: 4 }, (_, i) => ({
+				name: `Approach ${i + 1}`,
+				description: `Description ${i + 1}`,
+				pros: ["pro"],
+				cons: ["con"],
+				recommended: i === 0,
+			}));
+			mockAIResponse = JSON.stringify(fourApproaches);
+
+			const result = await generateDesignApproaches("Test context", ".maina");
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value.length).toBeLessThanOrEqual(3);
+			}
+		});
+	});
+
+	// ── Error Handling ──────────────────────────────────────────────────────
+
+	describe("error handling", () => {
+		test("returns empty array when AI is not available", async () => {
+			mockAIResponse = null;
+
+			const result = await generateDesignApproaches("Test context", ".maina");
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toHaveLength(0);
+			}
+		});
+
+		test("returns empty array when AI returns malformed JSON", async () => {
+			mockAIResponse = "not valid json at all";
+
+			const result = await generateDesignApproaches("Test context", ".maina");
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toHaveLength(0);
+			}
+		});
+
+		test("filters out approaches missing required fields", async () => {
+			mockAIResponse = JSON.stringify([
+				{
+					name: "Valid",
+					description: "D",
+					pros: ["p"],
+					cons: ["c"],
+					recommended: true,
+				},
+				{
+					description: "Missing name",
+					pros: ["p"],
+					cons: ["c"],
+					recommended: false,
+				},
+				{
+					name: "Also valid",
+					description: "D2",
+					pros: ["p"],
+					cons: ["c"],
+					recommended: false,
+				},
+			]);
+
+			const result = await generateDesignApproaches("Test context", ".maina");
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toHaveLength(2);
+				expect(result.value[0]?.name).toBe("Valid");
+				expect(result.value[1]?.name).toBe("Also valid");
+			}
+		});
+	});
+});

--- a/packages/core/src/ai/__tests__/spec-questions.test.ts
+++ b/packages/core/src/ai/__tests__/spec-questions.test.ts
@@ -1,0 +1,191 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Mock State ──────────────────────────────────────────────────────────────
+
+let mockAIResponse: string | null = null;
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+mock.module("../try-generate", () => ({
+	tryAIGenerate: async (
+		_task: string,
+		_mainaDir: string,
+		_variables: Record<string, string>,
+		_userPrompt: string,
+	) => ({
+		text: mockAIResponse,
+		fromAI: mockAIResponse !== null,
+		hostDelegation: false,
+	}),
+}));
+
+afterAll(() => {
+	mock.restore();
+});
+
+// ── Import after mocks ──────────────────────────────────────────────────────
+
+const { generateSpecQuestions } = await import("../spec-questions");
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("generateSpecQuestions", () => {
+	beforeEach(() => {
+		mockAIResponse = null;
+	});
+
+	// ── Happy Path ──────────────────────────────────────────────────────────
+
+	describe("happy path", () => {
+		test("returns parsed questions from valid AI JSON response", async () => {
+			mockAIResponse = JSON.stringify([
+				{
+					question: "Should cache invalidate on branch switch?",
+					type: "select",
+					options: ["Yes", "No", "Both"],
+					reason: "Not specified in plan",
+				},
+				{
+					question: "What error message for missing API key?",
+					type: "text",
+					reason: "Error handling unspecified",
+				},
+			]);
+
+			const result = await generateSpecQuestions(
+				"## Tasks\n- T001: Add cache",
+				".maina",
+			);
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toHaveLength(2);
+				expect(result.value[0]?.question).toBe(
+					"Should cache invalidate on branch switch?",
+				);
+				expect(result.value[0]?.type).toBe("select");
+				expect(result.value[0]?.options).toEqual(["Yes", "No", "Both"]);
+				expect(result.value[1]?.type).toBe("text");
+			}
+		});
+
+		test("returns empty array when AI says plan is clear", async () => {
+			mockAIResponse = "[]";
+
+			const result = await generateSpecQuestions(
+				"## Tasks\n- T001: Clear task",
+				".maina",
+			);
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toHaveLength(0);
+			}
+		});
+	});
+
+	// ── Edge Cases ──────────────────────────────────────────────────────────
+
+	describe("edge cases", () => {
+		test("returns empty array when plan content is empty", async () => {
+			const result = await generateSpecQuestions("", ".maina");
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toHaveLength(0);
+			}
+		});
+
+		test("handles AI response with markdown fences around JSON", async () => {
+			mockAIResponse =
+				'```json\n[{"question":"Test?","type":"text","reason":"r"}]\n```';
+
+			const result = await generateSpecQuestions(
+				"## Tasks\n- T001: Test",
+				".maina",
+			);
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toHaveLength(1);
+				expect(result.value[0]?.question).toBe("Test?");
+			}
+		});
+
+		test("caps questions at 5 even if AI returns more", async () => {
+			const sixQuestions = Array.from({ length: 6 }, (_, i) => ({
+				question: `Question ${i + 1}?`,
+				type: "text",
+				reason: `Reason ${i + 1}`,
+			}));
+			mockAIResponse = JSON.stringify(sixQuestions);
+
+			const result = await generateSpecQuestions(
+				"## Tasks\n- T001: Test",
+				".maina",
+			);
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value.length).toBeLessThanOrEqual(5);
+			}
+		});
+	});
+
+	// ── Error Handling ──────────────────────────────────────────────────────
+
+	describe("error handling", () => {
+		test("returns empty array when AI is not available (null response)", async () => {
+			mockAIResponse = null;
+
+			const result = await generateSpecQuestions(
+				"## Tasks\n- T001: Test",
+				".maina",
+			);
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toHaveLength(0);
+			}
+		});
+
+		test("returns empty array when AI returns malformed JSON", async () => {
+			mockAIResponse = "not valid json at all";
+
+			const result = await generateSpecQuestions(
+				"## Tasks\n- T001: Test",
+				".maina",
+			);
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toHaveLength(0);
+			}
+		});
+
+		test("filters out questions missing required fields", async () => {
+			mockAIResponse = JSON.stringify([
+				{ question: "Valid?", type: "text", reason: "Valid reason" },
+				{ type: "text", reason: "Missing question field" },
+				{
+					question: "Also valid?",
+					type: "select",
+					options: ["A", "B"],
+					reason: "OK",
+				},
+			]);
+
+			const result = await generateSpecQuestions(
+				"## Tasks\n- T001: Test",
+				".maina",
+			);
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.value).toHaveLength(2);
+				expect(result.value[0]?.question).toBe("Valid?");
+				expect(result.value[1]?.question).toBe("Also valid?");
+			}
+		});
+	});
+});

--- a/packages/core/src/ai/design-approaches.ts
+++ b/packages/core/src/ai/design-approaches.ts
@@ -1,0 +1,76 @@
+import type { Result } from "../db/index";
+import { tryAIGenerate } from "./try-generate";
+
+export interface DesignApproach {
+	name: string;
+	description: string;
+	pros: string[];
+	cons: string[];
+	recommended: boolean;
+}
+
+const MAX_APPROACHES = 3;
+
+/**
+ * Generates 2-3 design approaches with pros/cons/recommendation by asking
+ * the AI to analyze the design context and propose alternatives.
+ *
+ * Returns an empty array when:
+ * - Context is empty
+ * - AI is not available (no API key)
+ * - AI returns malformed JSON
+ */
+export async function generateDesignApproaches(
+	designContext: string,
+	mainaDir: string,
+): Promise<Result<DesignApproach[], string>> {
+	if (!designContext.trim()) {
+		return { ok: true, value: [] };
+	}
+
+	const result = await tryAIGenerate(
+		"design-approaches",
+		mainaDir,
+		{ context: designContext },
+		`Propose 2-3 architectural approaches for this design decision as a JSON array.\n\n${designContext}`,
+	);
+
+	if (!result.text) {
+		return { ok: true, value: [] };
+	}
+
+	try {
+		const parsed = parseApproachesJSON(result.text);
+		const validated = parsed.filter(isValidApproach);
+		return { ok: true, value: validated.slice(0, MAX_APPROACHES) };
+	} catch {
+		return { ok: true, value: [] };
+	}
+}
+
+function parseApproachesJSON(text: string): unknown[] {
+	let cleaned = text.trim();
+	const fenceMatch = cleaned.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+	if (fenceMatch?.[1]) {
+		cleaned = fenceMatch[1].trim();
+	}
+
+	const parsed: unknown = JSON.parse(cleaned);
+	if (!Array.isArray(parsed)) {
+		return [];
+	}
+	return parsed;
+}
+
+function isValidApproach(item: unknown): item is DesignApproach {
+	if (typeof item !== "object" || item === null) return false;
+	const obj = item as Record<string, unknown>;
+	return (
+		typeof obj.name === "string" &&
+		obj.name.length > 0 &&
+		typeof obj.description === "string" &&
+		Array.isArray(obj.pros) &&
+		Array.isArray(obj.cons) &&
+		typeof obj.recommended === "boolean"
+	);
+}

--- a/packages/core/src/ai/spec-questions.ts
+++ b/packages/core/src/ai/spec-questions.ts
@@ -1,0 +1,74 @@
+import type { Result } from "../db/index";
+import { tryAIGenerate } from "./try-generate";
+
+export interface SpecQuestion {
+	question: string;
+	type: "text" | "select";
+	options?: string[];
+	reason: string;
+}
+
+const MAX_QUESTIONS = 5;
+
+/**
+ * Generates clarifying questions from plan.md content by asking the AI
+ * to identify ambiguities, missing edge cases, and unstated assumptions.
+ *
+ * Returns an empty array when:
+ * - Plan content is empty
+ * - AI is not available (no API key)
+ * - AI returns malformed JSON
+ */
+export async function generateSpecQuestions(
+	planContent: string,
+	mainaDir: string,
+): Promise<Result<SpecQuestion[], string>> {
+	if (!planContent.trim()) {
+		return { ok: true, value: [] };
+	}
+
+	const result = await tryAIGenerate(
+		"spec-questions",
+		mainaDir,
+		{ plan: planContent },
+		`Analyze this implementation plan and return 3-5 clarifying questions as a JSON array.\n\n${planContent}`,
+	);
+
+	if (!result.text) {
+		return { ok: true, value: [] };
+	}
+
+	try {
+		const parsed = parseQuestionsJSON(result.text);
+		const validated = parsed.filter(isValidQuestion);
+		return { ok: true, value: validated.slice(0, MAX_QUESTIONS) };
+	} catch {
+		return { ok: true, value: [] };
+	}
+}
+
+function parseQuestionsJSON(text: string): unknown[] {
+	// Strip markdown code fences if present
+	let cleaned = text.trim();
+	const fenceMatch = cleaned.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+	if (fenceMatch?.[1]) {
+		cleaned = fenceMatch[1].trim();
+	}
+
+	const parsed: unknown = JSON.parse(cleaned);
+	if (!Array.isArray(parsed)) {
+		return [];
+	}
+	return parsed;
+}
+
+function isValidQuestion(item: unknown): item is SpecQuestion {
+	if (typeof item !== "object" || item === null) return false;
+	const obj = item as Record<string, unknown>;
+	return (
+		typeof obj.question === "string" &&
+		obj.question.length > 0 &&
+		(obj.type === "text" || obj.type === "select") &&
+		typeof obj.reason === "string"
+	);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,8 +2,16 @@ export const VERSION = "0.1.0";
 
 // AI
 export { generateCommitMessage } from "./ai/commit-msg";
+export {
+	type DesignApproach,
+	generateDesignApproaches,
+} from "./ai/design-approaches";
 export { generate } from "./ai/index";
 export { generatePrSummary } from "./ai/pr-summary";
+export {
+	generateSpecQuestions,
+	type SpecQuestion,
+} from "./ai/spec-questions";
 export { type TryAIResult, tryAIGenerate } from "./ai/try-generate";
 // AI validation
 export { type AIValidationResult, validateAIOutput } from "./ai/validate";

--- a/packages/core/src/prompts/defaults/design-approaches.md
+++ b/packages/core/src/prompts/defaults/design-approaches.md
@@ -1,0 +1,57 @@
+You are proposing architectural approaches for a design decision, with tradeoffs and a recommendation.
+
+## Constitution (non-negotiable)
+{{constitution}}
+
+## Team conventions
+{{conventions}}
+
+## Instructions
+
+Given the design context below, propose 2-3 distinct approaches to the architectural decision.
+
+For each approach, provide:
+1. **Name** — a short descriptive label (2-4 words)
+2. **Description** — how this approach works (2-3 sentences)
+3. **Pros** — concrete advantages (2-3 bullet points)
+4. **Cons** — concrete disadvantages (2-3 bullet points)
+5. **Recommendation** — boolean, true for at most one approach
+
+Rules:
+- Approaches must be genuinely different, not minor variations
+- Pros and cons must be specific to this decision, not generic
+- Exactly one approach should be recommended with reasoning
+- Consider: complexity, performance, maintainability, alignment with existing architecture
+- If the context is too vague to propose meaningful approaches, return an empty array
+
+Output format: valid JSON array. Each approach object has:
+- `name` (string): short label
+- `description` (string): how it works
+- `pros` (string[]): advantages
+- `cons` (string[]): disadvantages
+- `recommended` (boolean): true for the recommended approach
+
+Example:
+```json
+[
+  {
+    "name": "Event-driven pipeline",
+    "description": "Each verification step emits events consumed by the next. Steps run independently and communicate through an event bus.",
+    "pros": ["Easy to add new steps", "Steps can run in parallel", "Clear separation of concerns"],
+    "cons": ["Harder to debug event flow", "Event ordering complexity", "More infrastructure code"],
+    "recommended": true
+  },
+  {
+    "name": "Sequential middleware chain",
+    "description": "Steps are chained as middleware functions. Each step receives input, processes it, and passes to the next.",
+    "pros": ["Simple mental model", "Easy to debug", "Familiar pattern"],
+    "cons": ["Cannot parallelize", "Adding steps requires chain modification", "Tight coupling"],
+    "recommended": false
+  }
+]
+```
+
+Output ONLY the JSON array, no surrounding text or markdown fences.
+
+## Design context
+{{context}}

--- a/packages/core/src/prompts/defaults/index.ts
+++ b/packages/core/src/prompts/defaults/index.ts
@@ -7,7 +7,9 @@ export type PromptTask =
 	| "fix"
 	| "explain"
 	| "design"
-	| "context";
+	| "context"
+	| "spec-questions"
+	| "design-approaches";
 
 const FALLBACK_TEMPLATE = `You are a helpful AI assistant completing the "{{task}}" task.
 

--- a/packages/core/src/prompts/defaults/spec-questions.md
+++ b/packages/core/src/prompts/defaults/spec-questions.md
@@ -1,0 +1,59 @@
+You are analyzing an implementation plan to generate clarifying questions that surface ambiguity before test stubs are written.
+
+## Constitution (non-negotiable)
+{{constitution}}
+
+## Team conventions
+{{conventions}}
+
+## Instructions
+
+Given the implementation plan below, identify 3-5 clarifying questions that should be answered before writing test stubs or implementation code.
+
+Focus on:
+1. **Ambiguous requirements** — where multiple valid interpretations exist
+2. **Missing edge cases** — boundary conditions, error scenarios, empty/null inputs not addressed
+3. **Unstated assumptions** — implicit decisions that could go either way
+4. **Integration boundaries** — how this feature interacts with existing systems
+5. **Acceptance criteria gaps** — what "done" means for each task
+
+Do NOT ask:
+- Questions answered in the plan itself
+- Generic questions that apply to any feature
+- Questions about implementation details (HOW) — focus on requirements (WHAT)
+- More than 5 questions
+
+Output format: valid JSON array. Each question object has:
+- `question` (string): the clarifying question
+- `type` ("text" | "select"): "text" for open-ended, "select" for multiple choice
+- `options` (string[], optional): choices for "select" type questions
+- `reason` (string): why this question matters for spec quality
+
+Example:
+```json
+[
+  {
+    "question": "Should the cache invalidate on branch switch or only on explicit clear?",
+    "type": "select",
+    "options": ["Branch switch", "Explicit clear only", "Both"],
+    "reason": "The plan mentions caching but doesn't specify invalidation strategy"
+  },
+  {
+    "question": "What should happen when the API key is missing during interactive mode?",
+    "type": "text",
+    "reason": "Error handling for missing credentials isn't specified"
+  }
+]
+```
+
+If the plan is clear and complete with no ambiguities, return an empty array: `[]`
+
+If the plan is empty or too vague to analyze, return:
+```json
+[{"question": "The plan is empty or too vague — fill in plan.md with tasks before running interactive spec.", "type": "text", "reason": "No content to analyze"}]
+```
+
+Output ONLY the JSON array, no surrounding text or markdown fences.
+
+## Implementation plan
+{{plan}}

--- a/packages/mcp/src/tools/features.ts
+++ b/packages/mcp/src/tools/features.ts
@@ -13,9 +13,31 @@ export function registerFeatureTools(server: McpServer): void {
 		async ({ planPath }) => {
 			try {
 				const content = await Bun.file(planPath).text();
-				const { generateTestStubs } = await import("@maina/core");
+				const { generateTestStubs, generateSpecQuestions } = await import(
+					"@maina/core"
+				);
+
+				// Generate test stubs
 				const stubs = generateTestStubs(content, "feature");
-				return { content: [{ type: "text" as const, text: stubs }] };
+
+				// Generate clarifying questions when ambiguities detected
+				const mainaDir = planPath.includes(".maina")
+					? planPath.slice(0, planPath.indexOf(".maina") + ".maina".length)
+					: ".maina";
+				const questionsResult = await generateSpecQuestions(content, mainaDir);
+
+				const parts: Array<{ type: "text"; text: string }> = [
+					{ type: "text" as const, text: stubs },
+				];
+
+				if (questionsResult.ok && questionsResult.value.length > 0) {
+					parts.push({
+						type: "text" as const,
+						text: `\n\n## Clarifying Questions\n\nThe following ambiguities were detected in the plan. Consider resolving them before implementation:\n\n${JSON.stringify(questionsResult.value, null, 2)}`,
+					});
+				}
+
+				return { content: parts };
 			} catch (e) {
 				return {
 					content: [


### PR DESCRIPTION
## Summary

- **Interactive spec questions**: `maina spec` now asks 3-5 AI-generated clarifying questions from plan.md before generating test stubs, with answers recorded in spec.md under `## Clarifications`
- **Multi-approach design proposals**: `maina design` proposes 2-3 approaches with pros/cons/recommendation before writing the ADR, with selection recorded under `## Alternatives Considered`
- **MCP integration**: `suggestTests` tool surfaces clarifying questions alongside test stubs
- Both commands support `--no-interactive` for CI/subagent use
- 16 new tests (825 total, 0 failures), biome clean, typecheck clean, maina analyze 0 warnings

## New files

| File | Purpose |
|------|---------|
| `core/ai/spec-questions.ts` | `generateSpecQuestions()` — parse plan, return questions |
| `core/ai/design-approaches.ts` | `generateDesignApproaches()` — propose approaches |
| `core/prompts/defaults/spec-questions.md` | Prompt template for clarifying questions |
| `core/prompts/defaults/design-approaches.md` | Prompt template for design approaches |

## Test plan

- [x] Unit tests for `generateSpecQuestions()` (8 tests: happy path, edge cases, error handling)
- [x] Unit tests for `generateDesignApproaches()` (8 tests: happy path, edge cases, error handling)
- [x] Integration tests for interactive spec flow (3 tests: questions asked, --no-interactive, empty questions)
- [x] Integration tests for interactive design flow (3 tests: approach selection, --no-interactive, empty approaches)
- [x] `bun run verify` passes (825 tests, biome clean, typecheck clean)
- [x] `maina analyze` shows 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)