### PR TITLE
feat(docs): MCP install badges for Claude Code, Cursor, and Windsurf

### DIFF
--- a/.maina/features/038-mcp-install-badges/plan.md
+++ b/.maina/features/038-mcp-install-badges/plan.md
@@ -4,63 +4,20 @@
 
 ## Architecture
 
-What is the technical approach? How does it fit into existing architecture?
-Where are the integration points with existing code?
-
-- Pattern: [NEEDS CLARIFICATION]
-- Integration points: [NEEDS CLARIFICATION]
-
-## Key Technical Decisions
-
-What libraries, patterns, or approaches? WHY these and not alternatives?
-
-- [NEEDS CLARIFICATION]
+Add a badge row to `packages/docs/src/components/Hero.astro` below the install command. Each badge is an `<a>` or `<button>` with inline JS for clipboard/deeplink actions.
 
 ## Files
 
 | File | Purpose | New/Modified |
 |------|---------|-------------|
-| [NEEDS CLARIFICATION] | | |
+| `packages/docs/src/components/Hero.astro` | Add badge row below install-cmd | Modified |
+| `packages/docs/src/styles/landing.css` | Badge styling, mobile responsive | Modified |
 
 ## Tasks
 
-TDD: every implementation task must have a preceding test task.
-
-- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
-
-## Failure Modes
-
-What can go wrong? How do we handle it gracefully?
-
-- [NEEDS CLARIFICATION]
-
-## Testing Strategy
-
-Unit tests, integration tests, or both? What mocks are needed?
-
-- [NEEDS CLARIFICATION]
-
-
-## Wiki Context
-
-### Related Modules
-
-- **tools** (6 entities) — `modules/tools.md`
-- **cluster-135** (2 entities) — `modules/cluster-135.md`
-
-### Related Decisions
-
-- 0003-fix-host-delegation-for-cli-ai-tasks: Fix host delegation for CLI AI tasks [proposed]
-
-### Similar Features
-
-- 030-mcp-agent-files: Feature 030: Auto-Configure MCP + Agent Instruction Files During Init
-- 004-mcp-server: Implementation Plan
-- 009-interactive-design: Implementation Plan
-
-### Suggestions
-
-- Module 'tools' already has 6 entities — consider extending it
-- Feature 030-mcp-agent-files did something similar — check wiki/features/030-mcp-agent-files.md
-- Feature 004-mcp-server did something similar — check wiki/features/004-mcp-server.md
-- Feature 009-interactive-design did something similar — check wiki/features/009-interactive-design.md
+- [ ] T1: Add badge HTML to Hero.astro
+- [ ] T2: Implement Claude Code badge (shell command copy)
+- [ ] T3: Implement Cursor badge (deeplink with base64 config)
+- [ ] T4: Implement Windsurf badge (clipboard copy with toast)
+- [ ] T5: Add responsive CSS for mobile
+- [ ] T6: maina verify + build test

--- a/.maina/features/038-mcp-install-badges/plan.md
+++ b/.maina/features/038-mcp-install-badges/plan.md
@@ -1,0 +1,66 @@
+# Implementation Plan
+
+> HOW only — see spec.md for WHAT and WHY.
+
+## Architecture
+
+What is the technical approach? How does it fit into existing architecture?
+Where are the integration points with existing code?
+
+- Pattern: [NEEDS CLARIFICATION]
+- Integration points: [NEEDS CLARIFICATION]
+
+## Key Technical Decisions
+
+What libraries, patterns, or approaches? WHY these and not alternatives?
+
+- [NEEDS CLARIFICATION]
+
+## Files
+
+| File | Purpose | New/Modified |
+|------|---------|-------------|
+| [NEEDS CLARIFICATION] | | |
+
+## Tasks
+
+TDD: every implementation task must have a preceding test task.
+
+- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
+
+## Failure Modes
+
+What can go wrong? How do we handle it gracefully?
+
+- [NEEDS CLARIFICATION]
+
+## Testing Strategy
+
+Unit tests, integration tests, or both? What mocks are needed?
+
+- [NEEDS CLARIFICATION]
+
+
+## Wiki Context
+
+### Related Modules
+
+- **tools** (6 entities) — `modules/tools.md`
+- **cluster-135** (2 entities) — `modules/cluster-135.md`
+
+### Related Decisions
+
+- 0003-fix-host-delegation-for-cli-ai-tasks: Fix host delegation for CLI AI tasks [proposed]
+
+### Similar Features
+
+- 030-mcp-agent-files: Feature 030: Auto-Configure MCP + Agent Instruction Files During Init
+- 004-mcp-server: Implementation Plan
+- 009-interactive-design: Implementation Plan
+
+### Suggestions
+
+- Module 'tools' already has 6 entities — consider extending it
+- Feature 030-mcp-agent-files did something similar — check wiki/features/030-mcp-agent-files.md
+- Feature 004-mcp-server did something similar — check wiki/features/004-mcp-server.md
+- Feature 009-interactive-design did something similar — check wiki/features/009-interactive-design.md

