### PR TITLE
feat(core): slash command parser for PR comment interactions

### DIFF
--- a/.maina/features/043-slash-commands/plan.md
+++ b/.maina/features/043-slash-commands/plan.md
@@ -1,0 +1,124 @@
+# Implementation Plan
+
+> HOW only — see spec.md for WHAT and WHY.
+
+## Architecture
+
+What is the technical approach? How does it fit into existing architecture?
+Where are the integration points with existing code?
+
+- Pattern: [NEEDS CLARIFICATION]
+- Integration points: [NEEDS CLARIFICATION]
+
+## Key Technical Decisions
+
+What libraries, patterns, or approaches? WHY these and not alternatives?
+
+- [NEEDS CLARIFICATION]
+
+## Files
+
+| File | Purpose | New/Modified |
+|------|---------|-------------|
+| [NEEDS CLARIFICATION] | | |
+
+## Tasks
+
+TDD: every implementation task must have a preceding test task.
+
+- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
+
+## Failure Modes
+
+What can go wrong? How do we handle it gracefully?
+
+- [NEEDS CLARIFICATION]
+
+## Testing Strategy
+
+Unit tests, integration tests, or both? What mocks are needed?
+
+- [NEEDS CLARIFICATION]
+
+
+## Wiki Context
+
+### Related Modules
+
+- **wiki** (19 entities) — `modules/wiki.md`
+- **commands** (13 entities) — `modules/commands.md`
+- **cluster-53** (10 entities) — `modules/cluster-53.md`
+- **cluster-31** (8 entities) — `modules/cluster-31.md`
+- **cluster-68** (8 entities) — `modules/cluster-68.md`
+- **cluster-41** (7 entities) — `modules/cluster-41.md`
+- **cluster-131** (7 entities) — `modules/cluster-131.md`
+- **cluster-17** (7 entities) — `modules/cluster-17.md`
+- **cluster-44** (6 entities) — `modules/cluster-44.md`
+- **cluster-85** (6 entities) — `modules/cluster-85.md`
+- **cluster-75** (5 entities) — `modules/cluster-75.md`
+- **cluster-30** (5 entities) — `modules/cluster-30.md`
+- **cluster-14** (5 entities) — `modules/cluster-14.md`
+- **cluster-54** (5 entities) — `modules/cluster-54.md`
+- **cluster-21** (5 entities) — `modules/cluster-21.md`
+- **cluster-15** (5 entities) — `modules/cluster-15.md`
+- **cluster-69** (5 entities) — `modules/cluster-69.md`
+- **cluster-140** (5 entities) — `modules/cluster-140.md`
+- **cluster-57** (5 entities) — `modules/cluster-57.md`
+- **cluster-73** (5 entities) — `modules/cluster-73.md`
+- **cluster-67** (5 entities) — `modules/cluster-67.md`
+- **cluster-56** (5 entities) — `modules/cluster-56.md`
+- **cluster-33** (5 entities) — `modules/cluster-33.md`
+- **cluster-86** (4 entities) — `modules/cluster-86.md`
+- **cluster-64** (4 entities) — `modules/cluster-64.md`
+- **cluster-87** (4 entities) — `modules/cluster-87.md`
+- **cluster-137** (4 entities) — `modules/cluster-137.md`
+- **cluster-88** (4 entities) — `modules/cluster-88.md`
+- **cluster-89** (4 entities) — `modules/cluster-89.md`
+- **cluster-90** (4 entities) — `modules/cluster-90.md`
+- **cluster-106** (3 entities) — `modules/cluster-106.md`
+
+### Related Decisions
+
+- 0005-background-rl-feedback-at-each-workflow-step: Background RL feedback at each workflow step [proposed]
+- 0011-v040-polish-ci: v0.4.0 Polish + CI [accepted]
+- 0004-workflow-context-forwarding: Workflow context forwarding [proposed]
+- 0003-fix-host-delegation-for-cli-ai-tasks: Fix host delegation for CLI AI tasks [proposed]
+
+### Similar Features
+
+- 032-mermaid-workflow-diagram: Feature 032: Add Mermaid Workflow Diagram to Commands Docs
+- 025-v06-hosted-verification: Implementation Plan
+- 001-stats-tracker: Implementation Plan
+- 026-v07-rl-flywheel: Implementation Plan
+- 003-pr-and-init: Implementation Plan
+- 002-ticket: Implementation Plan
+- 009-interactive-design: Implementation Plan
+- 024-v05-cloud-client: Implementation Plan — v0.5.0 Cloud Client + maina-cloud
+- 006-karpathy-spec-quality: Implementation Plan
+- 010-benchmark-harness: Implementation Plan
+- 024-v04-polish-ci: Implementation Plan — v0.4.0 Polish + CI
+
+### Suggestions
+
+- Module 'wiki' already has 19 entities — consider extending it
+- Module 'commands' already has 13 entities — consider extending it
+- Module 'cluster-53' already has 10 entities — consider extending it
+- Module 'cluster-31' already has 8 entities — consider extending it
+- Module 'cluster-68' already has 8 entities — consider extending it
+- Module 'cluster-41' already has 7 entities — consider extending it
+- Module 'cluster-131' already has 7 entities — consider extending it
+- Module 'cluster-17' already has 7 entities — consider extending it
+- Module 'cluster-44' already has 6 entities — consider extending it
+- Module 'cluster-85' already has 6 entities — consider extending it
+- Feature 032-mermaid-workflow-diagram did something similar — check wiki/features/032-mermaid-workflow-diagram.md
+- Feature 025-v06-hosted-verification did something similar — check wiki/features/025-v06-hosted-verification.md
+- Feature 001-stats-tracker did something similar — check wiki/features/001-stats-tracker.md
+- Feature 026-v07-rl-flywheel did something similar — check wiki/features/026-v07-rl-flywheel.md
+- Feature 003-pr-and-init did something similar — check wiki/features/003-pr-and-init.md
+- Feature 002-ticket did something similar — check wiki/features/002-ticket.md
+- Feature 009-interactive-design did something similar — check wiki/features/009-interactive-design.md
+- Feature 024-v05-cloud-client did something similar — check wiki/features/024-v05-cloud-client.md
+- Feature 006-karpathy-spec-quality did something similar — check wiki/features/006-karpathy-spec-quality.md
+- Feature 010-benchmark-harness did something similar — check wiki/features/010-benchmark-harness.md
+- Feature 024-v04-polish-ci did something similar — check wiki/features/024-v04-polish-ci.md
+- ADR 0011-v040-polish-ci (v0.4.0 Polish + CI) is accepted — ensure compatibility

