### PR TITLE
docs: ADR — report storage backend (R2 with @workkit/r2)

### DIFF
--- a/.maina/features/036-adr-report-storage-r2/plan.md
+++ b/.maina/features/036-adr-report-storage-r2/plan.md
@@ -4,74 +4,38 @@
 
 ## Architecture
 
-What is the technical approach? How does it fit into existing architecture?
-Where are the integration points with existing code?
+Documentation-only change. Write an ADR in `adr/` following the standard format. The ADR formalizes the existing Cloudflare R2 choice and specifies that maina-cloud uses `@workkit/r2` for all storage operations.
 
-- Pattern: [NEEDS CLARIFICATION]
-- Integration points: [NEEDS CLARIFICATION]
+- Pattern: ADR (Architecture Decision Record)
+- Integration points: Referenced by #131 (report viewer) and #130 (PR comment v2)
+- **Storage layer: `@workkit/r2`** — typed R2 client with presigned URLs, streaming, multipart upload. Already used in maina-cloud. Zero custom R2 code needed.
 
 ## Key Technical Decisions
 
-What libraries, patterns, or approaches? WHY these and not alternatives?
-
-- [NEEDS CLARIFICATION]
+- Use `@workkit/r2` (MIT, `@workkit/r2@0.1.1`) for all R2 operations in maina-cloud
+  - `createPresignedUrl()` for CI upload flow (no server-side proxy needed)
+  - `r2.put()` / `r2.get()` for server-side report reads
+  - `streamToJson()` / `streamToBuffer()` for report and screenshot serving
+  - `multipartUpload()` for large reports if needed
+- Bucket layout: `r/<run-id>/report.json`, `r/<run-id>/report.html`, `r/<run-id>/shot/<id>.png`
+- CDN via Cloudflare Cache API (R2 is already in the Cloudflare ecosystem)
 
 ## Files
 
 | File | Purpose | New/Modified |
 |------|---------|-------------|
-| [NEEDS CLARIFICATION] | | |
+| `adr/0013-report-storage-backend-cloudflare-r2.md` | ADR document | Modified (fill in scaffolded template) |
 
 ## Tasks
 
-TDD: every implementation task must have a preceding test task.
-
-- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
+- [ ] T1: Write ADR with all sections using @workkit/r2 as the storage layer
+- [ ] T2: Verify ADR passes maina verify (no slop, no placeholders)
 
 ## Failure Modes
 
-What can go wrong? How do we handle it gracefully?
-
-- [NEEDS CLARIFICATION]
+- N/A — documentation only, no runtime changes
 
 ## Testing Strategy
 
-Unit tests, integration tests, or both? What mocks are needed?
-
-- [NEEDS CLARIFICATION]
-
-
-## Wiki Context
-
-### Related Modules
-
-- **cluster-109** (6 entities) — `modules/cluster-109.md`
-
-### Related Decisions
-
-- 0012-v050-cloud-client-maina-cloud: v0.5.0 Cloud Client + maina-cloud [accepted]
-- 0007-visual-verification-with-playwright: Visual verification with Playwright [proposed]
-- 0002-multi-language-verify-pipeline: Multi-language verify pipeline [accepted]
-- 0010-v03x-hardening-verify-gaps-rl-loop-hldlld: v0.3.x Hardening: Verify Gaps + RL Loop + HLD/LLD [accepted]
-
-### Similar Features
-
-- 027-v10-launch: Implementation Plan
-- 025-v06-hosted-verification: Implementation Plan
-- 009-interactive-design: Implementation Plan
-- 007-todo-api-crud: Implementation Plan
-- 024-v05-cloud-client: Implementation Plan — v0.5.0 Cloud Client + maina-cloud
-- 010-benchmark-harness: Implementation Plan
-
-### Suggestions
-
-- Module 'cluster-109' already has 6 entities — consider extending it
-- Feature 027-v10-launch did something similar — check wiki/features/027-v10-launch.md
-- Feature 025-v06-hosted-verification did something similar — check wiki/features/025-v06-hosted-verification.md
-- Feature 009-interactive-design did something similar — check wiki/features/009-interactive-design.md
-- Feature 007-todo-api-crud did something similar — check wiki/features/007-todo-api-crud.md
-- Feature 024-v05-cloud-client did something similar — check wiki/features/024-v05-cloud-client.md
-- Feature 010-benchmark-harness did something similar — check wiki/features/010-benchmark-harness.md
-- ADR 0012-v050-cloud-client-maina-cloud (v0.5.0 Cloud Client + maina-cloud) is accepted — ensure compatibility
-- ADR 0002-multi-language-verify-pipeline (Multi-language verify pipeline) is accepted — ensure compatibility
-- ADR 0010-v03x-hardening-verify-gaps-rl-loop-hldlld (v0.3.x Hardening: Verify Gaps + RL Loop + HLD/LLD) is accepted — ensure compatibility
+- maina verify (slop check, no TODO/FIXME markers)
+- Manual review for completeness against acceptance criteria

