### PR TITLE
chore: point strategy docs to private repo + ignore filenames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,11 @@ packages/docs/.astro/
 # Superpowers brainstorm sessions
 .superpowers/
 .claude/
+
+# Private strategy docs — kept in mainahq/maina-cloud:strategy/ (see CLAUDE.md).
+# Listed here so accidentally reviving these filenames won't leak them again.
+PRODUCT_SPEC.md
+IMPLEMENTATION_PLAN.md
+MAINA_WIKI_*.md
+maina-pitchdeck.pptx
+*.pptx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Maina — verification-first developer OS. CLI + MCP server + skills package that proves AI-generated code is correct before it merges. Three engines: Context (observes), Prompt (learns), Verify (verifies).
 
-Read PRODUCT_SPEC.md for full product context. Read IMPLEMENTATION_PLAN.md for sprint-by-sprint execution plan.
+Product spec and implementation plan live in the private `mainahq/maina-cloud` repo under `strategy/` (moved out on 2026-04-18 to keep roadmap private).
 
 ## Stack
 


### PR DESCRIPTION
Follow-up to the strategy-doc migration + history scrub.

## Context

PRODUCT_SPEC.md, IMPLEMENTATION_PLAN.md, MAINA_WIKI_*.md, and maina-pitchdeck.pptx were moved to the private `mainahq/maina-cloud:strategy/` repo and scrubbed from this repo's history via `git filter-repo` + force-push.

## Changes

- **CLAUDE.md**: points to the new private location instead of the deleted local files.
- **.gitignore**: blocks those exact filenames so accidentally re-adding them here won't leak them again.

## Caveats

- History scrub was done on `mainahq/maina` only. Anyone with an old clone should re-clone.
- GitHub may cache old commit SHAs via direct URL for ~90 days; if the files contained anything truly sensitive (secrets), rotate them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude private documentation and strategy files.

* **Documentation**
  * Updated internal documentation references regarding strategy file locations.

*Note: This release contains only internal updates with no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->