### PR TITLE
feat(core): import adapters for existing rule files

### DIFF
--- a/.maina/features/037-import-rule-adapters/plan.md
+++ b/.maina/features/037-import-rule-adapters/plan.md
@@ -1,0 +1,54 @@
+# Implementation Plan
+
+> HOW only — see spec.md for WHAT and WHY.
+
+## Architecture
+
+What is the technical approach? How does it fit into existing architecture?
+Where are the integration points with existing code?
+
+- Pattern: [NEEDS CLARIFICATION]
+- Integration points: [NEEDS CLARIFICATION]
+
+## Key Technical Decisions
+
+What libraries, patterns, or approaches? WHY these and not alternatives?
+
+- [NEEDS CLARIFICATION]
+
+## Files
+
+| File | Purpose | New/Modified |
+|------|---------|-------------|
+| [NEEDS CLARIFICATION] | | |
+
+## Tasks
+
+TDD: every implementation task must have a preceding test task.
+
+- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
+
+## Failure Modes
+
+What can go wrong? How do we handle it gracefully?
+
+- [NEEDS CLARIFICATION]
+
+## Testing Strategy
+
+Unit tests, integration tests, or both? What mocks are needed?
+
+- [NEEDS CLARIFICATION]
+
+
+## Wiki Context
+
+### Similar Features
+
+- 025-v06-hosted-verification: Implementation Plan
+- 007-todo-api-crud: Implementation Plan
+
+### Suggestions
+
+- Feature 025-v06-hosted-verification did something similar — check wiki/features/025-v06-hosted-verification.md
+- Feature 007-todo-api-crud did something similar — check wiki/features/007-todo-api-crud.md

--- a/.maina/features/037-import-rule-adapters/spec.md
+++ b/.maina/features/037-import-rule-adapters/spec.md
@@ -1,0 +1,45 @@
+# Feature: [Name]
+
+## Problem Statement
+
+What specific problem does this solve? Who experiences it? What happens if we don't solve it?
+
+- [NEEDS CLARIFICATION] Define the problem clearly.
+
+## Target User
+
+Who benefits? What is their current workflow? What frustrates them about it?
+
+- Primary: [NEEDS CLARIFICATION]
+- Secondary: [NEEDS CLARIFICATION]
+
+## User Stories
+
+- As a [role], I want [capability] so that [benefit].
+
+## Success Criteria
+
+How do we know this works? Every criterion must be testable — if you can't write
+an assertion for it, the requirement isn't clear enough.
+
+- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+
+## Scope
+
+### In Scope
+
+- [NEEDS CLARIFICATION] What this feature does.
+
+### Out of Scope
+
+- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
+
+## Design Decisions
+
+Key choices made and WHY. Record tradeoffs — future you will thank you.
+
+- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
+
+## Open Questions
+
+- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.

--- a/.maina/features/037-import-rule-adapters/tasks.md
+++ b/.maina/features/037-import-rule-adapters/tasks.md
@@ -1,0 +1,23 @@
+# Task Breakdown
+
+## Tasks
+
+Each task should be completable in one commit. Test tasks precede implementation tasks.
+
+- [ ] [NEEDS CLARIFICATION] Define tasks.
+
+## Dependencies
+
+Which tasks block which? Draw the critical path.
+
+- [NEEDS CLARIFICATION]
+
+## Definition of Done
+
+How do we know this feature is complete?
+
+- [ ] All tests pass
+- [ ] Biome lint clean
+- [ ] TypeScript compiles
+- [ ] maina analyze shows no errors
+- [ ] [NEEDS CLARIFICATION] Feature-specific criteria

--- a/packages/core/src/prompts/__tests__/loader.test.ts
+++ b/packages/core/src/prompts/__tests__/loader.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
+	formatImportedRules,
+	importExistingRules,
 	loadConstitution,
 	loadUserOverride,
 	mergePrompts,
@@ -101,5 +103,86 @@ describe("renderTemplate", () => {
 		const template = "Hello {{name}}.";
 		const result = renderTemplate(template, {});
 		expect(result).toBe("Hello {{name}}.");
+	});
+});
+
+// ── importExistingRules ─────────────────────────────────────────────
+
+describe("importExistingRules", () => {
+	test("reads CLAUDE.md and AGENTS.md from repo root", async () => {
+		writeFileSync(join(tmpDir, "CLAUDE.md"), "# Claude Rules\nUse TypeScript.");
+		writeFileSync(join(tmpDir, "AGENTS.md"), "# Agent Rules\nRun tests.");
+
+		const rules = await importExistingRules(tmpDir, "");
+		expect(rules.length).toBe(2);
+		expect(rules.some((r) => r.source === "CLAUDE.md")).toBe(true);
+		expect(rules.some((r) => r.source === "AGENTS.md")).toBe(true);
+	});
+
+	test("reads .cursorrules", async () => {
+		writeFileSync(join(tmpDir, ".cursorrules"), "Use arrow functions.");
+
+		const rules = await importExistingRules(tmpDir, "");
+		expect(rules.length).toBe(1);
+		expect(rules[0]?.source).toBe(".cursorrules");
+		expect(rules[0]?.content).toContain("arrow functions");
+	});
+
+	test("skips files already imported (provenance marker in constitution)", async () => {
+		writeFileSync(join(tmpDir, "CLAUDE.md"), "# Claude Rules");
+		const constitution = "## Imported Rules\n<!-- imported_from: CLAUDE.md -->";
+
+		const rules = await importExistingRules(tmpDir, constitution);
+		expect(rules.length).toBe(0);
+	});
+
+	test("skips empty files", async () => {
+		writeFileSync(join(tmpDir, "CLAUDE.md"), "");
+		writeFileSync(join(tmpDir, ".cursorrules"), "   \n  ");
+
+		const rules = await importExistingRules(tmpDir, "");
+		expect(rules.length).toBe(0);
+	});
+
+	test("skips missing files without error", async () => {
+		const rules = await importExistingRules(tmpDir, "");
+		expect(rules.length).toBe(0);
+	});
+
+	test("extracts only relevant sections from CONTRIBUTING.md", async () => {
+		writeFileSync(
+			join(tmpDir, "CONTRIBUTING.md"),
+			[
+				"# Contributing",
+				"Thanks for contributing!",
+				"## Code Style",
+				"Use tabs, not spaces.",
+				"## How to Submit",
+				"Open a PR on GitHub.",
+				"## Testing",
+				"Write tests first.",
+			].join("\n"),
+		);
+
+		const rules = await importExistingRules(tmpDir, "");
+		expect(rules.length).toBe(1);
+		expect(rules[0]?.content).toContain("Code Style");
+		expect(rules[0]?.content).toContain("Testing");
+		expect(rules[0]?.content).not.toContain("How to Submit");
+	});
+});
+
+describe("formatImportedRules", () => {
+	test("formats rules with provenance comments", () => {
+		const result = formatImportedRules([
+			{ source: "CLAUDE.md", content: "Use TypeScript." },
+		]);
+		expect(result).toContain("## Imported Rules");
+		expect(result).toContain("<!-- imported_from: CLAUDE.md -->");
+		expect(result).toContain("Use TypeScript.");
+	});
+
+	test("returns empty string for no rules", () => {
+		expect(formatImportedRules([])).toBe("");
 	});
 });