--- a/.maina/features/036-adr-report-storage-r2/plan.md
+++ b/.maina/features/036-adr-report-storage-r2/plan.md
@@ -1,0 +1,77 @@
+# Implementation Plan
+
+> HOW only — see spec.md for WHAT and WHY.
+
+## Architecture
+
+What is the technical approach? How does it fit into existing architecture?
+Where are the integration points with existing code?
+
+- Pattern: [NEEDS CLARIFICATION]
+- Integration points: [NEEDS CLARIFICATION]
+
+## Key Technical Decisions
+
+What libraries, patterns, or approaches? WHY these and not alternatives?
+
+- [NEEDS CLARIFICATION]
+
+## Files
+
+| File | Purpose | New/Modified |
+|------|---------|-------------|
+| [NEEDS CLARIFICATION] | | |
+
+## Tasks
+
+TDD: every implementation task must have a preceding test task.
+
+- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
+
+## Failure Modes
+
+What can go wrong? How do we handle it gracefully?
+
+- [NEEDS CLARIFICATION]
+
+## Testing Strategy
+
+Unit tests, integration tests, or both? What mocks are needed?
+
+- [NEEDS CLARIFICATION]
+
+
+## Wiki Context
+
+### Related Modules
+
+- **cluster-109** (6 entities) — `modules/cluster-109.md`
+
+### Related Decisions
+
+- 0012-v050-cloud-client-maina-cloud: v0.5.0 Cloud Client + maina-cloud [accepted]
+- 0007-visual-verification-with-playwright: Visual verification with Playwright [proposed]
+- 0002-multi-language-verify-pipeline: Multi-language verify pipeline [accepted]
+- 0010-v03x-hardening-verify-gaps-rl-loop-hldlld: v0.3.x Hardening: Verify Gaps + RL Loop + HLD/LLD [accepted]
+
+### Similar Features
+
+- 027-v10-launch: Implementation Plan
+- 025-v06-hosted-verification: Implementation Plan
+- 009-interactive-design: Implementation Plan
+- 007-todo-api-crud: Implementation Plan
+- 024-v05-cloud-client: Implementation Plan — v0.5.0 Cloud Client + maina-cloud
+- 010-benchmark-harness: Implementation Plan
+
+### Suggestions
+
+- Module 'cluster-109' already has 6 entities — consider extending it
+- Feature 027-v10-launch did something similar — check wiki/features/027-v10-launch.md
+- Feature 025-v06-hosted-verification did something similar — check wiki/features/025-v06-hosted-verification.md
+- Feature 009-interactive-design did something similar — check wiki/features/009-interactive-design.md
+- Feature 007-todo-api-crud did something similar — check wiki/features/007-todo-api-crud.md
+- Feature 024-v05-cloud-client did something similar — check wiki/features/024-v05-cloud-client.md
+- Feature 010-benchmark-harness did something similar — check wiki/features/010-benchmark-harness.md
+- ADR 0012-v050-cloud-client-maina-cloud (v0.5.0 Cloud Client + maina-cloud) is accepted — ensure compatibility
+- ADR 0002-multi-language-verify-pipeline (Multi-language verify pipeline) is accepted — ensure compatibility
+- ADR 0010-v03x-hardening-verify-gaps-rl-loop-hldlld (v0.3.x Hardening: Verify Gaps + RL Loop + HLD/LLD) is accepted — ensure compatibility