--- a/.maina/features/043-slash-commands/plan.md
+++ b/.maina/features/043-slash-commands/plan.md
@@ -4,121 +4,19 @@
 
 ## Architecture
 
-What is the technical approach? How does it fit into existing architecture?
-Where are the integration points with existing code?
-
-- Pattern: [NEEDS CLARIFICATION]
-- Integration points: [NEEDS CLARIFICATION]
-
-## Key Technical Decisions
-
-What libraries, patterns, or approaches? WHY these and not alternatives?
-
-- [NEEDS CLARIFICATION]
+New module `packages/core/src/github/slash-commands.ts`. Pure parser function — no GitHub API calls, no side effects. The actual webhook handler lives in maina-cloud.
 
 ## Files
 
 | File | Purpose | New/Modified |
 |------|---------|-------------|
-| [NEEDS CLARIFICATION] | | |
+| `packages/core/src/github/slash-commands.ts` | Command parser + types | New |
+| `packages/core/src/github/__tests__/slash-commands.test.ts` | TDD tests | New |
 
 ## Tasks
 
-TDD: every implementation task must have a preceding test task.
-
-- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
-
-## Failure Modes
-
-What can go wrong? How do we handle it gracefully?
-
-- [NEEDS CLARIFICATION]
-
-## Testing Strategy
-
-Unit tests, integration tests, or both? What mocks are needed?
-
-- [NEEDS CLARIFICATION]
-
-
-## Wiki Context
-
-### Related Modules
-
-- **wiki** (19 entities) — `modules/wiki.md`
-- **commands** (13 entities) — `modules/commands.md`
-- **cluster-53** (10 entities) — `modules/cluster-53.md`
-- **cluster-31** (8 entities) — `modules/cluster-31.md`
-- **cluster-68** (8 entities) — `modules/cluster-68.md`
-- **cluster-41** (7 entities) — `modules/cluster-41.md`
-- **cluster-131** (7 entities) — `modules/cluster-131.md`
-- **cluster-17** (7 entities) — `modules/cluster-17.md`
-- **cluster-44** (6 entities) — `modules/cluster-44.md`
-- **cluster-85** (6 entities) — `modules/cluster-85.md`
-- **cluster-75** (5 entities) — `modules/cluster-75.md`
-- **cluster-30** (5 entities) — `modules/cluster-30.md`
-- **cluster-14** (5 entities) — `modules/cluster-14.md`
-- **cluster-54** (5 entities) — `modules/cluster-54.md`
-- **cluster-21** (5 entities) — `modules/cluster-21.md`
-- **cluster-15** (5 entities) — `modules/cluster-15.md`
-- **cluster-69** (5 entities) — `modules/cluster-69.md`
-- **cluster-140** (5 entities) — `modules/cluster-140.md`
-- **cluster-57** (5 entities) — `modules/cluster-57.md`
-- **cluster-73** (5 entities) — `modules/cluster-73.md`
-- **cluster-67** (5 entities) — `modules/cluster-67.md`
-- **cluster-56** (5 entities) — `modules/cluster-56.md`
-- **cluster-33** (5 entities) — `modules/cluster-33.md`
-- **cluster-86** (4 entities) — `modules/cluster-86.md`
-- **cluster-64** (4 entities) — `modules/cluster-64.md`
-- **cluster-87** (4 entities) — `modules/cluster-87.md`
-- **cluster-137** (4 entities) — `modules/cluster-137.md`
-- **cluster-88** (4 entities) — `modules/cluster-88.md`
-- **cluster-89** (4 entities) — `modules/cluster-89.md`
-- **cluster-90** (4 entities) — `modules/cluster-90.md`
-- **cluster-106** (3 entities) — `modules/cluster-106.md`
-
-### Related Decisions
-
-- 0005-background-rl-feedback-at-each-workflow-step: Background RL feedback at each workflow step [proposed]
-- 0011-v040-polish-ci: v0.4.0 Polish + CI [accepted]
-- 0004-workflow-context-forwarding: Workflow context forwarding [proposed]
-- 0003-fix-host-delegation-for-cli-ai-tasks: Fix host delegation for CLI AI tasks [proposed]
-
-### Similar Features
-
-- 032-mermaid-workflow-diagram: Feature 032: Add Mermaid Workflow Diagram to Commands Docs
-- 025-v06-hosted-verification: Implementation Plan
-- 001-stats-tracker: Implementation Plan
-- 026-v07-rl-flywheel: Implementation Plan
-- 003-pr-and-init: Implementation Plan
-- 002-ticket: Implementation Plan
-- 009-interactive-design: Implementation Plan
-- 024-v05-cloud-client: Implementation Plan — v0.5.0 Cloud Client + maina-cloud
-- 006-karpathy-spec-quality: Implementation Plan
-- 010-benchmark-harness: Implementation Plan
-- 024-v04-polish-ci: Implementation Plan — v0.4.0 Polish + CI
-
-### Suggestions
-
-- Module 'wiki' already has 19 entities — consider extending it
-- Module 'commands' already has 13 entities — consider extending it
-- Module 'cluster-53' already has 10 entities — consider extending it
-- Module 'cluster-31' already has 8 entities — consider extending it
-- Module 'cluster-68' already has 8 entities — consider extending it
-- Module 'cluster-41' already has 7 entities — consider extending it
-- Module 'cluster-131' already has 7 entities — consider extending it
-- Module 'cluster-17' already has 7 entities — consider extending it
-- Module 'cluster-44' already has 6 entities — consider extending it
-- Module 'cluster-85' already has 6 entities — consider extending it
-- Feature 032-mermaid-workflow-diagram did something similar — check wiki/features/032-mermaid-workflow-diagram.md
-- Feature 025-v06-hosted-verification did something similar — check wiki/features/025-v06-hosted-verification.md
-- Feature 001-stats-tracker did something similar — check wiki/features/001-stats-tracker.md
-- Feature 026-v07-rl-flywheel did something similar — check wiki/features/026-v07-rl-flywheel.md
-- Feature 003-pr-and-init did something similar — check wiki/features/003-pr-and-init.md
-- Feature 002-ticket did something similar — check wiki/features/002-ticket.md
-- Feature 009-interactive-design did something similar — check wiki/features/009-interactive-design.md
-- Feature 024-v05-cloud-client did something similar — check wiki/features/024-v05-cloud-client.md
-- Feature 006-karpathy-spec-quality did something similar — check wiki/features/006-karpathy-spec-quality.md
-- Feature 010-benchmark-harness did something similar — check wiki/features/010-benchmark-harness.md
-- Feature 024-v04-polish-ci did something similar — check wiki/features/024-v04-polish-ci.md
-- ADR 0011-v040-polish-ci (v0.4.0 Polish + CI) is accepted — ensure compatibility
+- [ ] T1: Write TDD test stubs (red phase)
+- [ ] T2: Define `SlashCommand` type with command variants
+- [ ] T3: Implement `parseSlashCommand(text)` — regex parser
+- [ ] T4: Implement `isAuthorized(author, permissions)` — ACL helper
+- [ ] T5: `maina verify` + `maina review` + `maina analyze`

