### PR TITLE
feat: add Zoekt code search to retrieval layer

### DIFF
--- a/packages/core/src/context/__tests__/retrieval.test.ts
+++ b/packages/core/src/context/__tests__/retrieval.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import type { SearchResult } from "../retrieval";
-import { assembleRetrievalText, isToolAvailable, search } from "../retrieval";
+import {
+	assembleRetrievalText,
+	isToolAvailable,
+	parseZoektOutput,
+	search,
+} from "../retrieval";
 
 describe("isToolAvailable", () => {
 	test("returns true for 'git' (always available)", async () => {
@@ -50,6 +55,52 @@ describe("search", () => {
 		const results = await search("anything", {
 			cwd: "/nonexistent/path/xyz",
 		});
+		expect(Array.isArray(results)).toBe(true);
+	});
+});
+
+describe("parseZoektOutput", () => {
+	test("parses zoekt text output into SearchResult[]", () => {
+		const output = `src/app.ts:10:export function main() {
+src/app.ts:11:  return true;
+src/utils.ts:5:export const helper = () => {};`;
+
+		const results = parseZoektOutput(output);
+		expect(results).toHaveLength(3);
+		expect(results[0]?.filePath).toBe("src/app.ts");
+		expect(results[0]?.line).toBe(10);
+		expect(results[0]?.content).toBe("export function main() {");
+	});
+
+	test("handles empty output", () => {
+		expect(parseZoektOutput("")).toHaveLength(0);
+	});
+
+	test("skips malformed lines", () => {
+		const output = `src/app.ts:10:valid line
+not a valid line
+another:bad
+src/utils.ts:5:also valid`;
+		const results = parseZoektOutput(output);
+		expect(results).toHaveLength(2);
+	});
+
+	test("handles zoekt header lines gracefully", () => {
+		const output = `Repository: maina
+src/app.ts:10:export function main() {
+src/app.ts:11:  return true;`;
+		const results = parseZoektOutput(output);
+		// Should skip the Repository: line
+		expect(results).toHaveLength(2);
+	});
+});
+
+describe("searchWithZoekt", () => {
+	test("should skip when zoekt is not available", async () => {
+		// zoekt is almost certainly not installed in test environment
+		const { searchWithZoekt } = await import("../retrieval");
+		const results = await searchWithZoekt("testquery", { cwd: process.cwd() });
+		// Either returns results (if zoekt installed) or empty array (not installed)
 		expect(Array.isArray(results)).toBe(true);
 	});
 });

--- a/packages/core/src/context/retrieval.ts
+++ b/packages/core/src/context/retrieval.ts
@@ -88,6 +88,63 @@ function parsePlainOutput(output: string): SearchResult[] {
 }
 
 /**
+ * Parse Zoekt search output into SearchResult[].
+ * Zoekt outputs in format: filePath:lineNum:content
+ * Similar to grep/rg plain output but may include header lines.
+ */
+export function parseZoektOutput(output: string): SearchResult[] {
+	const results: SearchResult[] = [];
+	const lines = output.split("\n");
+	for (const line of lines) {
+		if (!line.trim()) continue;
+		// Skip Zoekt header lines (e.g., "Repository: name")
+		if (!line.includes(":") || line.startsWith("Repository:")) continue;
+		const firstColon = line.indexOf(":");
+		if (firstColon === -1) continue;
+		const afterFirst = line.indexOf(":", firstColon + 1);
+		if (afterFirst === -1) continue;
+		const filePath = line.slice(0, firstColon);
+		const lineNum = Number.parseInt(line.slice(firstColon + 1, afterFirst), 10);
+		const content = line.slice(afterFirst + 1);
+		if (filePath && !Number.isNaN(lineNum) && lineNum > 0) {
+			results.push({ filePath, line: lineNum, content, matchLength: 0 });
+		}
+	}
+	return results;
+}
+
+/**
+ * Search using Zoekt (Google's code search).
+ * Zoekt provides fast indexed search across the entire repo.
+ * Falls back gracefully if zoekt is not available.
+ */
+export async function searchWithZoekt(
+	query: string,
+	options: RetrievalOptions,
+): Promise<SearchResult[]> {
+	const cwd = options.cwd ?? process.cwd();
+	const maxResults = options.maxResults ?? 20;
+
+	const zoektAvailable = await isToolAvailable("zoekt");
+	if (!zoektAvailable) {
+		return [];
+	}
+
+	try {
+		const proc = Bun.spawn(["zoekt", "-n", String(maxResults), query], {
+			cwd,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const output = await new Response(proc.stdout).text();
+		await proc.exited;
+		return parseZoektOutput(output);
+	} catch {
+		return [];
+	}
+}
+
+/**
  * Search using ripgrep (rg). Uses --json format if available.
  * Respects .gitignore. Excludes node_modules, dist, .git.
  */
@@ -218,11 +275,17 @@ export async function search(
 	let results: SearchResult[] = [];
 
 	try {
-		const rgAvailable = await isToolAvailable("rg");
-		if (rgAvailable) {
-			results = await searchWithRipgrep(query, options);
+		// Try Zoekt first (indexed, fastest), then rg, then grep
+		const zoektResults = await searchWithZoekt(query, options);
+		if (zoektResults.length > 0) {
+			results = zoektResults;
 		} else {
-			results = await searchWithGrep(query, options);
+			const rgAvailable = await isToolAvailable("rg");
+			if (rgAvailable) {
+				results = await searchWithRipgrep(query, options);
+			} else {
+				results = await searchWithGrep(query, options);
+			}
 		}
 	} catch {
 		return [];


### PR DESCRIPTION
## Summary

- Add Zoekt (Google's code search) as highest-priority search backend in the retrieval layer
- Search priority: Zoekt (indexed) → ripgrep → grep fallback
- Graceful skip when Zoekt not installed — existing rg/grep behavior unchanged
- 909 tests pass, 0 fail

## Test plan

- [x] 5 new retrieval tests (parseZoektOutput + searchWithZoekt)
- [x] 909 total tests pass
- [x] Falls back to rg/grep when zoekt not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)