### PR TITLE
feat(cli): maina mcp add/remove/list across 8 AI clients

### DIFF
--- a/.changeset/mcp-add-remove.md
+++ b/.changeset/mcp-add-remove.md
@@ -1,0 +1,20 @@
+---
+"@mainahq/cli": minor
+"@mainahq/core": minor
+---
+
+feat(cli): `maina mcp add/remove/list` across 8 AI clients
+
+Adds three new top-level commands inspired by `npx @posthog/wizard mcp add`:
+
+- `maina mcp add` — install the maina MCP server in every detected client's global config
+- `maina mcp remove` — strip the maina entry from every client
+- `maina mcp list` — show install status per client
+
+Supported clients: **Claude Code, Cursor, Windsurf, Cline, OpenAI Codex CLI, Continue.dev, Gemini CLI, Zed**. Each client's config — JSON for seven of them, TOML for Codex — is parsed, mutated only at the maina entry, and atomically rewritten so all other MCP servers and unrelated config keys are preserved.
+
+Flags (all subcommands): `--client <list>` (comma-separated; default: auto-detect), `--scope global|project|both` (default: `global`), `--dry-run`, `--json`.
+
+This is the cross-project counterpart to the setup wizard's per-project install — `maina setup` continues to write `.mcp.json` and `.claude/settings.json` for the current repo, while `maina mcp add` reaches every project at once.
+
+The Continue.dev integration uses the legacy `~/.continue/config.json#experimental.modelContextProtocolServers` shape; the newer per-server YAML files at `~/.continue/.continue/mcpServers/*.yaml` will land when YAML support is added (tracked as a follow-up).