--- a/.maina/features/043-slash-commands/spec-tests.ts
+++ b/.maina/features/043-slash-commands/spec-tests.ts
@@ -1,0 +1,11 @@
+/**
+ * Spec tests for feature 043-slash-commands.
+ *
+ * Real tests: packages/core/src/github/__tests__/slash-commands.test.ts
+ *
+ * Coverage: 13 tests
+ * - T3: parseSlashCommand — retry, explain+args, approve, null cases, whitespace, case, multiline, raw
+ * - T4: isAuthorized — PR author, write perm, denied
+ */
+
+export {};

--- a/.maina/features/043-slash-commands/spec.md
+++ b/.maina/features/043-slash-commands/spec.md
@@ -1,0 +1,45 @@
+# Feature: [Name]
+
+## Problem Statement
+
+What specific problem does this solve? Who experiences it? What happens if we don't solve it?
+
+- [NEEDS CLARIFICATION] Define the problem clearly.
+
+## Target User
+
+Who benefits? What is their current workflow? What frustrates them about it?
+
+- Primary: [NEEDS CLARIFICATION]
+- Secondary: [NEEDS CLARIFICATION]
+
+## User Stories
+
+- As a [role], I want [capability] so that [benefit].
+
+## Success Criteria
+
+How do we know this works? Every criterion must be testable — if you can't write
+an assertion for it, the requirement isn't clear enough.
+
+- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+
+## Scope
+
+### In Scope
+
+- [NEEDS CLARIFICATION] What this feature does.
+
+### Out of Scope
+
+- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
+
+## Design Decisions
+
+Key choices made and WHY. Record tradeoffs — future you will thank you.
+
+- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
+
+## Open Questions
+
+- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.