--- a/packages/core/src/prompts/loader.ts
+++ b/packages/core/src/prompts/loader.ts
@@ -1,5 +1,22 @@
 import { join } from "node:path";
 
+// ── Rule file sources that may contain project conventions ──────────────
+
+const RULE_FILES = [
+	"CLAUDE.md",
+	"AGENTS.md",
+	".cursorrules",
+	".github/copilot-instructions.md",
+	".windsurfrules",
+	".clinerules",
+	"CONTRIBUTING.md",
+] as const;
+
+export interface ImportedRule {
+	source: string;
+	content: string;
+}
+
 /**
  * Reads .maina/constitution.md, returns empty string if not found.
  * Never throws.
@@ -16,6 +33,87 @@ export async function loadConstitution(mainaDir: string): Promise<string> {
 	} catch {
 		return "";
 	}
+}
+
+/**
+ * Scan existing rule files (CLAUDE.md, AGENTS.md, .cursorrules, etc.)
+ * and extract their content. Returns an array of imported rules with
+ * provenance. Does NOT duplicate — if a rule file's content is already
+ * present in the constitution, it's skipped.
+ *
+ * Never throws.
+ */
+export async function importExistingRules(
+	repoRoot: string,
+	constitution: string,
+): Promise<ImportedRule[]> {
+	const rules: ImportedRule[] = [];
+
+	for (const relPath of RULE_FILES) {
+		try {
+			const filePath = join(repoRoot, relPath);
+			const file = Bun.file(filePath);
+			const exists = await file.exists();
+			if (!exists) continue;
+
+			const content = await file.text();
+			if (!content.trim()) continue;
+
+			// Skip if the constitution already references this file
+			if (constitution.includes(`imported_from: ${relPath}`)) continue;
+
+			// For CONTRIBUTING.md, extract only relevant sections
+			const filtered =
+				relPath === "CONTRIBUTING.md"
+					? extractContributingSections(content)
+					: content;
+
+			if (filtered.trim()) {
+				rules.push({ source: relPath, content: filtered.trim() });
+			}
+		} catch {
+			// File read error — skip
+		}
+	}
+
+	return rules;
+}
+
+/**
+ * Extract convention-relevant sections from CONTRIBUTING.md.
+ * Keeps: Code Style, Conventions, Testing, Commit, Review sections.
+ * Drops: How to Submit, License, CoC, etc.
+ */
+function extractContributingSections(content: string): string {
+	const keepPatterns =
+		/^#{1,3}\s*(code\s*style|conventions?|testing|commit|review|lint|format|architecture)/im;
+	const lines = content.split("\n");
+	const sections: string[] = [];
+	let capturing = false;
+
+	for (const line of lines) {
+		if (/^#{1,3}\s/.test(line)) {
+			capturing = keepPatterns.test(line);
+		}
+		if (capturing) {
+			sections.push(line);
+		}
+	}
+
+	return sections.join("\n");
+}
+
+/**
+ * Format imported rules into a constitution-compatible block with provenance.
+ */
+export function formatImportedRules(rules: ImportedRule[]): string {
+	if (rules.length === 0) return "";
+
+	const blocks = rules.map(
+		(r) => `<!-- imported_from: ${r.source} -->\n${r.content}`,
+	);
+
+	return `\n## Imported Rules\n\n${blocks.join("\n\n")}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds `importExistingRules()` and `formatImportedRules()` to the prompt loader. Scans repo root for existing rule files and extracts conventions:

- CLAUDE.md, AGENTS.md, .cursorrules, .windsurfrules, .clinerules
- .github/copilot-instructions.md
- CONTRIBUTING.md (section-filtered: only Code Style, Conventions, Testing, Commit sections)

Each imported block carries `<!-- imported_from: <file> -->` provenance. Already-imported files (detected via marker) are skipped.

Closes #100

## Test plan

- [x] 18 tests pass — reads rule files, skips empty/missing, filters CONTRIBUTING.md sections, formats with provenance
- [x] Typecheck passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)