### PR TITLE
docs: Playwright MCP interop cookbook page

### DIFF
--- a/.maina/features/044-playwright-mcp-interop/plan.md
+++ b/.maina/features/044-playwright-mcp-interop/plan.md
@@ -1,0 +1,67 @@
+# Implementation Plan
+
+> HOW only — see spec.md for WHAT and WHY.
+
+## Architecture
+
+What is the technical approach? How does it fit into existing architecture?
+Where are the integration points with existing code?
+
+- Pattern: [NEEDS CLARIFICATION]
+- Integration points: [NEEDS CLARIFICATION]
+
+## Key Technical Decisions
+
+What libraries, patterns, or approaches? WHY these and not alternatives?
+
+- [NEEDS CLARIFICATION]
+
+## Files
+
+| File | Purpose | New/Modified |
+|------|---------|-------------|
+| [NEEDS CLARIFICATION] | | |
+
+## Tasks
+
+TDD: every implementation task must have a preceding test task.
+
+- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
+
+## Failure Modes
+
+What can go wrong? How do we handle it gracefully?
+
+- [NEEDS CLARIFICATION]
+
+## Testing Strategy
+
+Unit tests, integration tests, or both? What mocks are needed?
+
+- [NEEDS CLARIFICATION]
+
+
+## Wiki Context
+
+### Related Modules
+
+- **tools** (6 entities) — `modules/tools.md`
+- **cluster-135** (2 entities) — `modules/cluster-135.md`
+
+### Related Decisions
+
+- 0007-visual-verification-with-playwright: Visual verification with Playwright [proposed]
+- 0003-fix-host-delegation-for-cli-ai-tasks: Fix host delegation for CLI AI tasks [proposed]
+
+### Similar Features
+
+- 030-mcp-agent-files: Feature 030: Auto-Configure MCP + Agent Instruction Files During Init
+- 004-mcp-server: Implementation Plan
+- 009-interactive-design: Implementation Plan
+
+### Suggestions
+
+- Module 'tools' already has 6 entities — consider extending it
+- Feature 030-mcp-agent-files did something similar — check wiki/features/030-mcp-agent-files.md
+- Feature 004-mcp-server did something similar — check wiki/features/004-mcp-server.md
+- Feature 009-interactive-design did something similar — check wiki/features/009-interactive-design.md

--- a/.maina/features/044-playwright-mcp-interop/spec.md
+++ b/.maina/features/044-playwright-mcp-interop/spec.md
@@ -1,0 +1,45 @@
+# Feature: [Name]
+
+## Problem Statement
+
+What specific problem does this solve? Who experiences it? What happens if we don't solve it?
+
+- [NEEDS CLARIFICATION] Define the problem clearly.
+
+## Target User
+
+Who benefits? What is their current workflow? What frustrates them about it?
+
+- Primary: [NEEDS CLARIFICATION]
+- Secondary: [NEEDS CLARIFICATION]
+
+## User Stories
+
+- As a [role], I want [capability] so that [benefit].
+
+## Success Criteria
+
+How do we know this works? Every criterion must be testable — if you can't write
+an assertion for it, the requirement isn't clear enough.
+
+- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+
+## Scope
+
+### In Scope
+
+- [NEEDS CLARIFICATION] What this feature does.
+
+### Out of Scope
+
+- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
+
+## Design Decisions
+
+Key choices made and WHY. Record tradeoffs — future you will thank you.
+
+- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
+
+## Open Questions
+
+- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.

--- a/.maina/features/044-playwright-mcp-interop/spec.md
+++ b/.maina/features/044-playwright-mcp-interop/spec.md
@@ -1,45 +1,20 @@
-# Feature: [Name]
+# Feature: Ship Maina as a Playwright MCP interop partner
 
 ## Problem Statement
 
-What specific problem does this solve? Who experiences it? What happens if we don't solve it?
-
-- [NEEDS CLARIFICATION] Define the problem clearly.
-
-## Target User
-
-Who benefits? What is their current workflow? What frustrates them about it?
-
-- Primary: [NEEDS CLARIFICATION]
-- Secondary: [NEEDS CLARIFICATION]
-
-## User Stories
-
-- As a [role], I want [capability] so that [benefit].
+Playwright MCP (`@playwright/mcp`, Microsoft, Apache-2.0) is gaining traction. Maina's verify engine can consume Playwright results. Publishing "Maina works with Playwright MCP" gives free distribution via Microsoft's MCP directory.
 
 ## Success Criteria
 
-How do we know this works? Every criterion must be testable — if you can't write
-an assertion for it, the requirement isn't clear enough.
-
-- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+- [ ] Docs page: "Using Maina with Playwright MCP" in cookbooks
+- [ ] Example flow: Claude Code agent → Playwright MCP → Maina verify → report
 
 ## Scope
 
 ### In Scope