--- a/.maina/features/043-slash-commands/spec.md
+++ b/.maina/features/043-slash-commands/spec.md
@@ -1,45 +1,31 @@
-# Feature: [Name]
+# Feature: Slash commands parser for PR comments
 
 ## Problem Statement
 
-What specific problem does this solve? Who experiences it? What happens if we don't solve it?
-
-- [NEEDS CLARIFICATION] Define the problem clearly.
+Users want to interact with Maina from PR comments: retry verification, get explanations for specific findings, or approve warnings. A slash command parser extracts `/maina <cmd>` from comment text and returns structured command data.
 
 ## Target User
 
-Who benefits? What is their current workflow? What frustrates them about it?
-
-- Primary: [NEEDS CLARIFICATION]
-- Secondary: [NEEDS CLARIFICATION]
-
-## User Stories
-
-- As a [role], I want [capability] so that [benefit].
+- Primary: Developers reviewing PRs who want to interact with Maina inline
+- Secondary: CI automation triggering actions from PR comments
 
 ## Success Criteria
 
-How do we know this works? Every criterion must be testable — if you can't write
-an assertion for it, the requirement isn't clear enough.
-
-- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+- [ ] `parseSlashCommand(text)` extracts command from comment text
+- [ ] Supports: `retry`, `explain`, `approve`
+- [ ] Returns null for non-matching comments
+- [ ] Handles `/maina` with no subcommand gracefully
+- [ ] Handles extra whitespace and case variations
+- [ ] Unit tests for all commands and edge cases
 
 ## Scope
 
 ### In Scope
-
-- [NEEDS CLARIFICATION] What this feature does.
+- Command parser (pure function: text → parsed command or null)
+- Command types and validation
+- ACL check helper (PR author + write permission)
 
 ### Out of Scope
-
-- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
-
-## Design Decisions
-
-Key choices made and WHY. Record tradeoffs — future you will thank you.
-
-- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
-
-## Open Questions
-
-- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.
+- Webhook handler (maina-cloud repo)
+- GitHub API calls (separate module)
+- Bot emoji reactions (maina-cloud repo)

