### PR TITLE
fix(mcp): prefer installed maina binary over bunx to avoid cold-start cache race

### DIFF
--- a/.changeset/mcp-prefer-installed-binary.md
+++ b/.changeset/mcp-prefer-installed-binary.md
@@ -1,0 +1,29 @@
+---
+"@mainahq/cli": patch
+"@mainahq/core": patch
+---
+
+fix(mcp): prefer installed maina binary over bunx (avoids cold-start cache races)
+
+`maina mcp add` now writes the **direct path to the installed `maina` binary** when one is on PATH (e.g. `/Users/x/.bun/bin/maina --mcp`), falling back to `bunx`/`npx` only when the global install is absent.
+
+**Why:** real Cursor MCP logs against the v1.4.2 entry showed:
+
+```
+[error] Resolved, downloaded and extracted [24]
+[error] Unexpected: failed copying files from cache to destination for package drizzle-orm
+[warning] Connection failed: MCP error -32000: Connection closed
+```
+
+The previous default — `bunx @mainahq/cli` on every spawn — re-resolved the package each time Cursor (re)connected. Concurrent connection attempts during editor restart raced on `~/.bun/install/cache` and one would error mid-extraction, killing the spawned process before it could complete the MCP handshake. Going through the installed binary path skips the package manager entirely: zero downloads, zero cache, zero race.
+
+**Fallback chain (each tier resolves to absolute path via `Bun.which`):**
+
+1. **`maina` binary** — preferred. No package manager spawn.
+2. **`bunx @mainahq/cli@<version> --mcp`** — version-pinned so the bunx cache hits reliably across spawns even on cold start.
+3. **`npx @mainahq/cli@<version> --mcp`** — universally available fallback.
+4. Bare `npx` last-resort fallback so the entry stays syntactically valid on machines without Bun or Node.
+
+When `mcp add` falls back to a package-manager invocation (no global install present), the CLI prints a one-line tip pointing at `bun install -g @mainahq/cli` so users can opt into the fastest path.
+
+5 new launcher tests lock in the priority order and the absolute-path contract. All existing apply tests continue to pass under the version-pinned shape.

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -15,6 +15,8 @@
 
 import { intro, log, outro } from "@clack/prompts";
 import {
+	detectLauncher,
+	isDirectBinary,
 	type ListEntry,
 	listClientIds,
 	type McpClientId,
@@ -205,6 +207,14 @@ export function mcpCommand(): Command {
 			return;
 		}
 		emitAddReport(result.report ?? { results: [], skipped: [] });
+		// If we wrote a package-manager invocation (bunx/npx) instead of the
+		// installed maina binary, suggest a one-time global install. Avoids
+		// the bunx-on-every-spawn cost + cache races on cold start.
+		if (!isDirectBinary(detectLauncher())) {
+			log.info(
+				"Tip: install maina globally for faster, more reliable MCP startup:\n  bun install -g @mainahq/cli   (or  npm install -g @mainahq/cli)\nThen rerun `maina mcp add`.",
+			);
+		}
 		outro("Done.");
 	});
 

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -212,7 +212,7 @@ export function mcpCommand(): Command {
 		// the bunx-on-every-spawn cost + cache races on cold start.
 		if (!isDirectBinary(detectLauncher())) {
 			log.info(
-				"Tip: install maina globally for faster, more reliable MCP startup:\n  bun install -g @mainahq/cli   (or  npm install -g @mainahq/cli)\nThen rerun `maina mcp add`.",
+				"Tip: install maina globally for faster, more reliable MCP startup:\n  bun install -g @mainahq/cli   (or npm install -g @mainahq/cli)\nThen rerun `maina mcp add`.",
 			);
 		}
 		outro("Done.");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -264,6 +264,12 @@ export {
 	runList,
 	runRemove,
 } from "./mcp/index";
+export {
+	detectLauncher,
+	isDirectBinary,
+	type Launcher,
+	resetLauncherCache,
+} from "./mcp/launcher";
 export { loadDefault, type PromptTask } from "./prompts/defaults/index";
 // Prompts
 export {

--- a/packages/core/src/mcp/__tests__/apply.test.ts
+++ b/packages/core/src/mcp/__tests__/apply.test.ts
@@ -18,9 +18,12 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as toml from "@iarna/toml";
+import { version as PKG_VERSION } from "../../../package.json";
 import { addOnClient, inspectClient, removeFromClient } from "../apply";
 import { buildClientRegistry } from "../clients";
 import { detectLauncher, resetLauncherCache } from "../launcher";
+
+const PINNED_PKG = `@mainahq/cli@${PKG_VERSION}`;
 
 let HOME: string;
 
@@ -61,7 +64,7 @@ describe("addOnClient — JSON object shape (Cursor, Claude, etc.)", () => {
 		const json = readJson(path);
 		expect((json.mcpServers as Record<string, unknown>).maina).toEqual({
 			command: "npx",
-			args: ["@mainahq/cli", "--mcp"],
+			args: [PINNED_PKG, "--mcp"],
 		});
 	});
 
@@ -201,7 +204,7 @@ describe("addOnClient — TOML shape (Codex)", () => {
 		const section = (parsed.mcp_servers as Record<string, unknown>)
 			.maina as Record<string, unknown>;
 		expect(section.command).toBe("npx");
-		expect(section.args).toEqual(["@mainahq/cli", "--mcp"]);
+		expect(section.args).toEqual([PINNED_PKG, "--mcp"]);
 	});
 
 	test("preserves other TOML sections", async () => {

--- a/packages/core/src/mcp/__tests__/apply.test.ts
+++ b/packages/core/src/mcp/__tests__/apply.test.ts
@@ -18,12 +18,12 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as toml from "@iarna/toml";
-import { version as PKG_VERSION } from "../../../package.json";
+import pkg from "../../../package.json";
 import { addOnClient, inspectClient, removeFromClient } from "../apply";
 import { buildClientRegistry } from "../clients";
 import { detectLauncher, resetLauncherCache } from "../launcher";
 
-const PINNED_PKG = `@mainahq/cli@${PKG_VERSION}`;
+const PINNED_PKG = `@mainahq/cli@${pkg.version}`;
 
 let HOME: string;
 

--- a/packages/core/src/mcp/__tests__/launcher.test.ts
+++ b/packages/core/src/mcp/__tests__/launcher.test.ts
@@ -3,60 +3,87 @@
  * deterministic regardless of the runner machine's PATH (CI doesn't
  * have Bun installed by default; the developer's machine does).
  *
- * The most important behaviour this file locks down: the launcher's
- * `command` field is the **absolute resolved path** from `which`, not
- * the bare binary name. GUI MCP clients (Cursor, Zed, etc.) inherit
- * a stripped PATH on macOS and fail with `spawn bunx ENOENT` when given
- * a bare command. Resolving the path at install time fixes that.
+ * Two real bugs this file locks down regression tests for:
+ *
+ *   1. **Stripped GUI PATH**: launcher must use the absolute resolved
+ *      path from `which`, not the bare binary name. Cursor/Zed spawn
+ *      with stripped PATH and ENOENT on bare commands.
+ *
+ *   2. **bunx cache races**: prefer the installed `maina` binary over
+ *      bunx. When falling back to bunx/npx, pin the package version so
+ *      the package manager hits its cache reliably across spawns.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { detectLauncher, resetLauncherCache } from "../launcher";
+import { version as PKG_VERSION } from "../../../package.json";
+import {
+	detectLauncher,
+	isDirectBinary,
+	resetLauncherCache,
+} from "../launcher";
 
 afterEach(() => {
 	resetLauncherCache();
 });
 
-describe("detectLauncher — path resolution", () => {
-	test("returns the ABSOLUTE bunx path (not the bare name) when Bun is on PATH", () => {
+describe("detectLauncher — priority order", () => {
+	test("prefers installed maina binary over bunx (avoids cache race entirely)", () => {
+		const l = detectLauncher({
+			which: (cmd) => {
+				if (cmd === "maina") return "/Users/x/.bun/bin/maina";
+				if (cmd === "bunx") return "/opt/homebrew/bin/bunx";
+				return null;
+			},
+			noCache: true,
+		});
+		expect(l.command).toBe("/Users/x/.bun/bin/maina");
+		expect(l.args).toEqual(["--mcp"]);
+		expect(isDirectBinary(l)).toBe(true);
+	});
+
+	test("falls back to bunx with pinned version when maina binary is absent", () => {
 		const l = detectLauncher({
 			which: (cmd) => (cmd === "bunx" ? "/opt/homebrew/bin/bunx" : null),
 			noCache: true,
 		});
-		// Critical regression test: must be the absolute path so Cursor's
-		// stripped-PATH spawn doesn't ENOENT.
 		expect(l.command).toBe("/opt/homebrew/bin/bunx");
-		expect(l.command).not.toBe("bunx");
-		expect(l.args).toEqual(["@mainahq/cli", "--mcp"]);
+		expect(l.args).toEqual([`@mainahq/cli@${PKG_VERSION}`, "--mcp"]);
+		expect(isDirectBinary(l)).toBe(false);
 	});
 
-	test("returns the ABSOLUTE npx path when bunx is missing but npx exists", () => {
+	test("falls back to npx with pinned version when maina + bunx absent", () => {
 		const l = detectLauncher({
 			which: (cmd) => (cmd === "npx" ? "/usr/local/bin/npx" : null),
 			noCache: true,
 		});
 		expect(l.command).toBe("/usr/local/bin/npx");
-		expect(l.command).not.toBe("npx");
+		expect(l.args).toEqual([`@mainahq/cli@${PKG_VERSION}`, "--mcp"]);
 	});
 
-	test("prefers bunx over npx when both are on PATH", () => {
+	test("emits bare `npx` last-resort fallback when nothing resolves", () => {
+		const l = detectLauncher({ which: () => null, noCache: true });
+		expect(l.command).toBe("npx");
+		expect(l.args).toEqual([`@mainahq/cli@${PKG_VERSION}`, "--mcp"]);
+	});
+});
+
+describe("detectLauncher — absolute path contract (Cursor ENOENT regression)", () => {
+	test("maina path is absolute, never bare", () => {
 		const l = detectLauncher({
-			which: (cmd) => {
-				if (cmd === "bunx") return "/opt/homebrew/bin/bunx";
-				if (cmd === "npx") return "/usr/local/bin/npx";
-				return null;
-			},
+			which: (cmd) => (cmd === "maina" ? "/Users/x/.bun/bin/maina" : null),
+			noCache: true,
+		});
+		expect(l.command).toBe("/Users/x/.bun/bin/maina");
+		expect(l.command).not.toBe("maina");
+	});
+
+	test("bunx path is absolute, never bare", () => {
+		const l = detectLauncher({
+			which: (cmd) => (cmd === "bunx" ? "/opt/homebrew/bin/bunx" : null),
 			noCache: true,
 		});
 		expect(l.command).toBe("/opt/homebrew/bin/bunx");
-	});
-
-	test("falls back to bare `npx` when nothing resolves (entry stays syntactically valid)", () => {
-		const l = detectLauncher({
-			which: () => null,
-			noCache: true,
-		});
-		expect(l.command).toBe("npx");
+		expect(l.command).not.toBe("bunx");
 	});
 });
 
@@ -65,36 +92,46 @@ describe("detectLauncher — caching", () => {
 		let calls = 0;
 		const which = (cmd: string) => {
 			calls++;
-			return cmd === "bunx" ? "/opt/homebrew/bin/bunx" : null;
+			return cmd === "maina" ? "/x/maina" : null;
 		};
 		detectLauncher({ which });
 		detectLauncher({ which });
 		detectLauncher({ which });
-		// First call probed both bunx and npx (bunx hit, but the loop also
-		// records npx miss before the cache is set). Subsequent calls
-		// returned cache. So calls is bounded by 2 (first call only).
-		expect(calls).toBeLessThanOrEqual(2);
+		// Bounded: first call probes maina (hit, short-circuits). Subsequent
+		// calls return cache. So calls should be 1 (just the maina probe).
+		expect(calls).toBe(1);
 	});
 
 	test("noCache=true bypasses the cache", () => {
 		let calls = 0;
 		const which = (cmd: string) => {
 			calls++;
-			return cmd === "bunx" ? "/x/bunx" : null;
+			return cmd === "maina" ? "/x/maina" : null;
 		};
 		detectLauncher({ which, noCache: true });
 		detectLauncher({ which, noCache: true });
-		// Each call probes bunx (and possibly npx). Bounded by 4 (2 calls × 2 probes).
-		expect(calls).toBeGreaterThanOrEqual(2);
-		expect(calls).toBeLessThanOrEqual(4);
+		expect(calls).toBe(2);
 	});
 
 	test("resetLauncherCache forces re-detection on next call", () => {
-		detectLauncher({ which: () => "/x/bunx" });
+		detectLauncher({ which: () => "/x/maina" });
 		// Cached value used even with a different which.
-		expect(detectLauncher({ which: () => null }).command).toBe("/x/bunx");
+		expect(detectLauncher({ which: () => null }).command).toBe("/x/maina");
 
 		resetLauncherCache();
+		// Re-probes; nothing on PATH so emits bare npx fallback.
 		expect(detectLauncher({ which: () => null }).command).toBe("npx");
+	});
+});
+
+describe("isDirectBinary helper", () => {
+	test("true for direct binary, false for package-manager invocation", () => {
+		expect(isDirectBinary({ command: "/x/maina", args: ["--mcp"] })).toBe(true);
+		expect(
+			isDirectBinary({
+				command: "/x/bunx",
+				args: ["@mainahq/cli@1.0.0", "--mcp"],
+			}),
+		).toBe(false);
 	});
 });

--- a/packages/core/src/mcp/__tests__/launcher.test.ts
+++ b/packages/core/src/mcp/__tests__/launcher.test.ts
@@ -15,12 +15,14 @@
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { version as PKG_VERSION } from "../../../package.json";
+import pkg from "../../../package.json";
 import {
 	detectLauncher,
 	isDirectBinary,
 	resetLauncherCache,
 } from "../launcher";
+
+const PKG_VERSION = pkg.version;
 
 afterEach(() => {
 	resetLauncherCache();

--- a/packages/core/src/mcp/launcher.ts
+++ b/packages/core/src/mcp/launcher.ts
@@ -1,33 +1,45 @@
 /**
  * Pick the launcher used in MCP client configs.
  *
- * Three concerns this module gets right at install time:
+ * Priority order, each preferring the most-reliable option:
  *
- *   1. Prefer `bunx` when available (5-10× faster startup), `npx` as the
- *      universally-available fallback.
+ *   1. **Installed `maina` binary** (e.g. `/Users/x/.bun/bin/maina`) —
+ *      best by far. No package-manager spawn on every MCP request, no
+ *      cold-start download, no Bun cache race when multiple MCP clients
+ *      spawn the server concurrently. Requires the user to have run
+ *      `bun install -g @mainahq/cli` (or `npm i -g`).
  *
- *   2. Write the **absolute resolved path** of the launcher into the
- *      config — not the bare binary name. GUI-launched AI clients
- *      (Cursor, Claude Code, Zed, etc.) inherit a stripped PATH on macOS
- *      that does NOT include `/opt/homebrew/bin` or `~/.bun/bin`, so a
- *      bare `command: "bunx"` produces `spawn bunx ENOENT` even though
- *      the binary is installed for the user. Resolving via `Bun.which`
- *      gives us the full path the OS will actually find.
+ *   2. **`bunx` with a pinned version** (e.g. `bunx @mainahq/cli@1.4.3
+ *      --mcp`). 5-10× faster than `npx`, and the version pin lets `bunx`
+ *      hit its cache more reliably on subsequent spawns.
  *
- *   3. Cache the detection so each install round-trip probes PATH at
- *      most once. Tests inject a fake `which` to keep snapshots stable.
+ *   3. **`npx` with a pinned version** — universally available.
  *
- * Real-world signal that drove this: cursor MCP logs showed
- * `Connection failed: spawn bunx ENOENT` repeatedly against an entry
- * we wrote with bare `bunx`. Switching to the absolute path fixes it.
+ *   4. Bare `npx` last-resort fallback so the entry stays syntactically
+ *      valid even on a machine with neither bun nor node.
+ *
+ * Two real bugs this module dodges:
+ *
+ *   - **Stripped GUI PATH on macOS.** Cursor / Zed / Claude Code desktop
+ *     spawn subprocesses with a PATH that does NOT include
+ *     `/opt/homebrew/bin` or `~/.bun/bin`. We resolve to the absolute
+ *     path via `Bun.which` so spawning never ENOENTs.
+ *
+ *   - **bunx cache races on cold start.** Concurrent MCP-server spawns
+ *     from a single editor restart hit the same `~/.bun/install/cache`
+ *     and one of them errors with "failed copying files from cache to
+ *     destination for package X". Direct-binary launches dodge this
+ *     entirely; pinned-version `bunx` reduces the window.
  */
+
+import { version as PKG_VERSION } from "../../package.json";
 
 export interface Launcher {
 	command: string;
 	args: readonly string[];
 }
 
-const ARGS: readonly string[] = ["@mainahq/cli", "--mcp"];
+const PINNED_PACKAGE = `@mainahq/cli@${PKG_VERSION}`;
 
 export interface DetectLauncherOptions {
 	/**
@@ -46,21 +58,28 @@ export function detectLauncher(opts: DetectLauncherOptions = {}): Launcher {
 	if (cached !== null && opts.noCache !== true) return cached;
 
 	const which = opts.which ?? defaultWhich;
-	// Probe in preference order. Use the absolute resolved path when found
-	// so MCP clients with stripped spawn PATHs (Cursor, Zed, etc.) can
-	// actually find the binary.
-	const bunxPath = which("bunx");
-	const npxPath = which("npx");
+
+	// 1. Direct maina binary — fastest, no package manager involved.
+	const mainaPath = which("maina");
 	let result: Launcher;
-	if (bunxPath) {
-		result = { command: bunxPath, args: ARGS };
-	} else if (npxPath) {
-		result = { command: npxPath, args: ARGS };
+	if (mainaPath) {
+		result = { command: mainaPath, args: ["--mcp"] };
 	} else {
-		// Truly nothing on PATH. Fall back to bare `npx` so the entry is
-		// at least syntactically valid; the user can edit it after they
-		// install Node/Bun.
-		result = { command: "npx", args: ARGS };
+		// 2. bunx (preferred) or npx (fallback) — both with version pin so
+		//    the package manager hits its cache reliably across spawns.
+		const bunxPath = which("bunx");
+		if (bunxPath) {
+			result = { command: bunxPath, args: [PINNED_PACKAGE, "--mcp"] };
+		} else {
+			const npxPath = which("npx");
+			if (npxPath) {
+				result = { command: npxPath, args: [PINNED_PACKAGE, "--mcp"] };
+			} else {
+				// 3. Truly nothing on PATH. Emit a syntactically valid entry
+				//    that the user can edit after they install Node/Bun.
+				result = { command: "npx", args: [PINNED_PACKAGE, "--mcp"] };
+			}
+		}
 	}
 
 	if (opts.noCache !== true) cached = result;
@@ -70,6 +89,16 @@ export function detectLauncher(opts: DetectLauncherOptions = {}): Launcher {
 /** Reset the cached launcher detection. Tests use this between cases. */
 export function resetLauncherCache(): void {
 	cached = null;
+}
+
+/**
+ * Returns true if the launcher is the direct `maina` binary (preferred
+ * path), false if it's a package-manager invocation. CLI consumers use
+ * this to decide whether to print the "consider `bun install -g
+ * @mainahq/cli` for faster startup" tip after `mcp add`.
+ */
+export function isDirectBinary(launcher: Launcher): boolean {
+	return launcher.args.length === 1 && launcher.args[0] === "--mcp";
 }
 
 function defaultWhich(cmd: string): string | null {

--- a/packages/core/src/mcp/launcher.ts
+++ b/packages/core/src/mcp/launcher.ts
@@ -32,7 +32,9 @@
  *     entirely; pinned-version `bunx` reduces the window.
  */
 
-import { version as PKG_VERSION } from "../../package.json";
+import pkg from "../../package.json";
+
+const PKG_VERSION = pkg.version;
 
 export interface Launcher {
 	command: string;

--- a/packages/docs/src/content/docs/mcp.mdx
+++ b/packages/docs/src/content/docs/mcp.mdx
@@ -32,7 +32,13 @@ maina mcp list                         # show install status per client
 
 Supported clients: **Claude Code, Cursor, Windsurf, Cline, Codex CLI, Continue.dev, Gemini CLI, Zed**. The command preserves all other MCP servers and unrelated keys via an atomic merge — safe to run repeatedly.
 
-The launcher is auto-detected per machine: `bunx` when `bunx` is on `PATH` (typically when [Bun](https://bun.sh) is installed; 5-10× faster startup), `npx` otherwise (universally available via npm). All manual examples below use `npx` for portability — substitute `bunx` when available.
+The launcher is auto-detected per machine, in this priority order:
+
+1. **Direct `maina` binary** when `@mainahq/cli` is installed globally (`bun install -g @mainahq/cli` or `npm install -g @mainahq/cli`). Fastest by far — no package manager in the spawn path, no cold-start download, no cache races. **Recommended.**
+2. **`bunx @mainahq/cli@<version> --mcp`** when [Bun](https://bun.sh) is available.
+3. **`npx @mainahq/cli@<version> --mcp`** as the universal fallback.
+
+All paths are written as the absolute resolved binary location (`/opt/homebrew/bin/bunx`, `/Users/.../.bun/bin/maina`, etc.) so MCP clients with stripped-PATH spawn contexts (Cursor, Zed, Claude Code desktop) can find them. Manual examples below use `npx` for portability.
 
 The setup wizard (`maina setup`) also writes the project-scoped configs (`.mcp.json` and `.claude/settings.json`) for you, so most users won't need `maina mcp add` unless they want maina available in every project from any client.
 

--- a/packages/docs/src/content/docs/mcp.mdx
+++ b/packages/docs/src/content/docs/mcp.mdx
@@ -35,10 +35,11 @@ Supported clients: **Claude Code, Cursor, Windsurf, Cline, Codex CLI, Continue.d
 The launcher is auto-detected per machine, in this priority order:
 
 1. **Direct `maina` binary** when `@mainahq/cli` is installed globally (`bun install -g @mainahq/cli` or `npm install -g @mainahq/cli`). Fastest by far — no package manager in the spawn path, no cold-start download, no cache races. **Recommended.**
-2. **`bunx @mainahq/cli@<version> --mcp`** when [Bun](https://bun.sh) is available.
-3. **`npx @mainahq/cli@<version> --mcp`** as the universal fallback.
+2. **Resolved `bunx @mainahq/cli@<version> --mcp`** when [Bun](https://bun.sh) is available.
+3. **Resolved `npx @mainahq/cli@<version> --mcp`** as the universal fallback.
+4. **Bare `npx @mainahq/cli@<version> --mcp`** as the last-resort fallback when nothing else resolves on the install machine — entry stays syntactically valid; user can edit after installing Node or Bun.
 
-All paths are written as the absolute resolved binary location (`/opt/homebrew/bin/bunx`, `/Users/.../.bun/bin/maina`, etc.) so MCP clients with stripped-PATH spawn contexts (Cursor, Zed, Claude Code desktop) can find them. Manual examples below use `npx` for portability.
+Tiers 1-3 are written using the **absolute** resolved binary location (`/opt/homebrew/bin/bunx`, `/Users/.../.bun/bin/maina`, etc.) so MCP clients with stripped-PATH spawn contexts (Cursor, Zed, Claude Code desktop) can find them. Tier 4 is the only case where the bare command name is written. Manual examples below use `npx` for portability.
 
 The setup wizard (`maina setup`) also writes the project-scoped configs (`.mcp.json` and `.claude/settings.json`) for you, so most users won't need `maina mcp add` unless they want maina available in every project from any client.
 


### PR DESCRIPTION
## Summary

Real-world Cursor MCP logs against the v1.4.2 entry surfaced this failure:

```
[error] Resolved, downloaded and extracted [24]
[error] failed copying files from cache to destination for package drizzle-orm
[warning] Connection failed: MCP error -32000: Connection closed
[V2 FSM] connection:connect_failure: conn=connecting,auth=unknown -> conn=failed,auth=unknown
```

`bunx @mainahq/cli` was re-resolving the package on every Cursor (re)connect. Concurrent spawn attempts during editor restart raced on `~/.bun/install/cache` — one extracted mid-write, errored, killed the spawned process, MCP handshake never completed.

## Fix

`detectLauncher` now prefers the **installed `maina` binary** over `bunx`. When the user has run `bun install -g @mainahq/cli` (or npm equivalent), the MCP entry becomes:

```diff
- { "command": "/opt/homebrew/bin/bunx", "args": ["@mainahq/cli", "--mcp"] }
+ { "command": "/Users/x/.bun/bin/maina", "args": ["--mcp"] }
```

Zero package manager in the spawn path. Zero downloads. Zero cache races.

**New priority order:**

1. `maina` binary (absolute path) — preferred
2. `bunx @mainahq/cli@<version>` — version-pinned so cache hits work reliably
3. `npx @mainahq/cli@<version>` — universal fallback
4. bare `npx` last-resort fallback

`maina mcp add` now also prints a one-line tip when it had to fall back to bunx/npx, so users can opt into the fastest path.

## Test plan

- [x] **5 new launcher tests** lock in the priority order + absolute-path contract
- [x] All 26 mcp tests pass under the version-pinned apply shape
- [x] `bun run typecheck` clean; `bun run check` clean
- [x] Manual unblock against my own machine: `bun install -g @mainahq/cli` + manual config rewrite to `/Users/x/.bun/bin/maina --mcp` → Cursor logs no longer show ENOENT or cache extraction errors
- [ ] After publish: `bunx @mainahq/cli@1.4.3 mcp add`, restart Cursor, confirm clean connect

## Changeset

Patch bump for cli + core (next release will be **v1.4.3**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP launcher now prioritizes the installed `maina` binary when available, with fallbacks to `bunx` then `npx` using version-pinned package arguments
  * Added informational tip suggesting global `maina` installation for improved performance

* **Documentation**
  * Updated MCP launcher selection guidance to reflect new priority order

* **Tests**
  * Added launcher detection tests validating priority order and fallback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->