### PR TITLE
docs: add 4 cookbook pages

### DIFF
--- a/.maina/features/038-cookbook-pages/plan.md
+++ b/.maina/features/038-cookbook-pages/plan.md
@@ -1,0 +1,60 @@
+# Implementation Plan
+
+> HOW only — see spec.md for WHAT and WHY.
+
+## Architecture
+
+What is the technical approach? How does it fit into existing architecture?
+Where are the integration points with existing code?
+
+- Pattern: [NEEDS CLARIFICATION]
+- Integration points: [NEEDS CLARIFICATION]
+
+## Key Technical Decisions
+
+What libraries, patterns, or approaches? WHY these and not alternatives?
+
+- [NEEDS CLARIFICATION]
+
+## Files
+
+| File | Purpose | New/Modified |
+|------|---------|-------------|
+| [NEEDS CLARIFICATION] | | |
+
+## Tasks
+
+TDD: every implementation task must have a preceding test task.
+
+- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
+
+## Failure Modes
+
+What can go wrong? How do we handle it gracefully?
+
+- [NEEDS CLARIFICATION]
+
+## Testing Strategy
+
+Unit tests, integration tests, or both? What mocks are needed?
+
+- [NEEDS CLARIFICATION]
+
+
+## Wiki Context
+
+### Related Decisions
+
+- 0007-visual-verification-with-playwright: Visual verification with Playwright [proposed]
+
+### Similar Features
+
+- 031-landing-light-mode: Feature 031: Landing Page Full Light Mode
+- 027-v10-launch: Implementation Plan
+- 026-v07-rl-flywheel: Implementation Plan
+
+### Suggestions
+
+- Feature 031-landing-light-mode did something similar — check wiki/features/031-landing-light-mode.md
+- Feature 027-v10-launch did something similar — check wiki/features/027-v10-launch.md
+- Feature 026-v07-rl-flywheel did something similar — check wiki/features/026-v07-rl-flywheel.md

--- a/.maina/features/038-cookbook-pages/spec.md
+++ b/.maina/features/038-cookbook-pages/spec.md
@@ -1,0 +1,45 @@
+# Feature: [Name]
+
+## Problem Statement
+
+What specific problem does this solve? Who experiences it? What happens if we don't solve it?
+
+- [NEEDS CLARIFICATION] Define the problem clearly.
+
+## Target User
+
+Who benefits? What is their current workflow? What frustrates them about it?
+
+- Primary: [NEEDS CLARIFICATION]
+- Secondary: [NEEDS CLARIFICATION]
+
+## User Stories
+
+- As a [role], I want [capability] so that [benefit].
+
+## Success Criteria
+
+How do we know this works? Every criterion must be testable — if you can't write
+an assertion for it, the requirement isn't clear enough.
+
+- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+
+## Scope
+
+### In Scope
+
+- [NEEDS CLARIFICATION] What this feature does.
+
+### Out of Scope
+
+- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
+
+## Design Decisions
+
+Key choices made and WHY. Record tradeoffs — future you will thank you.
+
+- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
+
+## Open Questions
+
+- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.

--- a/.maina/features/038-cookbook-pages/spec.md
+++ b/.maina/features/038-cookbook-pages/spec.md
@@ -1,45 +1,21 @@
-# Feature: [Name]
+# Feature: Cookbook pages
 
 ## Problem Statement
 
-What specific problem does this solve? Who experiences it? What happens if we don't solve it?
-
-- [NEEDS CLARIFICATION] Define the problem clearly.
-
-## Target User
-
-Who benefits? What is their current workflow? What frustrates them about it?
-
-- Primary: [NEEDS CLARIFICATION]
-- Secondary: [NEEDS CLARIFICATION]
-
-## User Stories
-
-- As a [role], I want [capability] so that [benefit].
+Users need practical how-to guides showing Maina in real workflows. Currently docs explain features but don't show end-to-end recipes.
 
 ## Success Criteria
 
-How do we know this works? Every criterion must be testable — if you can't write
-an assertion for it, the requirement isn't clear enough.
-
-- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+- [ ] 4 cookbook pages: CI verification, Claude Code self-check, CodeRabbit integration, constitution as required check
+- [ ] Each has runnable example commands
+- [ ] Navigable via docs sidebar "Cookbooks"
 
 ## Scope
 
 ### In Scope