--- a/.maina/features/036-adr-report-storage-r2/spec.md
+++ b/.maina/features/036-adr-report-storage-r2/spec.md
@@ -1,0 +1,45 @@
+# Feature: [Name]
+
+## Problem Statement
+
+What specific problem does this solve? Who experiences it? What happens if we don't solve it?
+
+- [NEEDS CLARIFICATION] Define the problem clearly.
+
+## Target User
+
+Who benefits? What is their current workflow? What frustrates them about it?
+
+- Primary: [NEEDS CLARIFICATION]
+- Secondary: [NEEDS CLARIFICATION]
+
+## User Stories
+
+- As a [role], I want [capability] so that [benefit].
+
+## Success Criteria
+
+How do we know this works? Every criterion must be testable — if you can't write
+an assertion for it, the requirement isn't clear enough.
+
+- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+
+## Scope
+
+### In Scope
+
+- [NEEDS CLARIFICATION] What this feature does.
+
+### Out of Scope
+
+- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
+
+## Design Decisions
+
+Key choices made and WHY. Record tradeoffs — future you will thank you.
+
+- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
+
+## Open Questions
+
+- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.

--- a/.maina/features/036-adr-report-storage-r2/spec.md
+++ b/.maina/features/036-adr-report-storage-r2/spec.md
@@ -1,45 +1,50 @@
-# Feature: [Name]
+# Feature: ADR — Report Storage Backend (R2)
 
 ## Problem Statement
 
-What specific problem does this solve? Who experiences it? What happens if we don't solve it?
+Maina Cloud verification generates proof artifacts (JSON reports, screenshots, HTML views) that need durable storage with public read access. The team chose Cloudflare R2 early on, but the decision isn't documented. Future contributors have no written record of why R2, what the bucket layout is, or what retention/GDPR policies apply.
 