--- a/.maina/features/038-mcp-install-badges/spec.md
+++ b/.maina/features/038-mcp-install-badges/spec.md
@@ -1,0 +1,45 @@
+# Feature: [Name]
+
+## Problem Statement
+
+What specific problem does this solve? Who experiences it? What happens if we don't solve it?
+
+- [NEEDS CLARIFICATION] Define the problem clearly.
+
+## Target User
+
+Who benefits? What is their current workflow? What frustrates them about it?
+
+- Primary: [NEEDS CLARIFICATION]
+- Secondary: [NEEDS CLARIFICATION]
+
+## User Stories
+
+- As a [role], I want [capability] so that [benefit].
+
+## Success Criteria
+
+How do we know this works? Every criterion must be testable — if you can't write
+an assertion for it, the requirement isn't clear enough.
+
+- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+
+## Scope
+
+### In Scope
+
+- [NEEDS CLARIFICATION] What this feature does.
+
+### Out of Scope
+
+- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
+
+## Design Decisions
+
+Key choices made and WHY. Record tradeoffs — future you will thank you.
+
+- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
+
+## Open Questions
+
+- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.

--- a/.maina/features/038-mcp-install-badges/spec.md
+++ b/.maina/features/038-mcp-install-badges/spec.md
@@ -1,45 +1,25 @@
-# Feature: [Name]
+# Feature: MCP install badges on mainahq.com hero
 
 ## Problem Statement
 
-What specific problem does this solve? Who experiences it? What happens if we don't solve it?
-
-- [NEEDS CLARIFICATION] Define the problem clearly.
-
-## Target User
-
-Who benefits? What is their current workflow? What frustrates them about it?
-
-- Primary: [NEEDS CLARIFICATION]
-- Secondary: [NEEDS CLARIFICATION]
-
-## User Stories
-
-- As a [role], I want [capability] so that [benefit].
+The hero shows a curl install command but no one-click MCP setup for agent-native users (Claude Code, Cursor, Windsurf). These users want to add Maina to their IDE in one click, not copy-paste JSON.
 
 ## Success Criteria
 
-How do we know this works? Every criterion must be testable — if you can't write
-an assertion for it, the requirement isn't clear enough.
-
-- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+- [ ] Three badges next to the curl command: "Add to Claude Code", "Add to Cursor", "Add to Windsurf"
+- [ ] Each badge works end-to-end on a clean machine
+- [ ] Snippets reference the `@mainahq/cli`-installed `maina` binary
+- [ ] Badges render above the fold on mobile (<=375px width)
+- [ ] No layout shift on badge render
 
 ## Scope
 
 ### In Scope
-
-- [NEEDS CLARIFICATION] What this feature does.
+- Three badge components in the Hero
+- Claude Code: `claude mcp add-json maina '{"command":"maina","args":["--mcp"]}'`
+- Cursor: deeplink `cursor://anysphere.cursor-deeplink/mcp/install?name=maina&config=<base64>`
+- Windsurf: copy MCP config to clipboard with toast notification
 
 ### Out of Scope
-
-- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
-
-## Design Decisions
-
-Key choices made and WHY. Record tradeoffs — future you will thank you.
-
-- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
-
-## Open Questions
-
-- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.
+- Other IDEs (Cline, Roo, etc.) — future issue
+- Badge click analytics (needs telemetry first)

--- a/.maina/features/038-mcp-install-badges/tasks.md
+++ b/.maina/features/038-mcp-install-badges/tasks.md
@@ -1,0 +1,23 @@
+# Task Breakdown
+
+## Tasks
+
+Each task should be completable in one commit. Test tasks precede implementation tasks.
+
+- [ ] [NEEDS CLARIFICATION] Define tasks.
+
+## Dependencies
+
+Which tasks block which? Draw the critical path.
+
+- [NEEDS CLARIFICATION]
+
+## Definition of Done
+
+How do we know this feature is complete?
+
+- [ ] All tests pass
+- [ ] Biome lint clean
+- [ ] TypeScript compiles
+- [ ] maina analyze shows no errors
+- [ ] [NEEDS CLARIFICATION] Feature-specific criteria

--- a/adr/0022-mcp-install-badges-on-hero.md
+++ b/adr/0022-mcp-install-badges-on-hero.md
@@ -1,0 +1,79 @@
+# 0022. MCP install badges on hero
+
+Date: 2026-04-17
+
+## Status
+
+Proposed
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+[NEEDS CLARIFICATION] Describe the context.
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+[NEEDS CLARIFICATION] Describe the decision.
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?
+
+### Positive
+
+- [NEEDS CLARIFICATION]
+
+### Negative
+
+- [NEEDS CLARIFICATION]
+
+### Neutral
+
+- [NEEDS CLARIFICATION]
+
+## High-Level Design
+
+### System Overview
+
+[NEEDS CLARIFICATION]
+
+### Component Boundaries
+
+[NEEDS CLARIFICATION]
+
+### Data Flow
+
+[NEEDS CLARIFICATION]
+
+### External Dependencies
+
+[NEEDS CLARIFICATION]
+
+## Low-Level Design
+
+### Interfaces & Types
+
+[NEEDS CLARIFICATION]
+
+### Function Signatures
+
+[NEEDS CLARIFICATION]
+
+### DB Schema Changes
+
+[NEEDS CLARIFICATION]
+
+### Sequence of Operations
+
+[NEEDS CLARIFICATION]
+
+### Error Handling
+
+[NEEDS CLARIFICATION]
+
+### Edge Cases
+
+[NEEDS CLARIFICATION]

