### PR TITLE
fix(core): ticket warns and skips missing labels instead of aborting (#170)

### DIFF
--- a/.changeset/fix-ticket-labels.md
+++ b/.changeset/fix-ticket-labels.md
@@ -1,0 +1,8 @@
+---
+"@mainahq/core": patch
+"@mainahq/cli": patch
+---
+
+fix(core): `maina ticket` warns and skips missing labels instead of aborting (#170)
+
+Previously, inferred labels that didn't exist on the target repo would abort `gh issue create` one at a time, forcing users into whack-a-mole. `createTicket` now pre-fetches the repo's labels via `gh label list`, drops any that don't exist, and files the issue with the remainder. Skipped labels are surfaced via `skippedLabels` on the result and the CLI prints a `log.warning`. Pass `--strict-labels` to restore the old abort-on-missing behavior.

--- a/packages/cli/src/commands/__tests__/ticket.test.ts
+++ b/packages/cli/src/commands/__tests__/ticket.test.ts
@@ -232,6 +232,55 @@ describe("ticketAction", () => {
 		expect(result.reason).toBe("Authentication required");
 	});
 
+	test("plumbs strictLabels through to createTicket", async () => {
+		let capturedStrict: boolean | undefined;
+		const mockDeps: TicketDepsType = {
+			createTicket: async (options) => {
+				capturedStrict = options.strictLabels;
+				return {
+					ok: true,
+					value: { url: "https://github.com/owner/repo/issues/30", number: 30 },
+				};
+			},
+			detectModules: () => [],
+		};
+
+		await ticketAction(
+			{
+				title: "T",
+				body: "B",
+				label: ["bug"],
+				strictLabels: true,
+				cwd: tmpDir,
+			},
+			mockDeps,
+		);
+
+		expect(capturedStrict).toBe(true);
+	});
+
+	test("returns skippedLabels on the action result", async () => {
+		const mockDeps: TicketDepsType = {
+			createTicket: async () => ({
+				ok: true,
+				value: {
+					url: "https://github.com/owner/repo/issues/31",
+					number: 31,
+					skippedLabels: ["templates", "commands"],
+				},
+			}),
+			detectModules: () => ["templates", "commands"],
+		};
+
+		const result = await ticketAction(
+			{ title: "T", body: "B", cwd: tmpDir },
+			mockDeps,
+		);
+
+		expect(result.created).toBe(true);
+		expect(result.skippedLabels).toEqual(["templates", "commands"]);
+	});
+
 	test("works with no labels at all", async () => {
 		let capturedLabels: string[] | undefined;
 

--- a/packages/cli/src/commands/ticket.ts
+++ b/packages/cli/src/commands/ticket.ts
@@ -12,6 +12,7 @@ export interface TicketActionOptions {
 	title?: string;
 	body?: string;
 	label?: string[];
+	strictLabels?: boolean;
 	cwd?: string;
 	repo?: string; // Cross-repo: "owner/name" or alias from constitution
 }
@@ -20,6 +21,7 @@ export interface TicketActionResult {
 	created: boolean;
 	reason?: string;
 	url?: string;
+	skippedLabels?: string[];
 }
 
 export interface TicketDeps {
@@ -120,6 +122,7 @@ export async function ticketAction(
 		title,
 		body,
 		labels: allLabels.length > 0 ? allLabels : undefined,
+		strictLabels: options.strictLabels,
 		cwd,
 		repo,
 	});
@@ -136,7 +139,19 @@ export async function ticketAction(
 		log.info(`Auto-tagged modules: ${autoModules.join(", ")}`);
 	}
 
-	return { created: true, url: result.value.url };
+	const skipped = result.value.skippedLabels;
+	if (skipped && skipped.length > 0) {
+		log.warning(
+			`Skipped labels that don't exist on the repo: ${skipped.join(", ")}. ` +
+				`Create them with \`gh label create\` or pass --strict-labels to abort on missing.`,
+		);
+	}
+
+	return {
+		created: true,
+		url: result.value.url,
+		...(skipped && skipped.length > 0 ? { skippedLabels: skipped } : {}),
+	};
 }
 
 // ── Commander Command ────────────────────────────────────────────────────────
@@ -151,6 +166,10 @@ export function ticketCommand(): Command {
 			"-r, --repo <repo>",
 			"Target repo (alias: maina-cloud, workkit, or owner/name)",
 		)
+		.option(
+			"--strict-labels",
+			"Abort if any label doesn't exist on the repo (default: warn and skip)",
+		)
 		.action(async (options) => {
 			intro("maina ticket");
 
@@ -158,6 +177,7 @@ export function ticketCommand(): Command {
 				title: options.title,
 				body: options.body,
 				label: options.label,
+				strictLabels: options.strictLabels,
 				repo: options.repo,
 			});
 

--- a/packages/core/src/ticket/__tests__/ticket.test.ts
+++ b/packages/core/src/ticket/__tests__/ticket.test.ts
@@ -270,4 +270,183 @@ describe("createTicket", () => {
 
 		expect(capturedOpts?.cwd).toBe("/some/path");
 	});
+
+	// ── Skip-and-warn label behavior (issue #170) ────────────────────────────
+	//
+	// Default: pre-fetch available labels via `gh label list`; drop labels that
+	// don't exist on the repo (returned as `skippedLabels`); the issue is still
+	// filed with the subset that does exist.
+	//
+	// With `strictLabels: true`: skip the pre-fetch, pass all labels through
+	// to `gh issue create` (preserves the old abort-on-missing behavior).
+
+	test("skips labels that do not exist on repo and returns them in skippedLabels", async () => {
+		let createArgs: string[] = [];
+		const mockSpawn = async (args: string[]) => {
+			if (args[1] === "label" && args[2] === "list") {
+				return {
+					exitCode: 0,
+					stdout: JSON.stringify([{ name: "bug" }, { name: "context" }]),
+					stderr: "",
+				};
+			}
+			createArgs = args;
+			return {
+				exitCode: 0,
+				stdout: "https://github.com/owner/repo/issues/7\n",
+				stderr: "",
+			};
+		};
+
+		const result = await createTicket(
+			{
+				title: "t",
+				body: "b",
+				labels: ["bug", "templates", "commands", "context"],
+			},
+			{ spawn: mockSpawn },
+		);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.skippedLabels).toEqual(["templates", "commands"]);
+
+		const labelIdx = createArgs.indexOf("--label");
+		expect(labelIdx).toBeGreaterThan(-1);
+		expect(createArgs[labelIdx + 1]).toBe("bug,context");
+	});
+
+	test("omits --label entirely when every requested label is missing", async () => {
+		let createArgs: string[] = [];
+		const mockSpawn = async (args: string[]) => {
+			if (args[1] === "label" && args[2] === "list") {
+				return { exitCode: 0, stdout: "[]", stderr: "" };
+			}
+			createArgs = args;
+			return {
+				exitCode: 0,
+				stdout: "https://github.com/owner/repo/issues/8\n",
+				stderr: "",
+			};
+		};
+
+		const result = await createTicket(
+			{ title: "t", body: "b", labels: ["templates", "commands"] },
+			{ spawn: mockSpawn },
+		);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.skippedLabels).toEqual(["templates", "commands"]);
+		expect(createArgs).not.toContain("--label");
+	});
+
+	test("strictLabels=true skips pre-fetch and passes labels through as-is", async () => {
+		let labelListCalled = false;
+		let createArgs: string[] = [];
+		const mockSpawn = async (args: string[]) => {
+			if (args[1] === "label" && args[2] === "list") {
+				labelListCalled = true;
+				return { exitCode: 0, stdout: "[]", stderr: "" };
+			}
+			createArgs = args;
+			return {
+				exitCode: 1,
+				stdout: "",
+				stderr: "could not add label: 'templates' not found",
+			};
+		};
+
+		const result = await createTicket(
+			{
+				title: "t",
+				body: "b",
+				labels: ["templates"],
+				strictLabels: true,
+			},
+			{ spawn: mockSpawn },
+		);
+
+		expect(labelListCalled).toBe(false);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error).toContain("templates");
+		expect(createArgs).toContain("--label");
+	});
+
+	test("falls back to passing labels through when label list fails", async () => {
+		let createArgs: string[] = [];
+		const mockSpawn = async (args: string[]) => {
+			if (args[1] === "label" && args[2] === "list") {
+				return {
+					exitCode: 1,
+					stdout: "",
+					stderr: "gh: not authenticated",
+				};
+			}
+			createArgs = args;
+			return {
+				exitCode: 0,
+				stdout: "https://github.com/owner/repo/issues/9\n",
+				stderr: "",
+			};
+		};
+
+		const result = await createTicket(
+			{ title: "t", body: "b", labels: ["bug"] },
+			{ spawn: mockSpawn },
+		);
+
+		expect(result.ok).toBe(true);
+		const labelIdx = createArgs.indexOf("--label");
+		expect(labelIdx).toBeGreaterThan(-1);
+		expect(createArgs[labelIdx + 1]).toBe("bug");
+	});
+
+	test("forwards --repo to label list when set", async () => {
+		let labelListArgs: string[] = [];
+		const mockSpawn = async (args: string[]) => {
+			if (args[1] === "label" && args[2] === "list") {
+				labelListArgs = args;
+				return { exitCode: 0, stdout: "[]", stderr: "" };
+			}
+			return {
+				exitCode: 0,
+				stdout: "https://github.com/owner/repo/issues/1\n",
+				stderr: "",
+			};
+		};
+
+		await createTicket(
+			{
+				title: "t",
+				body: "b",
+				labels: ["bug"],
+				repo: "beeeku/workkit",
+			},
+			{ spawn: mockSpawn },
+		);
+
+		expect(labelListArgs).toContain("--repo");
+		expect(labelListArgs).toContain("beeeku/workkit");
+	});
+
+	test("skips label pre-fetch when no labels are requested", async () => {
+		let labelListCalled = false;
+		const mockSpawn = async (args: string[]) => {
+			if (args[1] === "label" && args[2] === "list") {
+				labelListCalled = true;
+				return { exitCode: 0, stdout: "[]", stderr: "" };
+			}
+			return {
+				exitCode: 0,
+				stdout: "https://github.com/owner/repo/issues/1\n",
+				stderr: "",
+			};
+		};
+
+		await createTicket({ title: "t", body: "b" }, { spawn: mockSpawn });
+
+		expect(labelListCalled).toBe(false);
+	});
 });