-
-- [NEEDS CLARIFICATION] What this feature does.
+- 4 cookbook MDX pages in docs
+- Sidebar section
 
 ### Out of Scope
-
-- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
-
-## Design Decisions
-
-Key choices made and WHY. Record tradeoffs — future you will thank you.
-
-- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
-
-## Open Questions
-
-- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.
+- Example repos (future)
+- Video tutorials

--- a/.maina/features/038-cookbook-pages/tasks.md
+++ b/.maina/features/038-cookbook-pages/tasks.md
@@ -1,0 +1,23 @@
+# Task Breakdown
+
+## Tasks
+
+Each task should be completable in one commit. Test tasks precede implementation tasks.
+
+- [ ] [NEEDS CLARIFICATION] Define tasks.
+
+## Dependencies
+
+Which tasks block which? Draw the critical path.
+
+- [NEEDS CLARIFICATION]
+
+## Definition of Done
+
+How do we know this feature is complete?
+
+- [ ] All tests pass
+- [ ] Biome lint clean
+- [ ] TypeScript compiles
+- [ ] maina analyze shows no errors
+- [ ] [NEEDS CLARIFICATION] Feature-specific criteria

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -52,6 +52,15 @@ export default defineConfig({
           ],
         },
         {
+          label: 'Cookbooks',
+          items: [
+            { slug: 'cookbooks/verify-pr-in-ci' },
+            { slug: 'cookbooks/claude-code-self-check' },
+            { slug: 'cookbooks/coderabbit-integration' },
+            { slug: 'cookbooks/constitution-required-check' },
+          ],
+        },
+        {
           label: 'Roadmap',
           items: [
             { slug: 'roadmap' },

--- a/packages/docs/src/content/docs/cookbooks/claude-code-self-check.mdx
+++ b/packages/docs/src/content/docs/cookbooks/claude-code-self-check.mdx
@@ -1,0 +1,42 @@
+---
+title: Claude Code self-check before committing
+description: Let Claude Code verify its own changes using Maina MCP tools before committing.
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+
+Claude Code can use Maina's MCP tools to verify its own work before committing.
+
+<Steps>
+
+1. **Ensure MCP is configured**
+
+   `maina init` creates `.claude/settings.json` automatically. Or add manually:
+
+   ```json title=".claude/settings.json"
+   {
+     "mcpServers": {
+       "maina": { "command": "maina", "args": ["--mcp"] }
+     }
+   }
+   ```
+
+2. **Add instructions to CLAUDE.md**
+
+   ```markdown title="CLAUDE.md"
+   Before committing, always:
+   1. Call `verify` to run the full verification pipeline
+   2. Call `checkSlop` on changed files
+   3. Call `reviewCode` with your diff
+   4. Fix any findings before committing
+   ```
+
+3. **Use `maina commit` instead of `git commit`**
+
+   Tell Claude Code to use `maina commit` — it runs verification automatically and only commits if everything passes.
+
+</Steps>
+
+<Aside>
+The MCP tools (`verify`, `checkSlop`, `reviewCode`) give Claude Code the same verification pipeline humans get, with zero extra setup.
+</Aside>

--- a/packages/docs/src/content/docs/cookbooks/coderabbit-integration.mdx
+++ b/packages/docs/src/content/docs/cookbooks/coderabbit-integration.mdx
@@ -1,0 +1,43 @@
+---
+title: Integrate Maina with CodeRabbit
+description: Run Maina verification alongside CodeRabbit reviews for comprehensive PR quality.
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+
+Maina and CodeRabbit complement each other — Maina handles deterministic verification (linting, security, slop detection) while CodeRabbit handles AI-powered code review.
+
+<Steps>
+
+1. **Set up Maina CI**
+
+   Add the Maina verification workflow (see [Verify a PR in CI](/cookbooks/verify-pr-in-ci)).
+
+2. **Configure CodeRabbit**
+
+   CodeRabbit runs automatically on PRs via GitHub App. No extra config needed — it coexists with Maina.
+
+3. **How they work together**
+
+   On every PR:
+   - **Maina** runs 25+ deterministic tools (Biome, Semgrep, Trivy, slop detection, etc.) and posts inline findings
+   - **CodeRabbit** runs AI-powered review and posts its own inline comments
+   - Both appear as separate review threads — no conflict
+
+4. **Feed Maina results into CodeRabbit context**
+
+   Add to your `.coderabbitai.yaml`:
+
+   ```yaml title=".coderabbitai.yaml"
+   reviews:
+     instructions: |
+       This repo uses Maina for verification. Check .maina/constitution.md
+       for project conventions. Maina handles linting and security — focus
+       your review on architecture, logic, and design decisions.
+   ```
+
+</Steps>
+
+<Aside type="tip">
+Maina is deterministic (same code = same findings). CodeRabbit is AI-powered (nuanced review). Together they cover both the "is it correct?" and "is it good?" dimensions.
+</Aside>

--- a/packages/docs/src/content/docs/cookbooks/constitution-required-check.mdx
+++ b/packages/docs/src/content/docs/cookbooks/constitution-required-check.mdx
@@ -1,0 +1,54 @@
+---
+title: Enforce constitution.md as a required check
+description: Use Maina's verification pipeline as a required GitHub status check to enforce your project's constitution.
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+
+Make Maina verification a required check — PRs can't merge until the constitution is satisfied.
+
+<Steps>
+
+1. **Set up Maina CI**
+
+   Add the verification workflow (see [Verify a PR in CI](/cookbooks/verify-pr-in-ci)).
+
+2. **Define your constitution**
+
+   ```markdown title=".maina/constitution.md"
+   # Project Constitution
+
+   ## Stack
+   - Runtime: Bun
+   - Language: TypeScript strict mode
+   - Lint/Format: Biome
+
+   ## Verification
+   - Lint: `bun run check`
+   - Typecheck: `bun run typecheck`
+   - Test: `bun test`
+   - Diff-only: only report findings on changed lines
+
+   ## Conventions
+   - Conventional commits enforced
+   - No console.log in production code
+   - TDD: write tests first
+   ```
+
+3. **Make it a required check**
+
+   In GitHub repo settings:
+   - Go to **Settings → Branches → Branch protection rules**
+   - Add rule for `main` / `master`
+   - Under **Require status checks**, add `Maina CI` (or your workflow name)
+   - Enable **Require branches to be up to date**
+
+4. **Result**
+
+   PRs that violate the constitution (lint failures, missing tests, slop patterns, security findings) can't merge until fixed.
+
+</Steps>
+
+<Aside>
+The constitution is injected into every AI call too — so Claude Code, Cursor, and other MCP clients will respect the same rules when generating code.
+</Aside>

--- a/packages/docs/src/content/docs/cookbooks/verify-pr-in-ci.mdx
+++ b/packages/docs/src/content/docs/cookbooks/verify-pr-in-ci.mdx
@@ -1,0 +1,51 @@
+---
+title: Verify a PR in CI
+description: Run maina verification on every pull request with GitHub Actions.
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+
+Run the full verification pipeline on every PR automatically.
+
+<Steps>
+
+1. **Add the workflow**
+
+   ```yaml title=".github/workflows/maina-ci.yml"
+   name: Maina CI
+   on: [pull_request]
+   jobs:
+     verify:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v4
+         - uses: oven-sh/setup-bun@v2
+         - run: bun install
+         - run: bun add -d @mainahq/cli
+         - run: bunx maina verify
+   ```
+
+2. **Or use the cloud action**
+
+   ```yaml title=".github/workflows/maina-cloud.yml"
+   name: Maina Cloud
+   on: [pull_request]
+   jobs:
+     verify:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v4
+         - uses: mainahq/verify-action@v1
+           with:
+             token: ${{ secrets.MAINA_TOKEN }}
+   ```
+
+3. **Review results**
+
+   Findings appear as inline PR review comments. Cloud runs also get a verification permalink.
+
+</Steps>
+
+<Aside type="tip">
+The local option installs all tools on the runner. The cloud option runs the pipeline server-side — no tool installs needed.
+</Aside>


### PR DESCRIPTION
## Summary

4 new cookbook pages under `/cookbooks/`:

1. **Verify a PR in CI** — local and cloud GitHub Actions workflows
2. **Claude Code self-check** — MCP tools + CLAUDE.md instructions for self-verification
3. **Integrate with CodeRabbit** — how Maina and CodeRabbit complement each other
4. **Enforce constitution as required check** — branch protection with Maina CI

New "Cookbooks" sidebar section in the docs.

**Maina workflow:** plan → spec → implement → verify → slop → commit

Closes #110

## Test plan

- [x] `bun run build` passes
- [x] `maina verify` passes
- [x] `maina slop` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)