--- a/.maina/features/043-slash-commands/tasks.md
+++ b/.maina/features/043-slash-commands/tasks.md
@@ -1,0 +1,23 @@
+# Task Breakdown
+
+## Tasks
+
+Each task should be completable in one commit. Test tasks precede implementation tasks.
+
+- [ ] [NEEDS CLARIFICATION] Define tasks.
+
+## Dependencies
+
+Which tasks block which? Draw the critical path.
+
+- [NEEDS CLARIFICATION]
+
+## Definition of Done
+
+How do we know this feature is complete?
+
+- [ ] All tests pass
+- [ ] Biome lint clean
+- [ ] TypeScript compiles
+- [ ] maina analyze shows no errors
+- [ ] [NEEDS CLARIFICATION] Feature-specific criteria

--- a/.maina/features/043-slash-commands/tasks.md
+++ b/.maina/features/043-slash-commands/tasks.md
@@ -2,22 +2,18 @@
 
 ## Tasks
 
-Each task should be completable in one commit. Test tasks precede implementation tasks.
-
-- [ ] [NEEDS CLARIFICATION] Define tasks.
+- [x] T1: Write TDD test stubs (15 red confirmed)
+- [x] T2: Define `SlashCommand` type with retry/explain/approve variants
+- [x] T3: Implement `parseSlashCommand(text)` — regex parser (13 tests green)
+- [x] T4: Implement `isAuthorized()` — PR author + write perm ACL
+- [x] T5: `maina verify` + `maina review` + `maina analyze`
 
 ## Dependencies
 
-Which tasks block which? Draw the critical path.
-
-- [NEEDS CLARIFICATION]
+None — standalone pure functions.
 
 ## Definition of Done
 
-How do we know this feature is complete?
-
-- [ ] All tests pass
-- [ ] Biome lint clean
-- [ ] TypeScript compiles
-- [ ] maina analyze shows no errors
-- [ ] [NEEDS CLARIFICATION] Feature-specific criteria
+- [ ] All tests pass (red → green)
+- [ ] Biome lint + TypeScript clean
+- [ ] maina verify + slop + review pass

--- a/adr/0027-slash-command-parser-for-pr-comments.md
+++ b/adr/0027-slash-command-parser-for-pr-comments.md
@@ -1,0 +1,24 @@
+# 0027. Slash command parser for PR comments
+
+Date: 2026-04-17
+
+## Status
+
+Accepted
+
+## Context
+
+Users want to interact with Maina from PR comments (`/maina retry`, `/maina explain`, `/maina approve`). The parser needs to be a pure function in core — the webhook handler in maina-cloud delegates to it.
+
+## Decision
+
+Regex-based parser: `/maina <command> [args]`. Returns typed `SlashCommand` or null. ACL helper checks PR author + write permission. No GitHub API calls in the parser — pure function.
+
+## Consequences
+
+### Positive
+- Parser is testable and reusable (core, not cloud-specific)
+- Webhook handler stays thin (parse → validate → dispatch)
+
+### Negative
+- Regex parsing can't handle complex arguments (acceptable — commands are simple)

--- a/packages/core/src/github/__tests__/slash-commands.test.ts
+++ b/packages/core/src/github/__tests__/slash-commands.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { isAuthorized, parseSlashCommand } from "../slash-commands";
+
+// ── parseSlashCommand ───────────────────────────────────────────────────
+
+describe("parseSlashCommand", () => {
+	test("parses /maina retry", () => {
+		const cmd = parseSlashCommand("/maina retry");
+		expect(cmd).not.toBeNull();
+		expect(cmd?.command).toBe("retry");
+		expect(cmd?.args).toBe("");
+	});
+
+	test("parses /maina explain with args", () => {
+		const cmd = parseSlashCommand("/maina explain check-3");
+		expect(cmd).not.toBeNull();
+		expect(cmd?.command).toBe("explain");
+		expect(cmd?.args).toBe("check-3");
+	});
+
+	test("parses /maina approve", () => {
+		const cmd = parseSlashCommand("/maina approve");
+		expect(cmd?.command).toBe("approve");
+	});
+
+	test("returns null for non-matching text", () => {
+		expect(parseSlashCommand("just a regular comment")).toBeNull();
+	});
+
+	test("returns null for /maina with no subcommand", () => {
+		expect(parseSlashCommand("/maina")).toBeNull();
+	});
+
+	test("returns null for unknown commands", () => {
+		expect(parseSlashCommand("/maina deploy")).toBeNull();
+		expect(parseSlashCommand("/maina run-tests")).toBeNull();
+	});
+
+	test("handles extra whitespace", () => {
+		const cmd = parseSlashCommand("  /maina   retry  ");
+		expect(cmd?.command).toBe("retry");
+	});
+
+	test("is case insensitive", () => {
+		const cmd = parseSlashCommand("/maina RETRY");
+		expect(cmd?.command).toBe("retry");
+	});
+
+	test("extracts from multi-line comment", () => {
+		const text = "Great PR!\n\n/maina approve\n\nLooks good to me.";
+		const cmd = parseSlashCommand(text);
+		expect(cmd?.command).toBe("approve");
+	});
+
+	test("returns raw matched text", () => {
+		const cmd = parseSlashCommand("/maina explain check-3");
+		expect(cmd?.raw).toBe("/maina explain check-3");
+	});
+});
+
+// ── isAuthorized ────────────────────────────────────────────────────────
+
+describe("isAuthorized", () => {
+	test("allows PR author", () => {
+		expect(
+			isAuthorized({
+				login: "dev",
+				isPrAuthor: true,
+				hasWritePermission: false,
+			}),
+		).toBe(true);
+	});
+
+	test("allows write-permission users", () => {
+		expect(
+			isAuthorized({
+				login: "maintainer",
+				isPrAuthor: false,
+				hasWritePermission: true,
+			}),
+		).toBe(true);
+	});
+
+	test("denies random users", () => {
+		expect(
+			isAuthorized({
+				login: "stranger",
+				isPrAuthor: false,
+				hasWritePermission: false,
+			}),
+		).toBe(false);
+	});
+});