--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "packages/cli": {
       "name": "@mainahq/cli",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "bin": {
         "maina": "dist/index.js",
       },
@@ -35,9 +35,10 @@
     },
     "packages/core": {
       "name": "@mainahq/core",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@ai-sdk/openai": "^3.0.50",
+        "@iarna/toml": "^2.2.5",
         "@orama/orama": "^3.1.18",
         "ai": "^6.0.145",
         "drizzle-orm": "^0.45.2",
@@ -63,7 +64,7 @@
     },
     "packages/mcp": {
       "name": "@mainahq/mcp",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@mainahq/core": "^1.1.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -72,7 +73,7 @@
     },
     "packages/skills": {
       "name": "@mainahq/skills",
-      "version": "1.1.2",
+      "version": "1.3.0",
     },
   },
   "packages": {
@@ -311,6 +312,8 @@
     "@expressive-code/plugin-text-markers": ["@expressive-code/plugin-text-markers@0.41.7", "", { "dependencies": { "@expressive-code/core": "^0.41.7" } }, "sha512-Ewpwuc5t6eFdZmWlFyeuy3e1PTQC0jFvw2Q+2bpcWXbOZhPLsT7+h8lsSIJxb5mS7wZko7cKyQ2RLYDyK6Fpmw=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
+
+    "@iarna/toml": ["@iarna/toml@2.2.5", "", {}, "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 

--- a/packages/cli/src/commands/__tests__/mcp.test.ts
+++ b/packages/cli/src/commands/__tests__/mcp.test.ts
@@ -168,4 +168,31 @@ describe("mcpAction list", () => {
 		const scopes = r.list?.entries.map((e) => e.scope).sort();
 		expect(scopes).toEqual(["global", "project"]);
 	});
+
+	test("scope=project skips clients that have no project config (no misleading global fallback)", async () => {
+		// Windsurf has no projectConfigPath. Asking for project-scope only
+		// should yield zero rows for it instead of silently reporting the
+		// global path under `scope: "project"`.
+		const r = await mcpAction({
+			command: "list",
+			home: HOME,
+			scope: "project",
+			client: "windsurf",
+			cwd: HOME,
+		});
+		expect(r.list?.entries).toHaveLength(0);
+	});
+
+	test("scope=both still includes global for clients without project support", async () => {
+		const r = await mcpAction({
+			command: "list",
+			home: HOME,
+			scope: "both",
+			client: "windsurf",
+			cwd: HOME,
+		});
+		// Only the global row — the project row is skipped.
+		expect(r.list?.entries).toHaveLength(1);
+		expect(r.list?.entries[0]?.scope).toBe("global");
+	});
 });

--- a/packages/cli/src/commands/__tests__/mcp.test.ts
+++ b/packages/cli/src/commands/__tests__/mcp.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for the `maina mcp` action layer.
+ *
+ * The Commander wrapper isn't tested here (it's just option-plumbing); the
+ * heavy lifting is in core's apply.test.ts. These tests assert the CLI's
+ * own contract: option parsing, error surfacing, and the JSON shape.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mcpAction, parseClientList, parseScope } from "../mcp";
+
+let HOME: string;
+
+beforeEach(() => {
+	HOME = join(
+		tmpdir(),
+		`maina-cli-mcp-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	mkdirSync(HOME, { recursive: true });
+	// Pretend Cursor is installed so auto-detection picks it up.
+	mkdirSync(join(HOME, ".cursor"), { recursive: true });
+});
+
+afterEach(() => {
+	rmSync(HOME, { recursive: true, force: true });
+});
+
+// ── parseClientList ────────────────────────────────────────────────────────
+
+describe("parseClientList", () => {
+	test("returns undefined when no value passed (auto-detect)", () => {
+		expect(parseClientList(undefined)).toBeUndefined();
+		expect(parseClientList("")).toBeUndefined();
+	});
+
+	test("splits on commas, trims, lowercases", () => {
+		expect(parseClientList("Claude, Cursor, Windsurf")).toEqual([
+			"claude",
+			"cursor",
+			"windsurf",
+		]);
+	});
+
+	test("throws on unknown client with helpful list", () => {
+		expect(() => parseClientList("claude,nope")).toThrow(
+			/Unknown client: nope/,
+		);
+	});
+
+	test("returns undefined for empty list after trimming", () => {
+		expect(parseClientList(", ,")).toBeUndefined();
+	});
+});
+
+describe("parseScope", () => {
+	test("defaults to global when undefined", () => {
+		expect(parseScope(undefined)).toBe("global");
+	});
+	test("accepts global / project / both case-insensitive", () => {
+		expect(parseScope("GLOBAL")).toBe("global");
+		expect(parseScope("project")).toBe("project");
+		expect(parseScope("Both")).toBe("both");
+	});
+	test("throws on unknown scope", () => {
+		expect(() => parseScope("user")).toThrow(/Unknown scope/);
+	});
+});
+
+// ── mcpAction (end-to-end against tmp HOME) ────────────────────────────────
+
+describe("mcpAction add", () => {
+	test("auto-detects Cursor in tmp HOME and writes its global config", async () => {
+		const r = await mcpAction({ command: "add", home: HOME });
+		const cursor = r.report?.results.find((x) => x.clientId === "cursor");
+		expect(cursor?.action).toBe("created");
+		expect(cursor?.scope).toBe("global");
+	});
+
+	test("--client claude installs only claude even though it isn't detected", async () => {
+		const r = await mcpAction({
+			command: "add",
+			home: HOME,
+			client: "claude",
+		});
+		expect(r.report?.results).toHaveLength(1);
+		expect(r.report?.results[0]?.clientId).toBe("claude");
+		expect(r.report?.results[0]?.action).toBe("created");
+	});
+
+	test("dry-run skips disk writes", async () => {
+		const r = await mcpAction({
+			command: "add",
+			home: HOME,
+			dryRun: true,
+			client: "cursor",
+		});
+		expect(r.report?.results[0]?.dryRun).toBe(true);
+		expect(r.report?.results[0]?.action).toBe("created");
+	});
+
+	test("invalid --client value surfaces an error", async () => {
+		const r = await mcpAction({
+			command: "add",
+			home: HOME,
+			client: "made-up",
+		});
+		expect(r.error).toBeDefined();
+		expect(r.error).toMatch(/Unknown client/);
+	});
+
+	test("invalid --scope value surfaces an error", async () => {
+		const r = await mcpAction({ command: "add", home: HOME, scope: "user" });
+		expect(r.error).toBeDefined();
+		expect(r.error).toMatch(/Unknown scope/);
+	});
+});
+
+describe("mcpAction remove", () => {
+	test("removes a previously added entry", async () => {
+		await mcpAction({ command: "add", home: HOME, client: "cursor" });
+		const r = await mcpAction({
+			command: "remove",
+			home: HOME,
+			client: "cursor",
+		});
+		expect(r.report?.results[0]?.action).toBe("removed");
+	});
+
+	test("'absent' when nothing to remove", async () => {
+		const r = await mcpAction({
+			command: "remove",
+			home: HOME,
+			client: "claude",
+		});
+		expect(r.report?.results[0]?.action).toBe("absent");
+	});
+});
+
+describe("mcpAction list", () => {
+	test("reports installed=false for fresh HOME, true after add", async () => {
+		const before = await mcpAction({
+			command: "list",
+			home: HOME,
+			client: "cursor",
+		});
+		expect(before.list?.entries[0]?.installed).toBe(false);
+		await mcpAction({ command: "add", home: HOME, client: "cursor" });
+		const after = await mcpAction({
+			command: "list",
+			home: HOME,
+			client: "cursor",
+		});
+		expect(after.list?.entries[0]?.installed).toBe(true);
+	});
+
+	test("scope=both lists global and project rows for each client", async () => {
+		const r = await mcpAction({
+			command: "list",
+			home: HOME,
+			scope: "both",
+			client: "cursor",
+			cwd: HOME,
+		});
+		expect(r.list?.entries).toHaveLength(2);
+		const scopes = r.list?.entries.map((e) => e.scope).sort();
+		expect(scopes).toEqual(["global", "project"]);
+	});
+});

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,0 +1,269 @@
+/**
+ * `maina mcp` — install / remove / list the maina MCP server across
+ * supported AI clients.
+ *
+ * Three subcommands:
+ *   maina mcp add        — write the maina entry into each detected client's
+ *                          global config (or specified --client list)
+ *   maina mcp remove     — strip the maina entry from those configs
+ *   maina mcp list       — show install status per client
+ *
+ * Inspired by `npx @posthog/wizard mcp add`. The setup wizard handles the
+ * project-scope (`.mcp.json`, `.claude/settings.json`); this command is
+ * the cross-project (user-global) counterpart.
+ */
+
+import { intro, log, outro } from "@clack/prompts";
+import {
+	type ListEntry,
+	listClientIds,
+	type McpClientId,
+	type McpScope,
+	type RunOptions,
+	type RunReport,
+	runAdd,
+	runList,
+	runRemove,
+} from "@mainahq/core";
+import { Command } from "commander";
+import { EXIT_PASSED, outputJson } from "../json";
+
+// ── Option parsing ─────────────────────────────────────────────────────────
+
+const VALID_CLIENTS = new Set<McpClientId>(listClientIds());
+
+export function parseClientList(
+	raw: string | undefined,
+): McpClientId[] | undefined {
+	if (!raw) return undefined;
+	const parts = raw
+		.split(",")
+		.map((s) => s.trim().toLowerCase())
+		.filter((s) => s.length > 0);
+	const validated: McpClientId[] = [];
+	for (const p of parts) {
+		if (!VALID_CLIENTS.has(p as McpClientId)) {
+			throw new Error(
+				`Unknown client: ${p}. Valid clients: ${listClientIds().join(", ")}`,
+			);
+		}
+		validated.push(p as McpClientId);
+	}
+	return validated.length > 0 ? validated : undefined;
+}
+
+export function parseScope(raw: string | undefined): McpScope {
+	if (raw === undefined) return "global";
+	const v = raw.toLowerCase();
+	if (v === "global" || v === "project" || v === "both") return v;
+	throw new Error(`Unknown scope: ${raw}. Use one of: global, project, both`);
+}
+
+// ── Pretty printing ────────────────────────────────────────────────────────
+
+function actionEmoji(action: string): string {
+	switch (action) {
+		case "created":
+		case "updated":
+		case "removed":
+			return "+";
+		case "unchanged":
+			return "·";
+		case "absent":
+			return "—";
+		default:
+			return "?";
+	}
+}
+
+function emitAddReport(report: RunReport): void {
+	for (const r of report.results) {
+		const prefix = actionEmoji(r.action);
+		const dry = r.dryRun ? " [dry-run]" : "";
+		const err = r.error ? ` (error: ${r.error})` : "";
+		log.message(
+			`  ${prefix} ${r.clientId.padEnd(10)} ${r.scope.padEnd(7)}  ${r.action.padEnd(9)}  ${r.configPath}${dry}${err}`,
+		);
+	}
+	for (const id of report.skipped) {
+		log.message(
+			`  · ${id.padEnd(10)} (not detected — pass --client ${id} to install anyway)`,
+		);
+	}
+}
+
+function emitListReport(entries: ListEntry[]): void {
+	log.message("  STATUS    CLIENT      SCOPE    PATH");
+	for (const e of entries) {
+		const installed = e.installed
+			? "✓ installed"
+			: e.detected
+				? "  not yet  "
+				: "  no client";
+		log.message(
+			`  ${installed}  ${e.clientId.padEnd(10)} ${e.scope.padEnd(7)} ${e.configPath}${e.error ? ` (${e.error})` : ""}`,
+		);
+	}
+}
+
+// ── Action interface (testable) ────────────────────────────────────────────
+
+export interface McpActionOptions {
+	command: "add" | "remove" | "list";
+	client?: string;
+	scope?: string;
+	dryRun?: boolean;
+	yes?: boolean;
+	json?: boolean;
+	cwd?: string;
+	home?: string;
+}
+
+export interface McpActionResult {
+	command: "add" | "remove" | "list";
+	report?: RunReport;
+	list?: { entries: ListEntry[] };
+	error?: string;
+}
+
+export async function mcpAction(
+	options: McpActionOptions,
+): Promise<McpActionResult> {
+	const cwd = options.cwd ?? process.cwd();
+
+	let clients: McpClientId[] | undefined;
+	let scope: McpScope;
+	try {
+		clients = parseClientList(options.client);
+		scope = parseScope(options.scope);
+	} catch (e) {
+		return {
+			command: options.command,
+			error: e instanceof Error ? e.message : String(e),
+		};
+	}
+
+	const runOpts: RunOptions = {
+		scope,
+		dryRun: options.dryRun === true,
+		cwd,
+		...(clients ? { clients } : {}),
+		...(options.home ? { home: options.home } : {}),
+	};
+
+	if (options.command === "add") {
+		return { command: "add", report: await runAdd(runOpts) };
+	}
+	if (options.command === "remove") {
+		return { command: "remove", report: await runRemove(runOpts) };
+	}
+	return { command: "list", list: await runList(runOpts) };
+}
+
+// ── Commander wiring ───────────────────────────────────────────────────────
+
+function buildCommonOptions(c: Command): Command {
+	return c
+		.option(
+			"--client <list>",
+			"Comma-separated client IDs (default: auto-detect all)",
+		)
+		.option("--scope <s>", "global | project | both (default: global)")
+		.option("--dry-run", "Print what would change without writing")
+		.option("--json", "Machine-readable JSON output")
+		.option("-y, --yes", "Skip confirmations (no-op today; reserved)");
+}
+
+export function mcpCommand(): Command {
+	const cmd = new Command("mcp").description(
+		"Install / remove / list the maina MCP server across AI clients",
+	);
+
+	const add = buildCommonOptions(
+		new Command("add").description(
+			"Install the maina MCP server in each detected client's global config",
+		),
+	).action(async (opts) => {
+		const json = opts.json === true;
+		if (!json) intro("maina mcp add");
+		const result = await mcpAction({
+			command: "add",
+			client: opts.client,
+			scope: opts.scope,
+			dryRun: opts.dryRun,
+			yes: opts.yes,
+			json,
+		});
+		if (result.error) {
+			if (json) outputJson({ error: result.error }, 1);
+			else outro(`Failed: ${result.error}`);
+			process.exitCode = 1;
+			return;
+		}
+		if (json) {
+			outputJson(result.report, EXIT_PASSED);
+			return;
+		}
+		emitAddReport(result.report ?? { results: [], skipped: [] });
+		outro("Done.");
+	});
+
+	const remove = buildCommonOptions(
+		new Command("remove").description(
+			"Remove the maina MCP server from each client's config",
+		),
+	).action(async (opts) => {
+		const json = opts.json === true;
+		if (!json) intro("maina mcp remove");
+		const result = await mcpAction({
+			command: "remove",
+			client: opts.client,
+			scope: opts.scope,
+			dryRun: opts.dryRun,
+			yes: opts.yes,
+			json,
+		});
+		if (result.error) {
+			if (json) outputJson({ error: result.error }, 1);
+			else outro(`Failed: ${result.error}`);
+			process.exitCode = 1;
+			return;
+		}
+		if (json) {
+			outputJson(result.report, EXIT_PASSED);
+			return;
+		}
+		emitAddReport(result.report ?? { results: [], skipped: [] });
+		outro("Done.");
+	});
+
+	const list = buildCommonOptions(
+		new Command("list").description("Show maina MCP install status per client"),
+	).action(async (opts) => {
+		const json = opts.json === true;
+		if (!json) intro("maina mcp list");
+		const result = await mcpAction({
+			command: "list",
+			client: opts.client,
+			scope: opts.scope,
+			json,
+		});
+		if (result.error) {
+			if (json) outputJson({ error: result.error }, 1);
+			else outro(`Failed: ${result.error}`);
+			process.exitCode = 1;
+			return;
+		}
+		if (json) {
+			outputJson(result.list, EXIT_PASSED);
+			return;
+		}
+		emitListReport(result.list?.entries ?? []);
+		outro("Done.");
+	});
+
+	cmd.addCommand(add);
+	cmd.addCommand(remove);
+	cmd.addCommand(list);
+	return cmd;
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -63,7 +63,10 @@ Setup & Config:
   setup         Guided first-time setup
   doctor        Check tool and engine health
   login         Cloud authentication
-  configure     Edit maina config`,
+  configure     Edit maina config
+  mcp add       Install maina MCP server in supported AI clients
+  mcp remove    Uninstall maina MCP server from clients
+  mcp list      Show maina MCP install status per client`,
 		)
 		.version(pkg.version);
 

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -13,6 +13,7 @@ import { explainCommand } from "./commands/explain";
 import { initCommand } from "./commands/init";
 import { learnCommand } from "./commands/learn";
 import { loginCommand, logoutCommand } from "./commands/login";
+import { mcpCommand } from "./commands/mcp";
 import { planCommand } from "./commands/plan";
 import { prCommand } from "./commands/pr";
 import { promptCommand } from "./commands/prompt";
@@ -91,6 +92,7 @@ Setup & Config:
 	program.addCommand(loginCommand());
 	program.addCommand(logoutCommand());
 	program.addCommand(configureCommand());
+	program.addCommand(mcpCommand());
 
 	// ── Internals ───────────────────────────────────────────────────────
 	program.addCommand(analyzeCommand());

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.50",
+    "@iarna/toml": "^2.2.5",
     "@orama/orama": "^3.1.18",
     "ai": "^6.0.145",
     "drizzle-orm": "^0.45.2"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -249,6 +249,21 @@ export {
 	RUST_PROFILE,
 	TYPESCRIPT_PROFILE,
 } from "./language/profile";
+export { buildMainaEntry, MAINA_MCP_KEY } from "./mcp/entry";
+// MCP install/remove across clients
+export {
+	type ApplyResult,
+	buildClientRegistry,
+	type ListEntry,
+	listClientIds,
+	type McpClientId,
+	type McpScope,
+	type RunOptions,
+	type RunReport,
+	runAdd,
+	runList,
+	runRemove,
+} from "./mcp/index";
 export { loadDefault, type PromptTask } from "./prompts/defaults/index";
 // Prompts
 export {

--- a/packages/core/src/mcp/__tests__/apply.test.ts
+++ b/packages/core/src/mcp/__tests__/apply.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Apply tests for the MCP add/remove machinery.
+ *
+ * Each test runs against a tmpdir-rooted fake $HOME so we never touch the
+ * developer's actual ~/.claude or ~/.cursor configs. The non-destructive
+ * merge contract — preserve other servers, preserve unrelated keys — is
+ * the most important behaviour to lock down here.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as toml from "@iarna/toml";
+import { addOnClient, inspectClient, removeFromClient } from "../apply";
+import { buildClientRegistry } from "../clients";
+
+let HOME: string;
+
+beforeEach(() => {
+	HOME = join(
+		tmpdir(),
+		`maina-mcp-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	mkdirSync(HOME, { recursive: true });
+});
+
+afterEach(() => {
+	rmSync(HOME, { recursive: true, force: true });
+});
+
+function readJson(path: string): Record<string, unknown> {
+	return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+}
+
+// ── add: object-shaped clients (Claude / Cursor / etc.) ────────────────────
+
+describe("addOnClient — JSON object shape (Cursor, Claude, etc.)", () => {
+	test("creates the config file when missing and inserts the maina entry", async () => {
+		const info = buildClientRegistry(HOME).cursor;
+		const path = info.globalConfigPath();
+		const r = await addOnClient(info, {
+			configPath: path,
+			scope: "global",
+			dryRun: false,
+		});
+
+		expect(r.action).toBe("created");
+		const json = readJson(path);
+		expect((json.mcpServers as Record<string, unknown>).maina).toEqual({
+			command: "npx",
+			args: ["@mainahq/cli", "--mcp"],
+		});
+	});
+
+	test("preserves existing servers and unrelated config keys", async () => {
+		const info = buildClientRegistry(HOME).cursor;
+		const path = info.globalConfigPath();
+		mkdirSync(join(HOME, ".cursor"), { recursive: true });
+		writeFileSync(
+			path,
+			JSON.stringify(
+				{
+					theme: "dark",
+					mcpServers: {
+						posthog: {
+							command: "npx",
+							args: ["mcp-remote@latest", "https://x"],
+						},
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		await addOnClient(info, {
+			configPath: path,
+			scope: "global",
+			dryRun: false,
+		});
+
+		const json = readJson(path);
+		expect(json.theme).toBe("dark");
+		const servers = json.mcpServers as Record<string, unknown>;
+		expect(servers.posthog).toBeDefined();
+		expect(servers.maina).toBeDefined();
+	});
+
+	test("re-running with the same entry returns 'unchanged'", async () => {
+		const info = buildClientRegistry(HOME).cursor;
+		const path = info.globalConfigPath();
+		await addOnClient(info, {
+			configPath: path,
+			scope: "global",
+			dryRun: false,
+		});
+		const second = await addOnClient(info, {
+			configPath: path,
+			scope: "global",
+			dryRun: false,
+		});
+		expect(second.action).toBe("unchanged");
+	});
+
+	test("dryRun=true never writes the file", async () => {
+		const info = buildClientRegistry(HOME).cursor;
+		const path = info.globalConfigPath();
+		const r = await addOnClient(info, {
+			configPath: path,
+			scope: "global",
+			dryRun: true,
+		});
+		expect(r.action).toBe("created");
+		expect(existsSync(path)).toBe(false);
+	});
+
+	test("malformed existing JSON surfaces an error and does not overwrite", async () => {
+		const info = buildClientRegistry(HOME).cursor;
+		const path = info.globalConfigPath();
+		mkdirSync(join(HOME, ".cursor"), { recursive: true });
+		writeFileSync(path, "{ not json");
+
+		const r = await addOnClient(info, {
+			configPath: path,
+			scope: "global",
+			dryRun: false,
+		});
+		expect(r.error).toBeDefined();
+		// Original content preserved.
+		expect(readFileSync(path, "utf-8")).toBe("{ not json");
+	});
+});
+
+// ── add: array-shaped client (Continue legacy) ─────────────────────────────
+
+describe("addOnClient — JSON array shape (Continue)", () => {
+	test("appends to the experimental.modelContextProtocolServers array", async () => {
+		const info = buildClientRegistry(HOME).continue;
+		const path = info.globalConfigPath();
+		const r = await addOnClient(info, {
+			configPath: path,
+			scope: "global",
+			dryRun: false,
+		});
+
+		expect(r.action).toBe("created");
+		const json = readJson(path);
+		const arr = (json.experimental as Record<string, unknown>)
+			.modelContextProtocolServers as Array<{ name: string }>;
+		expect(arr.length).toBe(1);
+		expect(arr[0]?.name).toBe("maina");
+	});
+
+	test("idempotent for arrays — re-running yields 'unchanged'", async () => {
+		const info = buildClientRegistry(HOME).continue;
+		const path = info.globalConfigPath();
+		await addOnClient(info, {
+			configPath: path,
+			scope: "global",
+			dryRun: false,
+		});
+		const second = await addOnClient(info, {
+			configPath: path,
+			scope: "global",
+			dryRun: false,
+		});
+		expect(second.action).toBe("unchanged");
+	});
+});
+
+// ── add: TOML client (Codex) ───────────────────────────────────────────────
+
+describe("addOnClient — TOML shape (Codex)", () => {
+	test("writes a TOML file with [mcp_servers.maina] section", async () => {
+		const info = buildClientRegistry(HOME).codex;
+		const path = info.globalConfigPath();
+		const r = await addOnClient(info, {
+			configPath: path,
+			scope: "global",
+			dryRun: false,
+		});
+
+		expect(r.action).toBe("created");
+		const parsed = toml.parse(readFileSync(path, "utf-8")) as Record<
+			string,
+			unknown
+		>;
+		const section = (parsed.mcp_servers as Record<string, unknown>)
+			.maina as Record<string, unknown>;
+		expect(section.command).toBe("npx");
+		expect(section.args).toEqual(["@mainahq/cli", "--mcp"]);
+	});
+
+	test("preserves other TOML sections", async () => {
+		const info = buildClientRegistry(HOME).codex;
+		const path = info.globalConfigPath();
+		mkdirSync(join(HOME, ".codex"), { recursive: true });
+		writeFileSync(
+			path,
+			'model = "gpt-4o"\n[mcp_servers.other]\ncommand = "x"\n',
+		);
+
+		await addOnClient(info, {
+			configPath: path,
+			scope: "global",
+			dryRun: false,
+		});
+
+		const parsed = toml.parse(readFileSync(path, "utf-8")) as Record<
+			string,
+			unknown
+		>;
+		expect(parsed.model).toBe("gpt-4o");
+		const servers = parsed.mcp_servers as Record<string, unknown>;
+		expect(servers.other).toBeDefined();
+		expect(servers.maina).toBeDefined();
+	});
+});
+
+// ── remove ─────────────────────────────────────────────────────────────────
+
+describe("removeFromClient", () => {
+	test("removes only the maina entry, preserves other servers", async () => {
+		const info = buildClientRegistry(HOME).cursor;
+		const path = info.globalConfigPath();
+		mkdirSync(join(HOME, ".cursor"), { recursive: true });
+		writeFileSync(
+			path,
+			JSON.stringify({
+				mcpServers: {
+					maina: { command: "npx", args: ["@mainahq/cli", "--mcp"] },
+					posthog: { command: "npx", args: ["other"] },
+				},
+			}),
+		);
+
+		const r = await removeFromClient(info, {
+			configPath: path,
+			scope: "global",
+			dryRun: false,
+		});
+		expect(r.action).toBe("removed");
+		const servers = readJson(path).mcpServers as Record<string, unknown>;
+		expect(servers.maina).toBeUndefined();
+		expect(servers.posthog).toBeDefined();
+	});
+
+	test("returns 'absent' when the file does not exist", async () => {
+		const info = buildClientRegistry(HOME).cursor;
+		const r = await removeFromClient(info, {
+			configPath: info.globalConfigPath(),
+			scope: "global",
+			dryRun: false,
+		});
+		expect(r.action).toBe("absent");
+	});
+
+	test("returns 'absent' when the entry was never added", async () => {
+		const info = buildClientRegistry(HOME).cursor;
+		const path = info.globalConfigPath();
+		mkdirSync(join(HOME, ".cursor"), { recursive: true });
+		writeFileSync(path, JSON.stringify({ mcpServers: { other: {} } }));
+
+		const r = await removeFromClient(info, {
+			configPath: path,
+			scope: "global",
+			dryRun: false,
+		});
+		expect(r.action).toBe("absent");
+	});
+
+	test("removes from Continue's array and leaves siblings alone", async () => {
+		const info = buildClientRegistry(HOME).continue;
+		const path = info.globalConfigPath();
+		mkdirSync(join(HOME, ".continue"), { recursive: true });
+		writeFileSync(
+			path,
+			JSON.stringify({
+				experimental: {
+					modelContextProtocolServers: [
+						{ name: "maina", transport: { type: "stdio" } },
+						{ name: "posthog", transport: { type: "stdio" } },
+					],
+				},
+			}),
+		);
+		const r = await removeFromClient(info, {
+			configPath: path,
+			scope: "global",
+			dryRun: false,
+		});
+		expect(r.action).toBe("removed");
+		const arr = (readJson(path).experimental as Record<string, unknown>)
+			.modelContextProtocolServers as Array<{ name: string }>;
+		expect(arr.length).toBe(1);
+		expect(arr[0]?.name).toBe("posthog");
+	});
+});
+
+// ── inspect ────────────────────────────────────────────────────────────────
+
+describe("inspectClient", () => {
+	test("reports installed=true after add()", async () => {
+		const info = buildClientRegistry(HOME).cursor;
+		const path = info.globalConfigPath();
+		await addOnClient(info, {
+			configPath: path,
+			scope: "global",
+			dryRun: false,
+		});
+		const status = await inspectClient(info, path);
+		expect(status.installed).toBe(true);
+	});
+
+	test("reports installed=false when the file is absent", async () => {
+		const info = buildClientRegistry(HOME).cursor;
+		const status = await inspectClient(info, info.globalConfigPath());
+		expect(status.installed).toBe(false);
+	});
+
+	test("works for Continue's array shape", async () => {
+		const info = buildClientRegistry(HOME).continue;
+		const path = info.globalConfigPath();
+		await addOnClient(info, {
+			configPath: path,
+			scope: "global",
+			dryRun: false,
+		});
+		const status = await inspectClient(info, path);
+		expect(status.installed).toBe(true);
+	});
+});

--- a/packages/core/src/mcp/apply.ts
+++ b/packages/core/src/mcp/apply.ts
@@ -1,0 +1,288 @@
+/**
+ * Apply add/remove operations against a single client's config file.
+ *
+ * Atomic write semantics: parse the existing file (or start fresh if it
+ * doesn't exist), mutate ONLY the maina entry, then write to a temp path
+ * + rename. Other entries — both other MCP servers and unrelated config
+ * keys — are preserved verbatim by the JSON / TOML round-trip.
+ */
+
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import * as toml from "@iarna/toml";
+import type { ApplyResult, McpClientInfo } from "./types";
+
+// ── File format adapters ───────────────────────────────────────────────────
+
+type Parsed = Record<string, unknown>;
+
+function parseConfig(raw: string, format: "json" | "toml"): Parsed {
+	if (raw.trim().length === 0) return {};
+	if (format === "json") {
+		const value = JSON.parse(raw);
+		return value && typeof value === "object" && !Array.isArray(value)
+			? (value as Parsed)
+			: {};
+	}
+	return toml.parse(raw) as Parsed;
+}
+
+function serialise(value: Parsed, format: "json" | "toml"): string {
+	if (format === "json") {
+		return `${JSON.stringify(value, null, 2)}\n`;
+	}
+	return toml.stringify(value as toml.JsonMap);
+}
+
+// ── Path navigation ────────────────────────────────────────────────────────
+
+/**
+ * Walk into `root` along `path`, creating intermediate objects as needed,
+ * and return the parent that holds the final container plus the final key.
+ */
+function getOrCreateContainer(
+	root: Parsed,
+	path: string[],
+	container: "object" | "array",
+): { parent: Parsed; key: string } {
+	let cursor: Parsed = root;
+	for (let i = 0; i < path.length - 1; i++) {
+		const k = path[i] as string;
+		const next = cursor[k];
+		if (!next || typeof next !== "object" || Array.isArray(next)) {
+			cursor[k] = {};
+		}
+		cursor = cursor[k] as Parsed;
+	}
+	const lastKey = path[path.length - 1] as string;
+	if (cursor[lastKey] === undefined || cursor[lastKey] === null) {
+		cursor[lastKey] = container === "object" ? {} : [];
+	}
+	return { parent: cursor, key: lastKey };
+}
+
+// ── Add / Remove core ──────────────────────────────────────────────────────
+
+interface MutationOutcome {
+	changed: boolean;
+	priorState: "absent" | "present";
+}
+
+function applyAdd(root: Parsed, info: McpClientInfo): MutationOutcome {
+	const { parent, key } = getOrCreateContainer(
+		root,
+		info.shape.path,
+		info.shape.container,
+	);
+	const desired = info.buildEntry();
+
+	if (info.shape.container === "object") {
+		const bag = parent[key] as Record<string, unknown>;
+		const existing = bag[info.shape.entryKey];
+		const prior: MutationOutcome["priorState"] =
+			existing === undefined ? "absent" : "present";
+		if (prior === "present" && deepEqual(existing, desired)) {
+			return { changed: false, priorState: prior };
+		}
+		bag[info.shape.entryKey] = desired;
+		return { changed: true, priorState: prior };
+	}
+
+	// container = "array" (Continue legacy shape)
+	const arr = parent[key] as unknown[];
+	const idx = arr.findIndex(
+		(e): e is { name?: unknown } =>
+			typeof e === "object" &&
+			e !== null &&
+			(e as { name?: unknown }).name === info.shape.entryKey,
+	);
+	if (idx >= 0 && deepEqual(arr[idx], desired)) {
+		return { changed: false, priorState: "present" };
+	}
+	if (idx >= 0) {
+		arr[idx] = desired;
+		return { changed: true, priorState: "present" };
+	}
+	arr.push(desired);
+	return { changed: true, priorState: "absent" };
+}
+
+function applyRemove(root: Parsed, info: McpClientInfo): MutationOutcome {
+	// Walk without creating; if any segment is missing, nothing to remove.
+	let cursor: Parsed = root;
+	for (let i = 0; i < info.shape.path.length - 1; i++) {
+		const next = cursor[info.shape.path[i] as string];
+		if (!next || typeof next !== "object" || Array.isArray(next)) {
+			return { changed: false, priorState: "absent" };
+		}
+		cursor = next as Parsed;
+	}
+	const lastKey = info.shape.path[info.shape.path.length - 1] as string;
+	const container = cursor[lastKey];
+	if (container === undefined || container === null) {
+		return { changed: false, priorState: "absent" };
+	}
+
+	if (info.shape.container === "object") {
+		const bag = container as Record<string, unknown>;
+		if (bag[info.shape.entryKey] === undefined) {
+			return { changed: false, priorState: "absent" };
+		}
+		delete bag[info.shape.entryKey];
+		return { changed: true, priorState: "present" };
+	}
+
+	const arr = container as unknown[];
+	const idx = arr.findIndex(
+		(e): e is { name?: unknown } =>
+			typeof e === "object" &&
+			e !== null &&
+			(e as { name?: unknown }).name === info.shape.entryKey,
+	);
+	if (idx < 0) return { changed: false, priorState: "absent" };
+	arr.splice(idx, 1);
+	return { changed: true, priorState: "present" };
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+	return JSON.stringify(a) === JSON.stringify(b);
+}
+
+// ── Atomic file ops ────────────────────────────────────────────────────────
+
+function readOrEmpty(path: string): string {
+	if (!existsSync(path)) return "";
+	return readFileSync(path, "utf-8");
+}
+
+function writeAtomic(path: string, content: string): void {
+	mkdirSync(dirname(path), { recursive: true });
+	const tmp = `${path}.tmp.${process.pid}.${Math.random().toString(36).slice(2)}`;
+	writeFileSync(tmp, content, "utf-8");
+	renameSync(tmp, path);
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+export interface RunOnClientOptions {
+	configPath: string;
+	scope: "global" | "project";
+	dryRun: boolean;
+}
+
+export async function addOnClient(
+	info: McpClientInfo,
+	opts: RunOnClientOptions,
+): Promise<ApplyResult> {
+	const result: ApplyResult = {
+		clientId: info.id,
+		configPath: opts.configPath,
+		scope: opts.scope,
+		action: "unchanged",
+		dryRun: opts.dryRun,
+	};
+	try {
+		const raw = readOrEmpty(opts.configPath);
+		const parsed = parseConfig(raw, info.configFormat);
+		const outcome = applyAdd(parsed, info);
+
+		if (!outcome.changed) {
+			result.action = "unchanged";
+			return result;
+		}
+
+		const wasNew = !existsSync(opts.configPath);
+		result.action = wasNew ? "created" : "updated";
+
+		if (!opts.dryRun) {
+			writeAtomic(opts.configPath, serialise(parsed, info.configFormat));
+		}
+		return result;
+	} catch (e) {
+		result.action = "unchanged";
+		result.error = e instanceof Error ? e.message : String(e);
+		return result;
+	}
+}
+
+export async function removeFromClient(
+	info: McpClientInfo,
+	opts: RunOnClientOptions,
+): Promise<ApplyResult> {
+	const result: ApplyResult = {
+		clientId: info.id,
+		configPath: opts.configPath,
+		scope: opts.scope,
+		action: "absent",
+		dryRun: opts.dryRun,
+	};
+	try {
+		if (!existsSync(opts.configPath)) {
+			result.action = "absent";
+			return result;
+		}
+		const raw = readOrEmpty(opts.configPath);
+		const parsed = parseConfig(raw, info.configFormat);
+		const outcome = applyRemove(parsed, info);
+
+		if (!outcome.changed) {
+			result.action = "absent";
+			return result;
+		}
+		result.action = "removed";
+		if (!opts.dryRun) {
+			writeAtomic(opts.configPath, serialise(parsed, info.configFormat));
+		}
+		return result;
+	} catch (e) {
+		result.action = "unchanged";
+		result.error = e instanceof Error ? e.message : String(e);
+		return result;
+	}
+}
+
+/**
+ * Inspect a client's config without modifying it. Used by `maina mcp list`.
+ */
+export async function inspectClient(
+	info: McpClientInfo,
+	configPath: string,
+): Promise<{ installed: boolean; error?: string }> {
+	try {
+		if (!existsSync(configPath)) return { installed: false };
+		const raw = readOrEmpty(configPath);
+		const parsed = parseConfig(raw, info.configFormat);
+		let cursor: unknown = parsed;
+		for (const segment of info.shape.path) {
+			if (!cursor || typeof cursor !== "object") return { installed: false };
+			cursor = (cursor as Record<string, unknown>)[segment];
+		}
+		if (!cursor) return { installed: false };
+		if (info.shape.container === "object") {
+			return {
+				installed:
+					(cursor as Record<string, unknown>)[info.shape.entryKey] !==
+					undefined,
+			};
+		}
+		return {
+			installed: (cursor as unknown[]).some(
+				(e) =>
+					typeof e === "object" &&
+					e !== null &&
+					(e as { name?: unknown }).name === info.shape.entryKey,
+			),
+		};
+	} catch (e) {
+		return {
+			installed: false,
+			error: e instanceof Error ? e.message : String(e),
+		};
+	}
+}

--- a/packages/core/src/mcp/clients.ts
+++ b/packages/core/src/mcp/clients.ts
@@ -1,0 +1,243 @@
+/**
+ * Registry of MCP clients we know how to install the maina server into.
+ *
+ * Each client describes:
+ *   - where its global config lives (per-platform)
+ *   - what serialisation format it uses (JSON vs TOML)
+ *   - where in the parsed object the MCP server map lives
+ *   - how to detect whether the user has the client installed
+ *
+ * We intentionally support only "global" install scope here — the per-
+ * project shape is already handled by the setup wizard via `.mcp.json`
+ * and `.claude/settings.json`. `maina mcp add` is the cross-project
+ * counterpart so a single install reaches every repo.
+ *
+ * Inspired by PostHog's wizard MCPClient pattern, simplified for our
+ * narrower use case (we always register the same maina entry).
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import type { McpClientId, McpClientInfo } from "./types";
+
+// ── Path helpers ────────────────────────────────────────────────────────────
+
+interface PathContext {
+	home: string;
+	platform: NodeJS.Platform;
+}
+
+function ctx(home?: string): PathContext {
+	return { home: home ?? homedir(), platform: platform() };
+}
+
+function vsCodeGlobalStorage(c: PathContext): string {
+	if (c.platform === "darwin") {
+		return join(
+			c.home,
+			"Library",
+			"Application Support",
+			"Code",
+			"User",
+			"globalStorage",
+		);
+	}
+	if (c.platform === "win32") {
+		return join(
+			process.env.APPDATA ?? join(c.home, "AppData", "Roaming"),
+			"Code",
+			"User",
+			"globalStorage",
+		);
+	}
+	return join(c.home, ".config", "Code", "User", "globalStorage");
+}
+
+function zedConfigDir(c: PathContext): string {
+	if (c.platform === "win32") {
+		return join(
+			process.env.APPDATA ?? join(c.home, "AppData", "Roaming"),
+			"Zed",
+		);
+	}
+	return join(c.home, ".config", "zed");
+}
+
+// ── Detection helpers ──────────────────────────────────────────────────────
+
+async function dirExists(p: string): Promise<boolean> {
+	try {
+		return existsSync(p);
+	} catch {
+		return false;
+	}
+}
+
+async function vsCodeExtensionInstalled(extPrefix: string): Promise<boolean> {
+	const dirs = [
+		join(homedir(), ".vscode", "extensions"),
+		join(homedir(), ".vscode-server", "extensions"),
+	];
+	for (const dir of dirs) {
+		if (!existsSync(dir)) continue;
+		try {
+			if (readdirSync(dir).some((e) => e.startsWith(extPrefix))) return true;
+		} catch {
+			// fall through
+		}
+	}
+	return false;
+}
+
+// ── Client definitions ─────────────────────────────────────────────────────
+
+export function buildClientRegistry(
+	home?: string,
+): Record<McpClientId, McpClientInfo> {
+	const c = ctx(home);
+
+	const claude: McpClientInfo = {
+		id: "claude",
+		label: "Claude Code",
+		configFormat: "json",
+		globalConfigPath: () => join(c.home, ".claude", "settings.json"),
+		projectConfigPath: (cwd) => join(cwd, ".claude", "settings.json"),
+		detect: async () =>
+			dirExists(join(c.home, ".claude")) ||
+			Boolean(process.env.CLAUDE_CODE) ||
+			Boolean(process.env.CLAUDE_PROJECT_DIR),
+		shape: { path: ["mcpServers"], container: "object", entryKey: "maina" },
+		buildEntry: () => ({ command: "npx", args: ["@mainahq/cli", "--mcp"] }),
+	};
+
+	const cursor: McpClientInfo = {
+		id: "cursor",
+		label: "Cursor",
+		configFormat: "json",
+		globalConfigPath: () => join(c.home, ".cursor", "mcp.json"),
+		projectConfigPath: (cwd) => join(cwd, ".cursor", "mcp.json"),
+		detect: async () =>
+			dirExists(join(c.home, ".cursor")) ||
+			Object.keys(process.env).some((k) => k.startsWith("CURSOR_")),
+		shape: { path: ["mcpServers"], container: "object", entryKey: "maina" },
+		buildEntry: () => ({ command: "npx", args: ["@mainahq/cli", "--mcp"] }),
+	};
+
+	const windsurf: McpClientInfo = {
+		id: "windsurf",
+		label: "Windsurf",
+		configFormat: "json",
+		globalConfigPath: () =>
+			join(c.home, ".codeium", "windsurf", "mcp_config.json"),
+		detect: async () =>
+			dirExists(join(c.home, ".codeium")) ||
+			Object.keys(process.env).some((k) => k.startsWith("CODEIUM_")),
+		shape: { path: ["mcpServers"], container: "object", entryKey: "maina" },
+		buildEntry: () => ({ command: "npx", args: ["@mainahq/cli", "--mcp"] }),
+	};
+
+	const cline: McpClientInfo = {
+		id: "cline",
+		label: "Cline (VS Code)",
+		configFormat: "json",
+		globalConfigPath: () =>
+			join(
+				vsCodeGlobalStorage(c),
+				"saoudrizwan.claude-dev",
+				"settings",
+				"cline_mcp_settings.json",
+			),
+		detect: () => vsCodeExtensionInstalled("saoudrizwan.claude-dev"),
+		shape: { path: ["mcpServers"], container: "object", entryKey: "maina" },
+		buildEntry: () => ({ command: "npx", args: ["@mainahq/cli", "--mcp"] }),
+	};
+
+	const codex: McpClientInfo = {
+		id: "codex",
+		label: "OpenAI Codex CLI",
+		configFormat: "toml",
+		globalConfigPath: () => join(c.home, ".codex", "config.toml"),
+		detect: async () => dirExists(join(c.home, ".codex")),
+		shape: { path: ["mcp_servers"], container: "object", entryKey: "maina" },
+		buildEntry: () => ({ command: "npx", args: ["@mainahq/cli", "--mcp"] }),
+	};
+
+	const continueClient: McpClientInfo = {
+		id: "continue",
+		label: "Continue.dev",
+		configFormat: "json",
+		// Continue's newer YAML format is `~/.continue/.continue/mcpServers/<name>.yaml`,
+		// but the legacy `config.json` `experimental` block is still respected and
+		// is JSON, so we target it here to keep the dep surface small. Users on
+		// the new YAML setup can run `maina mcp add --client continue` once we
+		// add YAML support — tracked as a follow-up.
+		globalConfigPath: () => join(c.home, ".continue", "config.json"),
+		projectConfigPath: (cwd) => join(cwd, ".continue", "config.json"),
+		detect: async () => dirExists(join(c.home, ".continue")),
+		shape: {
+			path: ["experimental", "modelContextProtocolServers"],
+			container: "array",
+			entryKey: "maina",
+		},
+		buildEntry: () => ({
+			name: "maina",
+			transport: {
+				type: "stdio",
+				command: "npx",
+				args: ["@mainahq/cli", "--mcp"],
+			},
+		}),
+	};
+
+	const gemini: McpClientInfo = {
+		id: "gemini",
+		label: "Gemini CLI",
+		configFormat: "json",
+		globalConfigPath: () => join(c.home, ".gemini", "settings.json"),
+		detect: async () => dirExists(join(c.home, ".gemini")),
+		shape: { path: ["mcpServers"], container: "object", entryKey: "maina" },
+		buildEntry: () => ({ command: "npx", args: ["@mainahq/cli", "--mcp"] }),
+	};
+
+	const zed: McpClientInfo = {
+		id: "zed",
+		label: "Zed",
+		configFormat: "json",
+		globalConfigPath: () => join(zedConfigDir(c), "settings.json"),
+		detect: async () => dirExists(zedConfigDir(c)),
+		shape: {
+			path: ["context_servers"],
+			container: "object",
+			entryKey: "maina",
+		},
+		buildEntry: () => ({
+			source: "custom",
+			command: { path: "npx", args: ["@mainahq/cli", "--mcp"] },
+		}),
+	};
+
+	return {
+		claude,
+		cursor,
+		windsurf,
+		cline,
+		codex,
+		continue: continueClient,
+		gemini,
+		zed,
+	};
+}
+
+export function listClientIds(): McpClientId[] {
+	return [
+		"claude",
+		"cursor",
+		"windsurf",
+		"cline",
+		"codex",
+		"continue",
+		"gemini",
+		"zed",
+	];
+}

--- a/packages/core/src/mcp/entry.ts
+++ b/packages/core/src/mcp/entry.ts
@@ -1,10 +1,21 @@
 /**
  * The maina MCP server entry. Single source of truth so every client
  * registers the same `command` / `args` shape — and so a future change
- * (e.g. switching from `npx @mainahq/cli` to `bunx`) is one edit.
+ * is one edit.
+ *
+ * We use `npx` (not `bunx`) on purpose: npm ships with Node which ships
+ * with virtually every developer environment, including the AI clients
+ * we target (Claude Code, Cursor, Windsurf, etc.). `bunx` would require
+ * users to install Bun globally just to run the maina MCP server. The
+ * setup wizard, init, and the per-project configs already use `npx
+ * @mainahq/cli` for the same reason — switching one surface would
+ * fragment the install story.
  */
 
 export const MAINA_MCP_KEY = "maina";
+
+const LAUNCHER_COMMAND = "npx";
+const LAUNCHER_ARGS: readonly string[] = ["@mainahq/cli", "--mcp"];
 
 export interface MainaMcpEntry {
 	command: string;
@@ -13,18 +24,16 @@ export interface MainaMcpEntry {
 
 export function buildMainaEntry(): MainaMcpEntry {
 	return {
-		command: "npx",
-		args: ["@mainahq/cli", "--mcp"],
+		command: LAUNCHER_COMMAND,
+		args: [...LAUNCHER_ARGS],
 	};
 }
 
 /**
- * Same shape as `buildMainaEntry()` but flattened for TOML, where command
- * + args sit alongside section metadata instead of inside an object value.
+ * Same shape as `buildMainaEntry()` but typed for serialisers that want
+ * a plain `Record<string, unknown>` (e.g. the TOML emitter for Codex).
  */
 export function buildMainaTomlSection(): Record<string, unknown> {
-	return {
-		command: "npx",
-		args: ["@mainahq/cli", "--mcp"],
-	};
+	const entry = buildMainaEntry();
+	return { command: entry.command, args: entry.args };
 }

--- a/packages/core/src/mcp/entry.ts
+++ b/packages/core/src/mcp/entry.ts
@@ -1,0 +1,30 @@
+/**
+ * The maina MCP server entry. Single source of truth so every client
+ * registers the same `command` / `args` shape — and so a future change
+ * (e.g. switching from `npx @mainahq/cli` to `bunx`) is one edit.
+ */
+
+export const MAINA_MCP_KEY = "maina";
+
+export interface MainaMcpEntry {
+	command: string;
+	args: string[];
+}
+
+export function buildMainaEntry(): MainaMcpEntry {
+	return {
+		command: "npx",
+		args: ["@mainahq/cli", "--mcp"],
+	};
+}
+
+/**
+ * Same shape as `buildMainaEntry()` but flattened for TOML, where command
+ * + args sit alongside section metadata instead of inside an object value.
+ */
+export function buildMainaTomlSection(): Record<string, unknown> {
+	return {
+		command: "npx",
+		args: ["@mainahq/cli", "--mcp"],
+	};
+}

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -127,6 +127,11 @@ export async function runList(
 					? ["project"]
 					: ["global"];
 		for (const scope of scopes) {
+			// If a client doesn't define a project-scope config path, skip
+			// the project entry entirely rather than silently reporting the
+			// global path with `scope: "project"` (which would mislead users
+			// who explicitly asked for `--scope project`).
+			if (scope === "project" && !info.projectConfigPath) continue;
 			const path =
 				scope === "project" && info.projectConfigPath
 					? info.projectConfigPath(opts.cwd)

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -1,0 +1,147 @@
+/**
+ * `maina mcp` — install, remove, and list the maina MCP server across
+ * supported AI clients.
+ *
+ * Public entry points: `runAdd`, `runRemove`, `runList`. Each takes a
+ * RunOptions describing the requested clients, scope, dry-run mode, and
+ * cwd. Each returns a per-client list of ApplyResult / status records.
+ */
+
+import { addOnClient, inspectClient, removeFromClient } from "./apply";
+import { buildClientRegistry, listClientIds } from "./clients";
+import type { ApplyResult, McpClientId, RunOptions } from "./types";
+
+export { buildClientRegistry, listClientIds } from "./clients";
+export type { ApplyResult, McpClientId, McpScope, RunOptions } from "./types";
+
+interface ResolvedClient {
+	id: McpClientId;
+	configPath: string;
+	scope: "global" | "project";
+}
+
+async function selectClients(
+	opts: RunOptions,
+): Promise<{ targets: ResolvedClient[]; skipped: McpClientId[] }> {
+	const registry = buildClientRegistry(opts.home);
+	const requested = opts.clients ?? listClientIds();
+	const targets: ResolvedClient[] = [];
+	const skipped: McpClientId[] = [];
+
+	for (const id of requested) {
+		const info = registry[id];
+		// When the user explicitly named clients, respect the choice and
+		// skip detection. Auto-mode (no --client list) only writes to
+		// clients we believe are present.
+		const explicit = opts.clients !== undefined;
+		if (!explicit) {
+			const installed = await info.detect();
+			if (!installed) {
+				skipped.push(id);
+				continue;
+			}
+		}
+		if (opts.scope === "global" || opts.scope === "both") {
+			targets.push({
+				id,
+				configPath: info.globalConfigPath(),
+				scope: "global",
+			});
+		}
+		if (
+			(opts.scope === "project" || opts.scope === "both") &&
+			info.projectConfigPath
+		) {
+			targets.push({
+				id,
+				configPath: info.projectConfigPath(opts.cwd),
+				scope: "project",
+			});
+		}
+	}
+	return { targets, skipped };
+}
+
+export interface RunReport {
+	results: ApplyResult[];
+	skipped: McpClientId[];
+}
+
+export async function runAdd(opts: RunOptions): Promise<RunReport> {
+	const registry = buildClientRegistry(opts.home);
+	const { targets, skipped } = await selectClients(opts);
+	const results: ApplyResult[] = [];
+	for (const t of targets) {
+		const info = registry[t.id];
+		results.push(
+			await addOnClient(info, {
+				configPath: t.configPath,
+				scope: t.scope,
+				dryRun: opts.dryRun,
+			}),
+		);
+	}
+	return { results, skipped };
+}
+
+export async function runRemove(opts: RunOptions): Promise<RunReport> {
+	const registry = buildClientRegistry(opts.home);
+	const { targets, skipped } = await selectClients(opts);
+	const results: ApplyResult[] = [];
+	for (const t of targets) {
+		const info = registry[t.id];
+		results.push(
+			await removeFromClient(info, {
+				configPath: t.configPath,
+				scope: t.scope,
+				dryRun: opts.dryRun,
+			}),
+		);
+	}
+	return { results, skipped };
+}
+
+export interface ListEntry {
+	clientId: McpClientId;
+	label: string;
+	scope: "global" | "project";
+	configPath: string;
+	detected: boolean;
+	installed: boolean;
+	error?: string;
+}
+
+export async function runList(
+	opts: RunOptions,
+): Promise<{ entries: ListEntry[] }> {
+	const registry = buildClientRegistry(opts.home);
+	const requested = opts.clients ?? listClientIds();
+	const entries: ListEntry[] = [];
+	for (const id of requested) {
+		const info = registry[id];
+		const detected = await info.detect();
+		const scopes: Array<"global" | "project"> =
+			opts.scope === "both"
+				? ["global", "project"]
+				: opts.scope === "project"
+					? ["project"]
+					: ["global"];
+		for (const scope of scopes) {
+			const path =
+				scope === "project" && info.projectConfigPath
+					? info.projectConfigPath(opts.cwd)
+					: info.globalConfigPath();
+			const status = await inspectClient(info, path);
+			entries.push({
+				clientId: id,
+				label: info.label,
+				scope,
+				configPath: path,
+				detected,
+				installed: status.installed,
+				...(status.error ? { error: status.error } : {}),
+			});
+		}
+	}
+	return { entries };
+}

--- a/packages/core/src/mcp/types.ts
+++ b/packages/core/src/mcp/types.ts
@@ -1,0 +1,72 @@
+/**
+ * Types shared across the `maina mcp add/remove/list` machinery.
+ *
+ * The goal of this module: write the maina MCP server entry into the
+ * GLOBAL config of any AI client the user has installed, so that
+ * `maina --mcp` is reachable from every project without per-repo setup.
+ * The setup wizard already writes per-project configs (`.mcp.json`,
+ * `.claude/settings.json`); this is the cross-project counterpart.
+ */
+
+import type { Result } from "../db/index";
+
+export type McpClientId =
+	| "claude"
+	| "cursor"
+	| "windsurf"
+	| "cline"
+	| "codex"
+	| "continue"
+	| "gemini"
+	| "zed";
+
+export type McpScope = "global" | "project" | "both";
+
+export type ConfigFormat = "json" | "toml";
+
+/** Description of where a client keeps the field that lists MCP servers. */
+export interface ClientMcpShape {
+	/** Top-level (or dotted) path to the MCP servers container. */
+	path: string[];
+	/** Whether the container is an object keyed by server name, or an array. */
+	container: "object" | "array";
+	/** The key the maina entry should use when container is "object". */
+	entryKey: string;
+}
+
+export interface McpClientInfo {
+	id: McpClientId;
+	label: string;
+	configFormat: ConfigFormat;
+	/** Absolute path to the global config file (resolves `~` + platform). */
+	globalConfigPath: () => string;
+	/** Optional project-scoped config path (relative to cwd). */
+	projectConfigPath?: (cwd: string) => string;
+	/** Heuristic for "is this client installed/used on this machine?". */
+	detect: () => Promise<boolean>;
+	shape: ClientMcpShape;
+	/** Build the maina entry in the shape this client expects. */
+	buildEntry: () => unknown;
+	/** True if the client expects an MCP entry only when the file already exists. */
+	requiresExistingFile?: boolean;
+}
+
+export interface ApplyResult {
+	clientId: McpClientId;
+	configPath: string;
+	scope: "global" | "project";
+	action: "created" | "updated" | "unchanged" | "removed" | "absent";
+	dryRun: boolean;
+	error?: string;
+}
+
+export interface RunOptions {
+	clients?: McpClientId[];
+	scope: McpScope;
+	dryRun: boolean;
+	cwd: string;
+	/** Override `os.homedir()` — primarily for tests. */
+	home?: string;
+}
+
+export type ApplyOutcome = Result<ApplyResult, string>;

--- a/packages/docs/src/content/docs/commands.mdx
+++ b/packages/docs/src/content/docs/commands.mdx
@@ -54,7 +54,7 @@ Eight commands support `--json` for machine-readable output (JSON envelope with 
 |---------|------------|
 | `maina setup` | Guided first-time setup — detects IDE, configures MCP, runs init + doctor |
 | `maina mcp add` | Install the maina MCP server in every detected client's global config (Claude Code, Cursor, Windsurf, Cline, Codex, Continue, Gemini, Zed). Auto-detects; pass `--client <list>` to override or `--scope project` for per-repo install. |
-| `maina mcp remove` | Strip the maina MCP entry from each client's global config. Same flags as `add`. |
+| `maina mcp remove` | Strip the maina MCP entry from each client's config. Defaults to global scope; same `--client / --scope global\|project\|both / --dry-run / --json` flags as `add`. |
 | `maina mcp list` | Show maina MCP install status per client. |
 
 ## Brainstorm Phase

--- a/packages/docs/src/content/docs/commands.mdx
+++ b/packages/docs/src/content/docs/commands.mdx
@@ -53,6 +53,9 @@ Eight commands support `--json` for machine-readable output (JSON envelope with 
 | Command | Description |
 |---------|------------|
 | `maina setup` | Guided first-time setup — detects IDE, configures MCP, runs init + doctor |
+| `maina mcp add` | Install the maina MCP server in every detected client's global config (Claude Code, Cursor, Windsurf, Cline, Codex, Continue, Gemini, Zed). Auto-detects; pass `--client <list>` to override or `--scope project` for per-repo install. |
+| `maina mcp remove` | Strip the maina MCP entry from each client's global config. Same flags as `add`. |
+| `maina mcp list` | Show maina MCP install status per client. |
 
 ## Brainstorm Phase
 

--- a/packages/docs/src/content/docs/mcp.mdx
+++ b/packages/docs/src/content/docs/mcp.mdx
@@ -55,20 +55,28 @@ Or configure manually per tool:
     {"mcpServers":{"maina":{"command":"npx","args":["@mainahq/cli","--mcp"]}}}
     ```
   </TabItem>
-  <TabItem label="Continue.dev">
-    `.continue/mcpServers/maina.json` (auto-discovered):
-    ```json
-    {"maina":{"command":"npx","args":["@mainahq/cli","--mcp"]}}
-    ```
-  </TabItem>
-  <TabItem label="Roo Code">
-    `.roo/mcp.json`:
+  <TabItem label="Cline">
+    `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` (mac; `.config/Code/...` on Linux, `%APPDATA%/Code/...` on Windows):
     ```json
     {"mcpServers":{"maina":{"command":"npx","args":["@mainahq/cli","--mcp"]}}}
     ```
   </TabItem>
-  <TabItem label="Amazon Q">
-    `.amazonq/mcp.json`:
+  <TabItem label="Codex CLI">
+    `~/.codex/config.toml`:
+    ```toml
+    [mcp_servers.maina]
+    command = "npx"
+    args = ["@mainahq/cli", "--mcp"]
+    ```
+  </TabItem>
+  <TabItem label="Continue.dev">
+    `~/.continue/config.json` under `experimental.modelContextProtocolServers`:
+    ```json
+    {"experimental":{"modelContextProtocolServers":[{"name":"maina","transport":{"type":"stdio","command":"npx","args":["@mainahq/cli","--mcp"]}}]}}
+    ```
+  </TabItem>
+  <TabItem label="Gemini CLI">
+    `~/.gemini/settings.json`:
     ```json
     {"mcpServers":{"maina":{"command":"npx","args":["@mainahq/cli","--mcp"]}}}
     ```
@@ -76,8 +84,15 @@ Or configure manually per tool:
   <TabItem label="Zed">
     `~/.config/zed/settings.json` under `context_servers`:
     ```json
-    {"context_servers":{"maina":{"command":{"path":"npx","args":["@mainahq/cli","--mcp"]},"source":"custom"}}}
+    {"context_servers":{"maina":{"source":"custom","command":{"path":"npx","args":["@mainahq/cli","--mcp"]}}}}
     ```
+  </TabItem>
+  <TabItem label="Other (Roo, Amazon Q)">
+    Not yet handled by `maina mcp add`. Configure manually under each tool's `mcpServers` block:
+    ```json
+    {"mcpServers":{"maina":{"command":"npx","args":["@mainahq/cli","--mcp"]}}}
+    ```
+    (`.roo/mcp.json` for Roo Code; `.amazonq/mcp.json` for Amazon Q.)
   </TabItem>
 </Tabs>
 

--- a/packages/docs/src/content/docs/mcp.mdx
+++ b/packages/docs/src/content/docs/mcp.mdx
@@ -9,11 +9,30 @@ Maina includes an MCP (Model Context Protocol) server that exposes its engines t
 
 ## Setup
 
-The install script handles this automatically:
+The fastest path is one command — it auto-detects every supported client on your machine and writes the maina entry into each global config:
 
 ```bash
-curl -fsSL https://api.mainahq.com/install | bash
+maina mcp add
 ```
+
+To remove maina from every client just as quickly:
+
+```bash
+maina mcp remove
+```
+
+Or scope to specific clients:
+
+```bash
+maina mcp add --client claude,cursor,windsurf
+maina mcp add --scope project          # write to .mcp.json / .claude/settings.json instead of global
+maina mcp add --dry-run                # preview the writes without touching disk
+maina mcp list                         # show install status per client
+```
+
+Supported clients: **Claude Code, Cursor, Windsurf, Cline, Codex CLI, Continue.dev, Gemini CLI, Zed**. The command preserves all other MCP servers and unrelated keys via an atomic merge — safe to run repeatedly.
+
+The setup wizard (`maina setup`) also writes the project-scoped configs (`.mcp.json` and `.claude/settings.json`) for you, so most users won't need `maina mcp add` unless they want maina available in every project from any client.
 
 Or configure manually per tool:
 


### PR DESCRIPTION
## Summary

New top-level command group inspired by `npx @posthog/wizard mcp add`:

```bash
maina mcp add        # auto-detect installed clients, write maina entry to each global config
maina mcp remove     # strip the maina entry from every client
maina mcp list       # show install status per client
```

**Supported clients (8):** Claude Code, Cursor, Windsurf, Cline (VS Code), OpenAI Codex CLI, Continue.dev, Gemini CLI, Zed.

**Flags (all subcommands):** `--client <list>`, `--scope global|project|both` (default: `global`), `--dry-run`, `--json`.

## Why

The setup wizard already writes per-project configs (`.mcp.json`, `.claude/settings.json`). `maina mcp add` is the cross-project counterpart — one command makes maina available in every project from any client.

## Architecture

- `packages/core/src/mcp/clients.ts` — registry of 8 clients with platform-aware paths, format (JSON/TOML), config shape (object vs array container, key path), and detection heuristics.
- `packages/core/src/mcp/apply.ts` — atomic merge: parse → mutate ONLY the maina entry → temp+rename. Other servers and unrelated config keys preserved verbatim.
- `packages/cli/src/commands/mcp.ts` — Commander wiring (3 subcommands).
- TOML support via new `@iarna/toml` core dep (small, zero-dep, battle-tested) for Codex.

## Test plan

- [x] **32 new tests** against tmpdir-rooted fake `$HOME` so the dev's real configs are never touched
  - 16 in core (`apply.test.ts`): JSON object shape, array shape (Continue), TOML shape (Codex), preservation of other servers + unrelated keys, idempotent re-runs, dry-run, malformed-JSON safe, remove behaviour for present/absent entries
  - 16 in CLI (`mcp.test.ts`): option parsing, error surfacing, end-to-end add/remove/list against a tmpdir HOME
- [x] Full setup + mcp suite: 32/32 pass
- [x] `bun run typecheck` clean; `bun run check` clean for new files
- [x] `bun run --cwd packages/docs build` passes (24 pages)
- [x] Manual smoke: `HOME=/tmp/x maina mcp add --client cursor --json` writes the entry; `mcp remove` strips it; `mcp list` reports status correctly

## Docs

- `mcp.mdx` rewritten: leads with the new `maina mcp add` command as the fastest install path
- `commands.mdx` adds the three commands under "Setup Phase"
- Changeset bumps `@mainahq/cli` + `@mainahq/core` to **minor** for v1.4.0

## Caveats / follow-ups

- **Continue.dev** uses the legacy `~/.continue/config.json#experimental.modelContextProtocolServers` shape. The newer per-server YAML at `~/.continue/.continue/mcpServers/*.yaml` will land when YAML support is added (kept dep surface to just TOML for v1).
- The `-y/--yes` flag is reserved (no-op today) for future interactive confirmation prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced `maina mcp` command group with `add`, `remove`, and `list` subcommands to manage MCP server installations across 8 supported AI clients (Claude, Cursor, Windsurf, Cline, Codex, Continue, Gemini, Zed)
  * Added `--scope` (global|project|both), `--client` filtering, `--dry-run`, and `--json` output modes
  * Configuration changes are applied atomically and preserve existing MCP servers and unrelated settings

* **Documentation**
  * Added CLI-driven MCP setup and per-tool usage guides, examples, and status commands
<!-- end of auto-generated comment: release notes by coderabbit.ai -->