--- a/packages/core/src/ticket/index.ts
+++ b/packages/core/src/ticket/index.ts
@@ -15,6 +15,13 @@ export interface TicketOptions {
 	title: string;
 	body: string;
 	labels?: string[];
+	/**
+	 * When true, pass all labels to `gh issue create` unchanged (the old
+	 * abort-on-missing behavior). When false/undefined (default), pre-fetch
+	 * the repo's labels and silently drop any that don't exist, returning
+	 * them as `skippedLabels` so the caller can warn. See issue #170.
+	 */
+	strictLabels?: boolean;
 	cwd?: string;
 	repo?: string; // Cross-repo: "owner/name" for gh --repo flag
 }
@@ -22,6 +29,8 @@ export interface TicketOptions {
 export interface TicketResult {
 	url: string;
 	number: number;
+	/** Requested labels that don't exist on the repo (skip-and-warn mode). */
+	skippedLabels?: string[];
 }
 
 /** Dependency injection for spawn, enabling testability. */
@@ -134,6 +143,29 @@ export function buildIssueBody(body: string, modules: string[]): string {
 // ── createTicket ────────────────────────────────────────────────────────────
 
 /**
+ * Fetch the set of label names that exist on the target repo.
+ * Returns null if the listing call fails — callers fall back to passing
+ * labels through unchanged and letting `gh issue create` surface the error.
+ */
+async function listAvailableLabels(
+	opts: { cwd?: string; repo?: string },
+	deps: SpawnDeps,
+): Promise<Set<string> | null> {
+	try {
+		const args = ["gh", "label", "list", "--json", "name", "--limit", "200"];
+		if (opts.repo) args.push("--repo", opts.repo);
+
+		const { exitCode, stdout } = await deps.spawn(args, { cwd: opts.cwd });
+		if (exitCode !== 0) return null;
+
+		const parsed = JSON.parse(stdout) as Array<{ name: string }>;
+		return new Set(parsed.map((l) => l.name));
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Create a GitHub Issue via `gh issue create`.
  * Returns the issue URL and number on success, or an error on failure.
  * Never throws — all errors are returned as Result Err values.
@@ -143,6 +175,24 @@ export async function createTicket(
 	deps: SpawnDeps = defaultDeps,
 ): Promise<Result<TicketResult>> {
 	try {
+		let effectiveLabels = options.labels ?? [];
+		const skippedLabels: string[] = [];
+
+		if (effectiveLabels.length > 0 && !options.strictLabels) {
+			const available = await listAvailableLabels(
+				{ cwd: options.cwd, repo: options.repo },
+				deps,
+			);
+			if (available) {
+				const known: string[] = [];
+				for (const label of effectiveLabels) {
+					if (available.has(label)) known.push(label);
+					else skippedLabels.push(label);
+				}
+				effectiveLabels = known;
+			}
+		}
+
 		const args = [
 			"gh",
 			"issue",
@@ -153,8 +203,8 @@ export async function createTicket(
 			options.body,
 		];
 
-		if (options.labels && options.labels.length > 0) {
-			args.push("--label", options.labels.join(","));
+		if (effectiveLabels.length > 0) {
+			args.push("--label", effectiveLabels.join(","));
 		}
 
 		if (options.repo) {
@@ -179,7 +229,11 @@ export async function createTicket(
 
 		return {
 			ok: true,
-			value: { url, number: issueNumber },
+			value: {
+				url,
+				number: issueNumber,
+				...(skippedLabels.length > 0 ? { skippedLabels } : {}),
+			},
 		};
 	} catch (e) {
 		return {

--- a/packages/core/src/ticket/index.ts
+++ b/packages/core/src/ticket/index.ts
@@ -152,7 +152,9 @@ async function listAvailableLabels(
 	deps: SpawnDeps,
 ): Promise<Set<string> | null> {
 	try {
-		const args = ["gh", "label", "list", "--json", "name", "--limit", "200"];
+		// --limit caps the total fetched (gh auto-paginates underneath at 100/call).
+		// 1000 covers the long tail of repos — anything higher is ~pathological.
+		const args = ["gh", "label", "list", "--json", "name", "--limit", "1000"];
 		if (opts.repo) args.push("--repo", opts.repo);
 
 		const { exitCode, stdout } = await deps.spawn(args, { cwd: opts.cwd });


### PR DESCRIPTION
## Summary

Closes #170.

`maina ticket` used to abort on the first inferred label that didn't exist on the target repo, forcing users into whack-a-mole: fix one missing label, re-run, hit the next one, repeat. On long technical issue bodies (exactly where module-tagging adds the most value), users gave up and fell back to `gh issue create`.

Now `createTicket` pre-fetches the repo's labels via `gh label list`, drops any requested label that doesn't exist, and **still files the issue** with the subset that does exist. Skipped labels are surfaced to the caller (`skippedLabels`) and the CLI prints a `log.warning` so the user sees which labels got dropped.

Users who want the old strict behavior can pass `--strict-labels` — this skips the pre-fetch entirely and passes labels through to `gh issue create` unchanged (so the familiar abort-on-missing error is preserved for CI and scripts).

## Changes

- `packages/core/src/ticket/index.ts`: new `listAvailableLabels` helper, new `strictLabels` option on `TicketOptions`, new `skippedLabels` field on `TicketResult`. If the label-list call fails (auth, no network), falls back to passing labels through unchanged so behavior matches the old code.
- `packages/cli/src/commands/ticket.ts`: `--strict-labels` flag; `log.warning` when labels were skipped, including a hint to use `gh label create` or `--strict-labels`.
- 7 new tests across core + cli covering: skip-and-warn happy path, all-missing (omits `--label`), strict passthrough, list-failure fallback, `--repo` forwarding to label list, no-labels short-circuit, strictLabels plumbing, skippedLabels returned to caller.

## Test plan

- [x] `bun test packages/core/src/ticket packages/cli/src/commands/__tests__/ticket.test.ts` — 28/28 green
- [x] `bun run check` — clean
- [x] `bun run typecheck` — clean
- [x] `maina commit` verification — passed (12 tools)
- [ ] Manual: `maina ticket -t "..." -b "body with modules like templates commands"` on a repo with limited labels → issue files cleanly with a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --strict-labels option for ticket creation to control label validation
  * Ticket creation now validates requested labels against the repository and skips any that don't exist
  * Creation results and logs include which labels were skipped so you can see missing labels during the process
<!-- end of auto-generated comment: release notes by coderabbit.ai -->