### PR TITLE
fix: wire A/B test into prompt resolution + learn --no-interactive + MCP review feedback

### DIFF
--- a/packages/cli/src/commands/learn.ts
+++ b/packages/cli/src/commands/learn.ts
@@ -26,7 +26,9 @@ const MIN_SAMPLES_FOR_LEARNING = 30;
 export function learnCommand(): Command {
 	return new Command("learn")
 		.description("Analyse feedback and propose prompt improvements")
-		.action(async () => {
+		.option("--no-interactive", "Skip interactive prompts (report only)")
+		.action(async (options) => {
+			const interactive = options.interactive !== false;
 			intro("maina learn");
 
 			const repoRoot = process.cwd();
@@ -132,6 +134,18 @@ export function learnCommand(): Command {
 			log.warning(
 				`${improvable.length} task(s) could benefit from prompt improvement.`,
 			);
+
+			if (!interactive) {
+				for (const task of improvable) {
+					log.step(
+						`${task.task}: ${task.totalSamples} samples, ${(task.acceptRate * 100).toFixed(0)}% accept rate — needs improvement`,
+					);
+				}
+				outro(
+					"Done. Run without --no-interactive to create improvement candidates.",
+				);
+				return;
+			}
 
 			for (const task of improvable) {
 				log.step(

--- a/packages/core/src/prompts/engine.ts
+++ b/packages/core/src/prompts/engine.ts
@@ -1,6 +1,7 @@
 import { hashContent } from "../cache/keys";
 import { getFeedbackDb } from "../db/index";
 import { loadDefault, type PromptTask } from "./defaults/index";
+import { abTest } from "./evolution";
 import {
 	loadConstitution,
 	loadUserOverride,
@@ -40,6 +41,26 @@ export async function buildSystemPrompt(
 
 	// Load default prompt template
 	const defaultPrompt = await loadDefault(task as PromptTask);
+
+	// A/B test: check if a candidate prompt should be used (20% traffic)
+	const abResult = abTest(mainaDir, task);
+	if (abResult.variant === "candidate" && abResult.hash) {
+		// Candidate selected — load its content from prompt_versions
+		const dbResult = getFeedbackDb(mainaDir);
+		if (dbResult.ok) {
+			const row = dbResult.value.db
+				.query("SELECT content FROM prompt_versions WHERE hash = ? LIMIT 1")
+				.get(abResult.hash) as { content: string } | null;
+			if (row?.content) {
+				const allVariables: Record<string, string> = {
+					constitution,
+					...variables,
+				};
+				const prompt = renderTemplate(row.content, allVariables);
+				return { prompt, hash: hashContent(prompt) };
+			}
+		}
+	}
 
 	// Load user override from .maina/prompts/<task>.md
 	const userOverride = await loadUserOverride(mainaDir, task);

--- a/packages/mcp/src/tools/review.ts
+++ b/packages/mcp/src/tools/review.ts
@@ -13,12 +13,31 @@ export function registerReviewTools(server: McpServer): void {
 		{ diff: z.string(), planContent: z.string().optional() },
 		async ({ diff, planContent }) => {
 			try {
-				const { runTwoStageReview } = await import("@maina/core");
+				const {
+					runTwoStageReview,
+					recordFeedbackAsync,
+					getWorkflowId,
+					getCurrentBranch,
+				} = await import("@maina/core");
+				const mainaDir = join(process.cwd(), ".maina");
 				const result = await runTwoStageReview({
 					diff,
 					planContent,
-					mainaDir: join(process.cwd(), ".maina"),
+					mainaDir,
 				});
+
+				// Record feedback for RL loop — review outcome feeds A/B test
+				const branch = await getCurrentBranch(process.cwd());
+				const workflowId = getWorkflowId(branch);
+				recordFeedbackAsync(mainaDir, {
+					promptHash: "review-mcp",
+					task: "review",
+					accepted: result.passed,
+					timestamp: new Date().toISOString(),
+					workflowStep: "review",
+					workflowId,
+				});
+
 				return {
 					content: [
 						{


### PR DESCRIPTION
## Summary

Three fixes for the RL feedback loop:

1. **A/B test wired into prompt resolution** — `buildSystemPrompt()` now calls `abTest()` and uses candidate prompt content when selected (20% traffic). Previously A/B test was dead code.
2. **`maina learn --no-interactive`** — reports metrics without hanging on interactive prompts. Essential for CI and agent workflows.
3. **MCP `reviewCode` records feedback** — every MCP review now feeds `recordFeedbackAsync` with workflow step + ID, so the A/B test gets samples from actual reviews.

## Test plan

- [x] 980 tests pass, 0 fail
- [x] MCP verify passed
- [x] MCP checkSlop clean
- [x] MCP reviewCode passed (2-stage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)