-
-- [NEEDS CLARIFICATION] What this feature does.
+- Cookbook docs page showing the interop flow
+- Example MCP config combining both servers
 
 ### Out of Scope
-
-- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
-
-## Design Decisions
-
-Key choices made and WHY. Record tradeoffs — future you will thank you.
-
-- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
-
-## Open Questions
-
-- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.
+- Direct Playwright MCP SDK dependency (they're independent MCP servers)
+- MCP registry submission (future marketing task)

--- a/.maina/features/044-playwright-mcp-interop/tasks.md
+++ b/.maina/features/044-playwright-mcp-interop/tasks.md
@@ -1,0 +1,23 @@
+# Task Breakdown
+
+## Tasks
+
+Each task should be completable in one commit. Test tasks precede implementation tasks.
+
+- [ ] [NEEDS CLARIFICATION] Define tasks.
+
+## Dependencies
+
+Which tasks block which? Draw the critical path.
+
+- [NEEDS CLARIFICATION]
+
+## Definition of Done
+
+How do we know this feature is complete?
+
+- [ ] All tests pass
+- [ ] Biome lint clean
+- [ ] TypeScript compiles
+- [ ] maina analyze shows no errors
+- [ ] [NEEDS CLARIFICATION] Feature-specific criteria

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -58,6 +58,7 @@ export default defineConfig({
             { slug: 'cookbooks/claude-code-self-check' },
             { slug: 'cookbooks/coderabbit-integration' },
             { slug: 'cookbooks/constitution-required-check' },
+            { slug: 'cookbooks/playwright-mcp' },
           ],
         },
         {

--- a/packages/docs/src/content/docs/cookbooks/playwright-mcp.mdx
+++ b/packages/docs/src/content/docs/cookbooks/playwright-mcp.mdx
@@ -1,0 +1,74 @@
+---
+title: Using Maina with Playwright MCP
+description: Combine Maina verification with Playwright MCP for AI-driven browser testing.
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+
+Maina and [Playwright MCP](https://github.com/microsoft/playwright-mcp) (`@playwright/mcp`, Microsoft, Apache-2.0) work together: Playwright drives the browser, Maina verifies the results.
+
+## Setup
+
+<Steps>
+
+1. **Configure both MCP servers**
+
+   ```json title=".mcp.json"
+   {
+     "mcpServers": {
+       "maina": {
+         "command": "maina",
+         "args": ["--mcp"]
+       },
+       "playwright": {
+         "command": "npx",
+         "args": ["@playwright/mcp@latest"]
+       }
+     }
+   }
+   ```
+
+2. **Tell your agent how to use them together**
+
+   Add to your `CLAUDE.md` or agent instructions:
+
+   ```markdown
+   ## Testing workflow
+   1. Use Playwright MCP to navigate and interact with the app
+   2. Use Maina `verify` to run the full verification pipeline
+   3. Use Maina `reviewCode` to review any changes
+   4. Capture screenshots with Playwright for visual regression
+   ```
+
+3. **Example flow**
+
+   The agent can now:
+   - Navigate to `localhost:3000` via Playwright MCP
+   - Fill forms, click buttons, verify page content
+   - Call Maina `verify` to check code quality
+   - Call Maina `checkSlop` on changed files
+   - Call Maina `reviewCode` with the diff
+
+</Steps>
+
+## How it works
+
+Playwright MCP and Maina MCP are independent servers that share the same host agent context:
+
+```
+Claude Code / Cursor / Windsurf
+  ├── Playwright MCP  → browser automation, screenshots, DOM inspection
+  └── Maina MCP       → verification, code review, slop detection, wiki
+```
+
+The agent orchestrates both: use Playwright for browser interactions, use Maina for code verification. They don't talk to each other directly — the agent is the glue.
+
+<Aside type="tip">
+This pattern works with any MCP-compatible host: Claude Code, Cursor, Windsurf, Copilot, Cline, and more.
+</Aside>
+
+## When to use this
+
+- **E2E testing**: Agent writes code, tests it with Playwright, verifies with Maina
+- **Visual regression**: Playwright captures screenshots, Maina verifies the code that generated them
+- **Feature development**: Build → test in browser → verify code quality → commit


### PR DESCRIPTION
## Summary

New cookbook page: "Using Maina with Playwright MCP"

- Shows how to configure both MCP servers side-by-side in `.mcp.json`
- Example agent workflow: Playwright for browser → Maina for verification
- Architecture diagram showing independent MCP servers with shared host
- Added to Cookbooks sidebar

**Maina workflow:** plan → implement → verify → slop → commit

Closes #107

## Test plan

- [x] `bun run build` passes
- [x] `maina verify` + `maina slop` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)