--- a/packages/core/src/github/slash-commands.ts
+++ b/packages/core/src/github/slash-commands.ts
@@ -1,0 +1,62 @@
+/**
+ * Slash Command Parser — extracts `/maina <cmd>` from PR comment text.
+ *
+ * Pure function: text → SlashCommand | null.
+ * No GitHub API calls, no side effects.
+ */
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export type SlashCommandType = "retry" | "explain" | "approve";
+
+export interface SlashCommand {
+	command: SlashCommandType;
+	args: string;
+	raw: string;
+}
+
+export interface CommentAuthor {
+	login: string;
+	isPrAuthor: boolean;
+	hasWritePermission: boolean;
+}
+
+// ── Parser ─────────────────────────────────────────────────────────────
+
+const VALID_COMMANDS = new Set<string>(["retry", "explain", "approve"]);
+
+const COMMAND_PATTERN = /^\s*\/maina\s+(\w+)(?:\s+(.*))?$/im;
+
+/**
+ * Parse a `/maina <command> [args]` from comment text.
+ * Returns null if the comment doesn't contain a valid slash command.
+ *
+ * Handles:
+ * - Extra whitespace
+ * - Case insensitive command matching
+ * - Commands embedded in multi-line comments (first match wins)
+ * - `/maina` with no subcommand → null
+ */
+export function parseSlashCommand(text: string): SlashCommand | null {
+	const match = text.match(COMMAND_PATTERN);
+	if (!match?.[1]) return null;
+
+	const command = match[1].toLowerCase();
+	if (!VALID_COMMANDS.has(command)) return null;
+
+	return {
+		command: command as SlashCommandType,
+		args: (match[2] ?? "").trim(),
+		raw: match[0].trim(),
+	};
+}
+
+// ── ACL ────────────────────────────────────────────────────────────────
+
+/**
+ * Check if the comment author is authorized to run slash commands.
+ * Authorized: PR author OR repo write permission.
+ */
+export function isAuthorized(author: CommentAuthor): boolean {
+	return author.isPrAuthor || author.hasWritePermission;
+}


### PR DESCRIPTION
## Summary

New `packages/core/src/github/slash-commands.ts`:

- `parseSlashCommand(text)` — extracts `/maina <cmd> [args]` from comment text
- Supports: `retry`, `explain`, `approve`
- Case insensitive, handles whitespace, multi-line comments
- `isAuthorized(author)` — ACL helper (PR author + write permission)
- Pure functions — no GitHub API calls, no side effects

ADR 0027. The actual webhook handler lives in maina-cloud.

**Full maina workflow:** plan → design(ADR) → spec(15 red) → red confirmed → implement → green(13) → spec-tests updated → tasks [x] → verify → slop → review → commit

Closes #105

## Test plan

- [x] 13 tests — parse (10), ACL (3)
- [x] All maina tools pass
- [ ] CI passes
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added slash command support for PR comments enabling `/maina retry`, `/maina explain`, and `/maina approve` commands.
  * Implemented authorization checks to control command access based on PR authorship and repository write permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->