### PR TITLE
fix(docs): cursor deeplink config + bunx for zero pre-install

### DIFF
--- a/packages/docs/src/components/Hero.astro
+++ b/packages/docs/src/components/Hero.astro
@@ -32,10 +32,12 @@ const base = rawBase.endsWith('/') ? rawBase.slice(0, -1) : rawBase;
 
 <script is:inline>
 (function() {
-  var mcpConfig = JSON.stringify({"command":"bunx","args":["@mainahq/cli","--mcp"]});
+  var serverConfig = {command:"bunx",args:["@mainahq/cli","--mcp"]};
+  var mcpConfig = JSON.stringify(serverConfig);
 
-  // Cursor deeplink: base64-encode just the server config (name param identifies the server)
-  var cursorConfig = btoa(JSON.stringify({command:"bunx",args:["@mainahq/cli","--mcp"]}));
+  // Cursor deeplink: base64-encode just the server config (name param identifies the server).
+  // Percent-encode the base64 because +, /, = are reserved in query strings.
+  var cursorConfig = encodeURIComponent(btoa(mcpConfig));
   var cursorBadge = document.getElementById('cursor-badge');
   if (cursorBadge) {
     cursorBadge.href = 'cursor://anysphere.cursor-deeplink/mcp/install?name=maina&config=' + cursorConfig;
@@ -52,7 +54,7 @@ const base = rawBase.endsWith('/') ? rawBase.slice(0, -1) : rawBase;
         text = "claude mcp add-json maina '" + mcpConfig + "'";
         msg = 'Claude Code command copied!';
       } else if (action === 'windsurf') {
-        text = JSON.stringify({mcpServers:{maina:{command:"bunx",args:["@mainahq/cli","--mcp"]}}}, null, 2);
+        text = JSON.stringify({mcpServers:{maina:serverConfig}}, null, 2);
         msg = 'Windsurf MCP config copied! Paste into ~/.codeium/windsurf/mcp_config.json';
       }
 

--- a/packages/docs/src/components/Hero.astro
+++ b/packages/docs/src/components/Hero.astro
@@ -32,10 +32,10 @@ const base = rawBase.endsWith('/') ? rawBase.slice(0, -1) : rawBase;
 
 <script is:inline>
 (function() {
-  var mcpConfig = JSON.stringify({"command":"maina","args":["--mcp"]});
+  var mcpConfig = JSON.stringify({"command":"bunx","args":["@mainahq/cli","--mcp"]});
 
-  // Cursor deeplink: base64-encode the MCP config
-  var cursorConfig = btoa(JSON.stringify({mcpServers:{maina:{command:"maina",args:["--mcp"]}}}));
+  // Cursor deeplink: base64-encode just the server config (name param identifies the server)
+  var cursorConfig = btoa(JSON.stringify({command:"bunx",args:["@mainahq/cli","--mcp"]}));
   var cursorBadge = document.getElementById('cursor-badge');
   if (cursorBadge) {
     cursorBadge.href = 'cursor://anysphere.cursor-deeplink/mcp/install?name=maina&config=' + cursorConfig;
@@ -52,7 +52,7 @@ const base = rawBase.endsWith('/') ? rawBase.slice(0, -1) : rawBase;
         text = "claude mcp add-json maina '" + mcpConfig + "'";
         msg = 'Claude Code command copied!';
       } else if (action === 'windsurf') {
-        text = JSON.stringify({mcpServers:{maina:{command:"maina",args:["--mcp"]}}}, null, 2);
+        text = JSON.stringify({mcpServers:{maina:{command:"bunx",args:["@mainahq/cli","--mcp"]}}}, null, 2);
         msg = 'Windsurf MCP config copied! Paste into ~/.codeium/windsurf/mcp_config.json';
       }
 


### PR DESCRIPTION
## Summary
- Cursor MCP deeplink was base64-encoding the full `{mcpServers:{maina:{...}}}` wrapper; Cursor expects just the inner server config (the `name` query param already identifies the server). Malformed config is why the V2 FSM failed to connect after the install prompt.
- Switched the command across all three badges (Claude Code, Cursor, Windsurf) from bare `maina` to `bunx @mainahq/cli --mcp` so users don't need to `curl | bash` or `npm i -g` first — any machine with Bun can one-click install.

## Test plan
- [ ] Build docs locally, click "Add to Cursor" badge, confirm Cursor shows the install prompt with `bunx @mainahq/cli --mcp` and connects without the `connect_failure` error
- [ ] "Add to Claude Code" copies `claude mcp add-json maina '{"command":"bunx","args":["@mainahq/cli","--mcp"]}'`
- [ ] "Add to Windsurf" copies the `mcpServers` JSON with the `bunx` command
- [ ] GitHub Pages deploy workflow publishes the change to mainahq.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  - Updated MCP configuration generation and editor integration behaviors: Cursor deeplinks now use safer encoding for query strings, and Windsurf/Claude copy actions paste the revised MCP config format for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->