-- [NEEDS CLARIFICATION] Define the problem clearly.
+- Without a written ADR, contributors may duplicate the decision or pick a conflicting backend.
+- Blocks the self-hosted report viewer (#131) and PR comment v2 (#130).
 
 ## Target User
 
-Who benefits? What is their current workflow? What frustrates them about it?
-
-- Primary: [NEEDS CLARIFICATION]
-- Secondary: [NEEDS CLARIFICATION]
-
-## User Stories
-
-- As a [role], I want [capability] so that [benefit].
+- Primary: Maina contributors extending cloud verification infrastructure
+- Secondary: Cloud customers who need to understand data retention and GDPR compliance
 
 ## Success Criteria
 
-How do we know this works? Every criterion must be testable — if you can't write
-an assertion for it, the requirement isn't clear enough.
-
-- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+- [ ] `docs/decisions/0001-report-storage-backend.md` exists and is comprehensive
+- [ ] Covers cost model at 10k runs/month and 100k runs/month
+- [ ] Documents bucket layout: `r/<run-id>/` with sub-paths for JSON, HTML, screenshots
+- [ ] Describes signed upload flow from CI
+- [ ] Retention policy: 90 days default, extensible per plan
+- [ ] GDPR delete path documented
+- [ ] CDN cache strategy documented
+- [ ] Disaster recovery approach documented
+- [ ] Documents why R2 over S3 / Supabase Storage (zero egress, S3-compatible, cheaper at scale)
 
 ## Scope
 
 ### In Scope
 
-- [NEEDS CLARIFICATION] What this feature does.
+- Writing the ADR document with all acceptance criteria
+- Cost comparison table (R2 vs S3 vs Supabase Storage)
+- Bucket layout specification
+- Retention and GDPR policies
 
 ### Out of Scope
 
-- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
+- Implementing any infrastructure changes
+- Building the report viewer (that's #131)
+- CI upload pipeline (that's part of PR comment v2)
 
 ## Design Decisions
 
-Key choices made and WHY. Record tradeoffs — future you will thank you.
-
-- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
+- R2 chosen over S3: zero egress fees, S3-compatible API, cheaper at scale
+- R2 chosen over Supabase Storage: simpler, no extra auth layer, Cloudflare ecosystem alignment
+- Bucket layout uses `r/<run-id>/` prefix for easy per-run cleanup
 
 ## Open Questions
 
-- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.
+- None — this is a documentation-only ADR formalizing existing decisions.

--- a/.maina/features/036-adr-report-storage-r2/tasks.md
+++ b/.maina/features/036-adr-report-storage-r2/tasks.md
@@ -1,0 +1,23 @@
+# Task Breakdown
+
+## Tasks
+
+Each task should be completable in one commit. Test tasks precede implementation tasks.
+
+- [ ] [NEEDS CLARIFICATION] Define tasks.
+
+## Dependencies
+
+Which tasks block which? Draw the critical path.
+
+- [NEEDS CLARIFICATION]
+
+## Definition of Done
+
+How do we know this feature is complete?
+
+- [ ] All tests pass
+- [ ] Biome lint clean
+- [ ] TypeScript compiles
+- [ ] maina analyze shows no errors
+- [ ] [NEEDS CLARIFICATION] Feature-specific criteria

--- a/adr/0013-report-storage-backend-cloudflare-r2.md
+++ b/adr/0013-report-storage-backend-cloudflare-r2.md
@@ -1,0 +1,122 @@
+# 0013. Report storage backend (Cloudflare R2)
+
+Date: 2026-04-17
+
+## Status
+
+Accepted
+
+## Context
+
+Maina Cloud verification generates proof artifacts that need durable, publicly readable storage: JSON reports, HTML report views, and PNG screenshots for visual-diff checks. The system needs:
+
+- Signed uploads from CI (no server-side proxy for large payloads)
+- Public read access with CDN caching for report permalinks
+- Per-run cleanup for retention and GDPR deletion
+- Cost predictability at scale (10k–100k runs/month)
+
+maina-cloud already runs on Cloudflare Workers and uses the `@workkit` monorepo for infrastructure primitives.
+
+## Decision
+
+Use **Cloudflare R2** as the storage backend for all verification artifacts. All R2 operations go through **`@workkit/r2`** (`@workkit/r2@0.1.1`, MIT) — the typed R2 client library that provides presigned URLs, streaming helpers, multipart upload, and error handling out of the box.
+
+### Bucket Layout
+
+```
+maina-reports/
+  r/<run-id>/
+    report.json          # structured verification result
+    report.html          # rendered HTML report
+    shot/<id>.png        # screenshots (visual-diff before/after pairs)
+    meta.json            # run metadata: commit, branch, timestamp, org_id
+```
+
+### Upload Flow (CI → R2)
+
+1. CI calls `POST /api/runs` with run metadata
+2. Server generates presigned PUT URLs via `@workkit/r2`'s `createPresignedUrl()`
+3. CI uploads artifacts directly to R2 (no server proxy — zero bandwidth cost on Workers)
+4. CI calls `POST /api/runs/<id>/complete` to finalize
+
+### Read Flow (Report Viewer)
+
+1. `GET /r/<run-id>` → server reads `report.html` via `r2.get()`, streams with `streamToBuffer()`
+2. `GET /r/<run-id>.json` → server reads `report.json` via `r2.get()`, streams with `streamToJson()`
+3. `GET /r/<run-id>/shot/<id>.png` → server reads PNG via `r2.get()`, serves with appropriate headers
+4. Cloudflare Cache API caches responses at the edge (immutable content, cache forever)
+
+### Retention Policy
+
+- Default: 90 days from run creation
+- Paid plans: configurable (30/90/180/365 days)
+- Implementation: Cloudflare R2 lifecycle rules on `meta.json` creation date
+- Alternatively: daily cron job via `@workkit/cron` listing runs older than retention window
+
+### GDPR Delete Path
+
+- `DELETE /api/runs/<id>` → deletes all objects under `r/<run-id>/` prefix
+- `DELETE /api/org/<id>/data` → lists and deletes all runs for an org
+- Uses `r2.list({ prefix })` + batch `r2.delete()` from `@workkit/r2`
+- Deletion is synchronous — confirmed before response
+
+### CDN Cache Strategy
+
+- Report artifacts are immutable (same run-id = same content)
+- Set `Cache-Control: public, max-age=31536000, immutable` on all `r/<run-id>/*` responses
+- Cloudflare Cache API for edge caching (free with Workers)
+- Cache purge not needed — content never changes per run-id
+
+### Disaster Recovery
+
+- R2 stores data across multiple Cloudflare data centers (built-in replication)
+- Daily backup of `meta.json` index to a separate R2 bucket (`maina-reports-backup/`)
+- Recovery: re-index from backup bucket if primary is corrupted
+
+## Cost Model
+
+| Scale | Storage | Class A (writes) | Class B (reads) | Egress | Total/mo |
+|-------|---------|-------------------|-----------------|--------|----------|
+| 10k runs/mo (~50MB avg) | 500GB @ $0.015/GB = $7.50 | 50k @ $4.50/M = $0.23 | 200k @ $0.36/M = $0.07 | $0 | ~$8 |
+| 100k runs/mo (~50MB avg) | 5TB @ $0.015/GB = $75 | 500k @ $4.50/M = $2.25 | 2M @ $0.36/M = $0.72 | $0 | ~$78 |
+
+Key advantage: **zero egress fees** regardless of how many report views or API reads.
+
+## Alternatives Considered
+
+### AWS S3
+
+- Pros: Industry standard, mature tooling, lifecycle policies
+- Cons: Egress fees ($0.09/GB) would dominate costs at scale. At 100k runs/mo with 5TB of reads, egress alone would be ~$450/mo vs $0 on R2.
+- Verdict: Rejected — egress cost makes it 5x+ more expensive.
+
+### Supabase Storage
+
+- Pros: Built on S3, nice dashboard, auth integration
+- Cons: Extra auth layer we don't need (maina-cloud has its own), not Cloudflare-native, egress fees via AWS underneath.
+- Verdict: Rejected — adds complexity without benefit for our use case.
+
+### Cloudflare R2 (chosen)
+
+- Pros: Zero egress, S3-compatible API, native to our Workers stack, `@workkit/r2` already provides typed client with presigned URLs
+- Cons: Smaller ecosystem than S3 (mitigated by S3-compatible API)
+- Verdict: **Accepted** — best cost/complexity tradeoff for our Cloudflare-native stack.
+
+## Consequences
+
+### Positive
+
+- Zero egress fees keep costs predictable and low
+- `@workkit/r2` provides typed, tested R2 operations — no custom storage code
+- Presigned URLs mean CI uploads bypass the server entirely
+- Cloudflare-native: no cross-cloud latency for Workers reading from R2
+
+### Negative
+
+- Vendor lock-in to Cloudflare (mitigated: R2 is S3-compatible, migration path exists)
+- R2 lifecycle rules are less mature than S3 (mitigated: cron-based cleanup as fallback)
+
+### Neutral
+
+- Report viewer must be hosted on Cloudflare Workers (already the case for maina-cloud)
+- S3-compatible API means existing S3 tooling works if we ever need it

--- a/packages/core/src/verify/builtin.ts
+++ b/packages/core/src/verify/builtin.ts
@@ -211,7 +211,7 @@ export function checkSecrets(filePath: string, content: string): Finding[] {
 
 	for (const [i, line] of lines.entries()) {
 		const match = line.match(secretPattern);
-		if (match && match[2] && !testValuePattern.test(match[2])) {
+		if (match?.[2] && !testValuePattern.test(match[2])) {
 			findings.push({
 				tool: "builtin",
 				file: filePath,


### PR DESCRIPTION
## Summary

- ADR `0013-report-storage-backend-cloudflare-r2.md` documenting the R2 storage decision
- Uses `@workkit/r2` for all storage operations (presigned URLs, streaming, multipart)
- Covers: cost model (10k–100k runs/mo), bucket layout, upload flow, retention, GDPR delete, CDN cache, disaster recovery
- Compares R2 vs S3 vs Supabase Storage with cost analysis
- Also fixes biome lint warning in `builtin.ts` (optional chain)

Closes #86

## Test plan

- [x] `maina verify` passes — no slop, no errors
- [x] `maina checkSlop` — clean
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established architecture decision for verification report storage, including bucket organization, presigned upload workflow from CI, 90-day retention (configurable for paid plans), GDPR compliance procedures, immutable CDN caching, and disaster recovery mechanisms.

* **Bug Fixes**
  * Enhanced secret verification error handling with safer capture group access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->