--- a/packages/docs/src/components/Hero.astro
+++ b/packages/docs/src/components/Hero.astro
@@ -16,4 +16,60 @@ const base = rawBase.endsWith('/') ? rawBase.slice(0, -1) : rawBase;
   <div class="install-cmd">
     <code>curl -fsSL https://api.mainahq.com/install | bash</code>
   </div>
+  <div class="mcp-badges">
+    <button class="mcp-badge" data-action="claude" title="Add Maina MCP to Claude Code">
+      <span class="mcp-badge-icon">&#x2728;</span> Add to Claude Code
+    </button>
+    <a class="mcp-badge" id="cursor-badge" href="#" title="Add Maina MCP to Cursor">
+      <span class="mcp-badge-icon">&#x1F4DD;</span> Add to Cursor
+    </a>
+    <button class="mcp-badge" data-action="windsurf" title="Add Maina MCP to Windsurf">
+      <span class="mcp-badge-icon">&#x1F3C4;</span> Add to Windsurf
+    </button>
+  </div>
+  <div class="mcp-toast" id="mcp-toast" aria-live="polite"></div>
 </section>
+
+<script is:inline>
+(function() {
+  var mcpConfig = JSON.stringify({"command":"maina","args":["--mcp"]});
+
+  // Cursor deeplink: base64-encode the MCP config
+  var cursorConfig = btoa(JSON.stringify({mcpServers:{maina:{command:"maina",args:["--mcp"]}}}));
+  var cursorBadge = document.getElementById('cursor-badge');
+  if (cursorBadge) {
+    cursorBadge.href = 'cursor://anysphere.cursor-deeplink/mcp/install?name=maina&config=' + cursorConfig;
+  }
+
+  // Badge click handlers
+  document.querySelectorAll('.mcp-badge[data-action]').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var action = btn.getAttribute('data-action');
+      var text = '';
+      var msg = '';
+
+      if (action === 'claude') {
+        text = "claude mcp add-json maina '" + mcpConfig + "'";
+        msg = 'Claude Code command copied!';
+      } else if (action === 'windsurf') {
+        text = JSON.stringify({mcpServers:{maina:{command:"maina",args:["--mcp"]}}}, null, 2);
+        msg = 'Windsurf MCP config copied! Paste into ~/.codeium/windsurf/mcp_config.json';
+      }
+
+      if (text) {
+        navigator.clipboard.writeText(text).then(function() {
+          showToast(msg);
+        });
+      }
+    });
+  });
+
+  function showToast(msg) {
+    var toast = document.getElementById('mcp-toast');
+    if (!toast) return;
+    toast.textContent = msg;
+    toast.classList.add('visible');
+    setTimeout(function() { toast.classList.remove('visible'); }, 3000);
+  }
+})();
+</script>

--- a/packages/docs/src/styles/landing.css
+++ b/packages/docs/src/styles/landing.css
@@ -311,6 +311,75 @@ img {
   color: var(--green);
 }
 
+.mcp-badges {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.mcp-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: border-color 0.15s, color 0.15s;
+  font-family: inherit;
+  line-height: 1.4;
+}
+
+.mcp-badge:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.mcp-badge-icon {
+  font-size: 0.85rem;
+}
+
+.mcp-toast {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(100%);
+  padding: 0.6rem 1.2rem;
+  background: var(--accent);
+  color: #fff;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  opacity: 0;
+  transition: transform 0.3s, opacity 0.3s;
+  pointer-events: none;
+  z-index: 100;
+}
+
+.mcp-toast.visible {
+  transform: translateX(-50%) translateY(0);
+  opacity: 1;
+}
+
+@media (max-width: 375px) {
+  .mcp-badges {
+    flex-direction: column;
+    align-items: center;
+  }
+  .mcp-badge {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
 .metrics {
   display: grid;
   grid-template-columns: repeat(4, 1fr);


### PR DESCRIPTION
## Summary

Three one-click MCP install badges on the hero, below the curl command:

- **Add to Claude Code** — copies `claude mcp add-json maina '{"command":"maina","args":["--mcp"]}'` to clipboard
- **Add to Cursor** — deeplink `cursor://anysphere.cursor-deeplink/mcp/install?name=maina&config=<base64>`
- **Add to Windsurf** — copies MCP config JSON to clipboard with toast notification

Responsive: stacks vertically on mobile (<=375px). No layout shift. Toast notification on clipboard actions.

**Maina workflow:** plan → design → spec → implement → verify → slop → commit

Closes #98

## Test plan

- [x] `bun run build` passes
- [x] `maina verify` passes
- [x] `maina slop` clean
- [ ] CI passes
- [ ] CodeRabbit review
- [ ] Manual: test each badge on clean machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)