### PR TITLE
feat(core): add doc-claims verify tool to catch fabricated API signatures in markdown

### DIFF
--- a/.changeset/doc-claims-verify.md
+++ b/.changeset/doc-claims-verify.md
@@ -1,0 +1,23 @@
+---
+"@mainahq/cli": minor
+"@mainahq/core": minor
+---
+
+feat(verify): add doc-claims tool that catches fabricated API signatures in markdown
+
+New built-in verify tool that runs on changed `.md` / `.mdx` files. It parses
+fenced code blocks for `import` / `require` statements, resolves the module to
+the corresponding workspace package source, and emits a warning when a claimed
+symbol is not actually exported.
+
+Motivated by issue #180: a subagent asked to summarize a package's public API
+returned a narrative that mixed real exports with plausible-looking
+fabrications, and the fabrications shipped to docs (workkit#43, 20+ wrong API
+claims caught only by Copilot post-merge). This gate catches that class of
+slop before the docs ever land.
+
+v1 is mechanical (no LLM), diff-only, and intentionally scoped: external
+packages are skipped (no `node_modules` walk), member-access claims are not
+validated (requires type info), and `export *` re-exports are treated as
+wildcards. Severity is `warning` so users can tune via the noisy-rules
+preference before promoting to `error` in their constitution.

--- a/packages/core/src/verify/__tests__/doc-claims.test.ts
+++ b/packages/core/src/verify/__tests__/doc-claims.test.ts
@@ -255,4 +255,43 @@ describe("detectDocClaims", () => {
 		const result = await detectDocClaims(["guide.mdx"], { cwd: testDir });
 		expect(result.findings.length).toBe(1);
 	});
+
+	it("refuses to read paths that escape cwd via relative-import traversal", async () => {
+		// Hostile doc claims a relative import that climbs out of cwd. We
+		// must NOT produce findings (which would imply we read the
+		// out-of-tree target) AND must NOT throw.
+		const md = [
+			"```ts",
+			'import { x } from "../../../../etc/passwd";',
+			"```",
+		].join("\n");
+		writeFileSync(join(testDir, "hostile.md"), md);
+		const result = await detectDocClaims(["hostile.md"], { cwd: testDir });
+		expect(result.findings.length).toBe(0);
+	});
+
+	it("strips TS `type` / `typeof` modifiers from export list items", async () => {
+		// Source uses TS export-list type modifiers; the EXPORTED name is
+		// the identifier after the modifier, not the modifier itself.
+		writePackage(
+			"@local/pkg",
+			"export { type Foo, typeof Bar, Baz } from './internal';\n",
+		);
+		const md = [
+			"```ts",
+			'import { Foo, Bar, Baz } from "@local/pkg";',
+			"```",
+		].join("\n");
+		writeFileSync(join(testDir, "doc.md"), md);
+		const result = await detectDocClaims(["doc.md"], { cwd: testDir });
+		expect(result.findings.length).toBe(0);
+	});
+
+	it("recognises default-import identifiers containing `$` (e.g. `import $ from`)", async () => {
+		writePackage("@local/pkg", "export default function pkg() {}\n");
+		const md = ["```ts", 'import $ from "@local/pkg";', "```"].join("\n");
+		writeFileSync(join(testDir, "doc.md"), md);
+		const result = await detectDocClaims(["doc.md"], { cwd: testDir });
+		expect(result.findings.length).toBe(0);
+	});
 });

--- a/packages/core/src/verify/__tests__/doc-claims.test.ts
+++ b/packages/core/src/verify/__tests__/doc-claims.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for the doc-claims verify tool.
+ *
+ * Validates that import/require lines in markdown docs reference symbols
+ * that actually exist in the resolved package source. Catches the class of
+ * bug where a subagent fabricates plausible-looking exports in a doc draft
+ * (the workkit#43 → maina#180 incident).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { detectDocClaims, extractMarkdownImports } from "../tools/doc-claims";
+
+describe("extractMarkdownImports", () => {
+	it("returns nothing for empty markdown", () => {
+		expect(extractMarkdownImports("", "doc.md")).toEqual([]);
+	});
+
+	it("ignores prose without code blocks", () => {
+		const md = "# Title\n\nJust some prose about `Foo.bar()`.\n";
+		expect(extractMarkdownImports(md, "doc.md")).toEqual([]);
+	});
+
+	it("extracts named imports inside fenced code blocks", () => {
+		const md = [
+			"# Guide",
+			"",
+			"```ts",
+			'import { Foo, Bar } from "@local/pkg";',
+			"```",
+			"",
+		].join("\n");
+
+		const imports = extractMarkdownImports(md, "doc.md");
+		expect(imports.length).toBe(1);
+		expect(imports[0]?.module).toBe("@local/pkg");
+		expect(imports[0]?.symbols.sort()).toEqual(["Bar", "Foo"]);
+		// Line numbers are 1-based and point to the import statement
+		expect(imports[0]?.line).toBe(4);
+	});
+
+	it("extracts default imports", () => {
+		const md = ["```ts", 'import lodash from "lodash";', "```"].join("\n");
+		const imports = extractMarkdownImports(md, "doc.md");
+		expect(imports[0]?.module).toBe("lodash");
+		// Default imports register as "default" — that's the export key consumers
+		// must validate against on the source side.
+		expect(imports[0]?.symbols).toEqual(["default"]);
+	});
+
+	it("extracts dynamic import() / require() forms", () => {
+		const md = [
+			"```ts",
+			'const x = require("./foo");',
+			'const y = await import("./bar");',
+			"```",
+		].join("\n");
+		const imports = extractMarkdownImports(md, "doc.md");
+		const modules = imports.map((i) => i.module).sort();
+		expect(modules).toEqual(["./bar", "./foo"]);
+	});
+});
+
+describe("detectDocClaims", () => {
+	let testDir: string;
+
+	beforeEach(() => {
+		testDir = join(
+			tmpdir(),
+			`maina-doc-claims-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		mkdirSync(testDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(testDir, { recursive: true, force: true });
+	});
+
+	function writePackage(
+		name: string,
+		exportsContent: string,
+		dirName?: string,
+	): void {
+		const pkgDir = join(testDir, "packages", dirName ?? name);
+		mkdirSync(join(pkgDir, "src"), { recursive: true });
+		writeFileSync(
+			join(pkgDir, "package.json"),
+			JSON.stringify({ name, main: "src/index.ts" }),
+		);
+		writeFileSync(join(pkgDir, "src", "index.ts"), exportsContent);
+	}
+
+	it("returns no findings for an empty markdown file", async () => {
+		writeFileSync(join(testDir, "doc.md"), "");
+		const result = await detectDocClaims(["doc.md"], { cwd: testDir });
+		expect(result.findings).toEqual([]);
+	});
+
+	it("skips non-markdown files silently", async () => {
+		writeFileSync(join(testDir, "code.ts"), 'import { foo } from "missing";');
+		const result = await detectDocClaims(["code.ts"], { cwd: testDir });
+		expect(result.findings).toEqual([]);
+	});
+
+	it("does not flag valid imports against an existing workspace package", async () => {
+		writePackage("@local/pkg", "export const realExport = 1;\n");
+
+		const md = [
+			"```ts",
+			'import { realExport } from "@local/pkg";',
+			"```",
+			"",
+		].join("\n");
+		writeFileSync(join(testDir, "doc.md"), md);
+
+		const result = await detectDocClaims(["doc.md"], { cwd: testDir });
+		expect(result.findings).toEqual([]);
+	});
+
+	it("flags a fabricated symbol from a workspace package", async () => {
+		writePackage("@local/pkg", "export const realExport = 1;\n");
+
+		const md = [
+			"```ts",
+			'import { fabricated } from "@local/pkg";',
+			"```",
+			"",
+		].join("\n");
+		writeFileSync(join(testDir, "doc.md"), md);
+
+		const result = await detectDocClaims(["doc.md"], { cwd: testDir });
+		expect(result.findings.length).toBe(1);
+		const finding = result.findings[0];
+		expect(finding?.tool).toBe("doc-claims");
+		expect(finding?.severity).toBe("warning");
+		expect(finding?.ruleId).toBe("doc-claims/missing-export");
+		expect(finding?.file).toBe("doc.md");
+		// Line points to the `import` line inside the fence (line 2)
+		expect(finding?.line).toBe(2);
+		expect(finding?.message).toContain("fabricated");
+		expect(finding?.message).toContain("@local/pkg");
+	});
+
+	it("resolves @workkit/<name> to packages/<name>/src/index.ts", async () => {
+		writePackage(
+			"@workkit/memory",
+			"export class Conversation { get() {} }\nexport function generateKey() {}\n",
+			"memory",
+		);
+
+		const md = [
+			"```ts",
+			'import { Conversation, fabricatedHelper } from "@workkit/memory";',
+			"```",
+		].join("\n");
+		writeFileSync(join(testDir, "doc.md"), md);
+
+		const result = await detectDocClaims(["doc.md"], { cwd: testDir });
+		expect(result.findings.length).toBe(1);
+		expect(result.findings[0]?.message).toContain("fabricatedHelper");
+	});
+
+	it("recognises re-exports (export { x } from ...)", async () => {
+		// Inner module
+		const pkgDir = join(testDir, "packages", "pkg");
+		mkdirSync(join(pkgDir, "src"), { recursive: true });
+		writeFileSync(
+			join(pkgDir, "package.json"),
+			JSON.stringify({ name: "@local/pkg", main: "src/index.ts" }),
+		);
+		writeFileSync(
+			join(pkgDir, "src", "inner.ts"),
+			"export const reExportedThing = 1;\n",
+		);
+		writeFileSync(
+			join(pkgDir, "src", "index.ts"),
+			'export { reExportedThing } from "./inner";\n',
+		);
+
+		const md = [
+			"```ts",
+			'import { reExportedThing } from "@local/pkg";',
+			"```",
+		].join("\n");
+		writeFileSync(join(testDir, "doc.md"), md);
+
+		const result = await detectDocClaims(["doc.md"], { cwd: testDir });
+		expect(result.findings).toEqual([]);
+	});
+
+	it("skips external packages silently when not resolvable", async () => {
+		// No @local/anything written — looks like external
+		const md = [
+			"```ts",
+			'import { useState } from "react";',
+			'import { debounce } from "lodash";',
+			"```",
+		].join("\n");
+		writeFileSync(join(testDir, "doc.md"), md);
+
+		const result = await detectDocClaims(["doc.md"], { cwd: testDir });
+		expect(result.findings).toEqual([]);
+	});
+
+	it("handles fenced blocks without language hints", async () => {
+		writePackage("@local/pkg", "export const realExport = 1;\n");
+		const md = [
+			"```",
+			'import { realExport, ghost } from "@local/pkg";',
+			"```",
+		].join("\n");
+		writeFileSync(join(testDir, "doc.md"), md);
+
+		const result = await detectDocClaims(["doc.md"], { cwd: testDir });
+		expect(result.findings.length).toBe(1);
+		expect(result.findings[0]?.message).toContain("ghost");
+	});
+
+	it("returns empty findings when given no files", async () => {
+		const result = await detectDocClaims([], { cwd: testDir });
+		expect(result.findings).toEqual([]);
+	});
+
+	it("skips files that do not exist (does not throw)", async () => {
+		const result = await detectDocClaims(["nonexistent.md"], { cwd: testDir });
+		expect(result.findings).toEqual([]);
+	});
+
+	it("flags multiple fabricated symbols separately", async () => {
+		writePackage("@local/pkg", "export const real = 1;\n");
+		const md = [
+			"```ts",
+			'import { real, ghost1, ghost2 } from "@local/pkg";',
+			"```",
+		].join("\n");
+		writeFileSync(join(testDir, "doc.md"), md);
+
+		const result = await detectDocClaims(["doc.md"], { cwd: testDir });
+		expect(result.findings.length).toBe(2);
+		const messages = result.findings.map((f) => f.message).join(" ");
+		expect(messages).toContain("ghost1");
+		expect(messages).toContain("ghost2");
+	});
+
+	it("treats .mdx files the same as .md", async () => {
+		writePackage("@local/pkg", "export const real = 1;\n");
+		const md = ["```ts", 'import { fakeOne } from "@local/pkg";', "```"].join(
+			"\n",
+		);
+		writeFileSync(join(testDir, "guide.mdx"), md);
+
+		const result = await detectDocClaims(["guide.mdx"], { cwd: testDir });
+		expect(result.findings.length).toBe(1);
+	});
+});

--- a/packages/core/src/verify/__tests__/pipeline.test.ts
+++ b/packages/core/src/verify/__tests__/pipeline.test.ts
@@ -272,8 +272,8 @@ describe("VerifyPipeline", () => {
 		expect(callOrder).toContain("runTrivy");
 		expect(callOrder).toContain("runSecretlint");
 
-		// 12 tool reports (slop + semgrep + trivy + secretlint + sonarqube + stryker + diff-cover + typecheck + consistency + builtin + ai-review + wiki-lint)
-		expect(result.tools).toHaveLength(12);
+		// 13 tool reports (slop + doc-claims + semgrep + trivy + secretlint + sonarqube + stryker + diff-cover + typecheck + consistency + builtin + ai-review + wiki-lint)
+		expect(result.tools).toHaveLength(13);
 		expect(result.findings).toHaveLength(3);
 	});
 

--- a/packages/core/src/verify/pipeline.ts
+++ b/packages/core/src/verify/pipeline.ts
@@ -33,6 +33,7 @@ import { detectSlop } from "./slop";
 import { runSonar } from "./sonar";
 import type { SyntaxDiagnostic } from "./syntax-guard";
 import { syntaxGuard } from "./syntax-guard";
+import { detectDocClaims } from "./tools/doc-claims";
 import { runWikiLintTool } from "./tools/wiki-lint-runner";
 import { runTrivy } from "./trivy";
 import { runTypecheck } from "./typecheck";
@@ -168,6 +169,16 @@ export async function runPipeline(
 		}),
 	);
 
+	// Doc-claims — verifies that import statements in changed markdown docs
+	// reference symbols actually exported by the resolved package source.
+	// Mechanical, no LLM. See packages/core/src/verify/tools/doc-claims.ts.
+	toolPromises.push(
+		runToolWithTiming("doc-claims", async () => {
+			const result = await detectDocClaims(files, { cwd });
+			return { findings: result.findings, skipped: false };
+		}),
+	);
+
 	// Semgrep — pass pre-resolved availability
 	toolPromises.push(
 		runToolWithTiming("semgrep", () =>
@@ -273,6 +284,7 @@ export async function runPipeline(
 		"consistency",
 		"builtin",
 		"wiki-lint",
+		"doc-claims",
 	]);
 	const externalTools = toolReports.filter((r) => !builtInTools.has(r.tool));
 	const allExternalSkipped =

--- a/packages/core/src/verify/tools/doc-claims.ts
+++ b/packages/core/src/verify/tools/doc-claims.ts
@@ -36,7 +36,7 @@
  */
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { dirname, isAbsolute, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 import type { Finding } from "../diff-filter";
 
@@ -45,7 +45,13 @@ import type { Finding } from "../diff-filter";
 export interface DocImport {
 	/** Module specifier as written in the doc (`@workkit/memory`, `./foo`, `react`). */
 	module: string;
-	/** Named symbols imported. For default imports we use the local name. */
+	/**
+	 * Imported export keys to validate against the resolved source. Default
+	 * imports are recorded as the literal string `"default"` (matching what
+	 * `export default` produces in `collectExports`), not the local binding
+	 * name in the doc — the local name is irrelevant to whether the source
+	 * actually exports a default.
+	 */
 	symbols: string[];
 	/** 1-based line number within the markdown file pointing at the import. */
 	line: number;
@@ -131,17 +137,23 @@ function parseNamedImport(
 	return { module: m[2] ?? "", symbols };
 }
 
-/** Match `import Foo from "mod";`. */
+/** Match `import Foo from "mod";`. Identifier may include `$` (e.g. `import $ from "lodash"`). */
 function parseDefaultImport(
 	line: string,
 ): { module: string; symbols: string[] } | null {
-	const re = /import\s+(\w+)\s+from\s*["']([^"']+)["']/;
+	const re = /import\s+([A-Za-z_$][\w$]*)\s+from\s*["']([^"']+)["']/;
 	const m = re.exec(line);
 	if (!m) return null;
 	return { module: m[2] ?? "", symbols: ["default"] };
 }
 
-/** Match `require("mod")` or `import("mod")`. No symbol claims, just module. */
+/**
+ * Match `require("mod")` or `import("mod")`. We DO NOT extract destructured
+ * symbols (e.g. `const { foo } = require("mod")`) — those are validated only
+ * if the doc also has an explicit ES `import` form. The bare module access
+ * still records the module so future iterations can verify the package
+ * resolves; today the empty `symbols` array short-circuits validation.
+ */
 function parseDynamicImport(
 	line: string,
 ): { module: string; symbols: string[] } | null {
@@ -157,18 +169,30 @@ function parseDynamicImport(
  * Try to resolve a module specifier to an absolute source-file path inside
  * the workspace. Returns null when the specifier looks external (npm) or
  * cannot be resolved — caller treats that as "skip".
+ *
+ * Pass a `pkgIndex` Map to memoize the (potentially expensive) workspace
+ * package scan across many imports in one verify run.
  */
 function resolveWorkspaceModule(
 	specifier: string,
 	docFile: string,
 	cwd: string,
+	pkgIndex?: Map<string, string>,
 ): string | null {
-	// Relative imports — resolve against doc directory
+	// Relative imports — resolve against doc directory, then guard against
+	// path traversal: a hostile doc could write a relative specifier that
+	// climbs out of the workspace root, and we should refuse to read it.
 	if (specifier.startsWith(".")) {
 		const docDir = dirname(
 			isAbsolute(docFile) ? docFile : resolve(cwd, docFile),
 		);
 		const base = resolve(docDir, specifier);
+		const cwdAbs = resolve(cwd);
+		const rel = relative(cwdAbs, base);
+		if (rel.startsWith("..") || isAbsolute(rel)) {
+			// Escape attempt; treat as unresolvable.
+			return null;
+		}
 		return firstExisting([
 			base,
 			`${base}.ts`,
@@ -180,8 +204,12 @@ function resolveWorkspaceModule(
 		]);
 	}
 
-	// Workspace package by scanning packages/*. Walks one level deep, plus
-	// one extra level for scoped layouts (`packages/@scope/name`).
+	// Workspace package — use the memoized index when provided, else scan.
+	if (pkgIndex !== undefined) {
+		const cached = pkgIndex.get(specifier);
+		return cached ?? null;
+	}
+
 	const packagesRoot = join(cwd, "packages");
 	if (!existsSync(packagesRoot)) return null;
 
@@ -308,13 +336,17 @@ function collectExports(source: string): Set<string> {
 		if (m[1]) exports.add(m[1]);
 	}
 
-	// `export { A, B as C, default as D }` — possibly with `from "..."`
-	const listRe = /\bexport\s*\{([^}]+)\}/g;
+	// `export { A, B as C, default as D, type Foo, typeof Bar }` — possibly with `from "..."`.
+	// TS lets each list item carry an optional `type ` or `typeof ` modifier; the
+	// exported NAME is the identifier after that modifier, not the modifier itself.
+	const listRe = /\bexport\s+(?:type\s+)?\{([^}]+)\}/g;
 	for (const m of stripped.matchAll(listRe)) {
 		const list = m[1] ?? "";
 		for (const raw of list.split(",")) {
-			const item = raw.trim();
+			let item = raw.trim();
 			if (!item) continue;
+			// Strip a leading `type ` or `typeof ` modifier on the item itself.
+			item = item.replace(/^(?:type|typeof)\s+/, "");
 			// `X as Y` — the EXPORTED name is Y (what consumers import).
 			const aliasIdx = item.toLowerCase().indexOf(" as ");
 			const exported = aliasIdx === -1 ? item : item.slice(aliasIdx + 4).trim();
@@ -323,6 +355,43 @@ function collectExports(source: string): Set<string> {
 	}
 
 	return exports;
+}
+
+/**
+ * Build a one-shot index of `package.json#name` → resolved entrypoint path
+ * for every workspace package under `<cwd>/packages`. Used by
+ * `detectDocClaims` so we scan the filesystem ONCE per verify run instead
+ * of once per import in the changed docs.
+ */
+function buildPackageIndex(cwd: string): Map<string, string> {
+	const idx = new Map<string, string>();
+	const packagesRoot = join(cwd, "packages");
+	if (!existsSync(packagesRoot)) return idx;
+
+	for (const pkgDir of collectPackageDirs(packagesRoot)) {
+		const pkgJsonPath = join(pkgDir, "package.json");
+		if (!existsSync(pkgJsonPath)) continue;
+		let pkgJson: { name?: string; main?: string; module?: string };
+		try {
+			pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+		} catch {
+			continue;
+		}
+		if (!pkgJson.name) continue;
+		const main = pkgJson.module ?? pkgJson.main ?? "src/index.ts";
+		const candidate = resolve(pkgDir, main);
+		const found = firstExisting([
+			candidate,
+			`${candidate}.ts`,
+			`${candidate}.tsx`,
+			`${candidate}.js`,
+			join(candidate, "index.ts"),
+			join(candidate, "index.tsx"),
+			join(candidate, "index.js"),
+		]);
+		if (found) idx.set(pkgJson.name, found);
+	}
+	return idx;
 }
 
 // ─── Main entry point ─────────────────────────────────────────────────────
@@ -339,6 +408,9 @@ export async function detectDocClaims(
 ): Promise<DocClaimsResult> {
 	const { cwd } = options;
 	const findings: Finding[] = [];
+	// One-shot scan of workspace packages so each import resolves in O(1)
+	// instead of O(packages × imports).
+	const pkgIndex = buildPackageIndex(cwd);
 
 	for (const file of files) {
 		if (!isMarkdown(file)) continue;
@@ -355,7 +427,7 @@ export async function detectDocClaims(
 		for (const imp of imports) {
 			if (imp.symbols.length === 0) continue; // dynamic import with no symbol claim
 
-			const resolved = resolveWorkspaceModule(imp.module, file, cwd);
+			const resolved = resolveWorkspaceModule(imp.module, file, cwd, pkgIndex);
 			// External / unresolved → skip silently (documented limitation).
 			if (!resolved) continue;
 

--- a/packages/core/src/verify/tools/doc-claims.ts
+++ b/packages/core/src/verify/tools/doc-claims.ts
@@ -1,0 +1,393 @@
+/**
+ * Doc Claims Verifier — catches fabricated API signatures in markdown.
+ *
+ * Real-world bug this prevents (issue #180): a subagent asked to "summarize the
+ * public API surface" of a workspace package returned a narrative that mixed
+ * real exports with plausible-looking fabrications. The fabrications shipped to
+ * docs because no verification gate compared the doc claims against source.
+ *
+ * Strategy (mechanical, no LLM):
+ *   1. Run only on changed `.md` / `.mdx` files (diff-only filter, applied by
+ *      the pipeline, narrows further).
+ *   2. Parse fenced code blocks; extract `import` and `require` statements with
+ *      their named/default symbols.
+ *   3. Resolve the module specifier to a file on disk:
+ *      - relative paths resolve against the markdown file's directory
+ *      - workspace paths (`@scope/name`, `@local/name`, etc.) are resolved by
+ *        scanning `<cwd>/packages/*` for a matching `package.json#name`
+ *      - everything else is treated as external and skipped (we cannot verify
+ *        node_modules without walking them, which is out of scope for v1)
+ *   4. Read the resolved source; collect every top-level exported identifier
+ *      (direct exports, `export { ... }` lists, `export { x } from ...`
+ *      re-exports, namespace re-exports `export * from ...`).
+ *   5. For each claimed symbol that is not in the export set, emit a warning
+ *      finding pointing at the import line.
+ *
+ * Limitations (deliberate, documented for v1):
+ *   - External packages (`react`, `lodash`, npm) are skipped — we do not walk
+ *     `node_modules`.
+ *   - Member-access checks (`obj.method()`) are NOT validated — that requires
+ *     type information; out of scope for v1.
+ *   - `export *` re-exports are accepted as a wildcard (we do not recursively
+ *     enumerate the re-exported file). This trades precision for fewer false
+ *     positives in v1.
+ *   - Severity is `warning`, not `error`. Users may promote it via a
+ *     constitution rule once the false-positive rate is well understood.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+import type { Finding } from "../diff-filter";
+
+// ─── Types ────────────────────────────────────────────────────────────────
+
+export interface DocImport {
+	/** Module specifier as written in the doc (`@workkit/memory`, `./foo`, `react`). */
+	module: string;
+	/** Named symbols imported. For default imports we use the local name. */
+	symbols: string[];
+	/** 1-based line number within the markdown file pointing at the import. */
+	line: number;
+}
+
+export interface DocClaimsResult {
+	findings: Finding[];
+}
+
+interface DetectOptions {
+	cwd: string;
+}
+
+// ─── Markdown parsing ─────────────────────────────────────────────────────
+
+/**
+ * Extract import / require statements from fenced code blocks in markdown.
+ *
+ * Inline-prose imports (outside ``` fences) are intentionally ignored — they
+ * are usually narrative references, not concrete claims.
+ */
+export function extractMarkdownImports(
+	content: string,
+	_file: string,
+): DocImport[] {
+	const lines = content.split("\n");
+	const imports: DocImport[] = [];
+
+	let inFence = false;
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i] ?? "";
+		const trimmed = line.trim();
+
+		// Toggle fence on any ``` line. We do not require a language hint.
+		if (trimmed.startsWith("```")) {
+			inFence = !inFence;
+			continue;
+		}
+
+		if (!inFence) continue;
+
+		// 1-based line number
+		const lineNo = i + 1;
+
+		const namedImport = parseNamedImport(line);
+		if (namedImport) {
+			imports.push({ ...namedImport, line: lineNo });
+			continue;
+		}
+
+		const defaultImport = parseDefaultImport(line);
+		if (defaultImport) {
+			imports.push({ ...defaultImport, line: lineNo });
+			continue;
+		}
+
+		const dyn = parseDynamicImport(line);
+		if (dyn) {
+			imports.push({ ...dyn, line: lineNo });
+		}
+	}
+
+	return imports;
+}
+
+/** Match `import { A, B as C } from "mod";`. */
+function parseNamedImport(
+	line: string,
+): { module: string; symbols: string[] } | null {
+	const re = /import\s*(?:type\s+)?\{([^}]+)\}\s*from\s*["']([^"']+)["']/;
+	const m = re.exec(line);
+	if (!m) return null;
+	const symbols = (m[1] ?? "")
+		.split(",")
+		.map((s) => s.trim())
+		.filter(Boolean)
+		.map((s) => {
+			// Handle `Foo as Bar` — we care about the source name (Foo), since
+			// that is what the package must export.
+			const aliasIdx = s.toLowerCase().indexOf(" as ");
+			return aliasIdx === -1 ? s : s.slice(0, aliasIdx).trim();
+		});
+	return { module: m[2] ?? "", symbols };
+}
+
+/** Match `import Foo from "mod";`. */
+function parseDefaultImport(
+	line: string,
+): { module: string; symbols: string[] } | null {
+	const re = /import\s+(\w+)\s+from\s*["']([^"']+)["']/;
+	const m = re.exec(line);
+	if (!m) return null;
+	return { module: m[2] ?? "", symbols: ["default"] };
+}
+
+/** Match `require("mod")` or `import("mod")`. No symbol claims, just module. */
+function parseDynamicImport(
+	line: string,
+): { module: string; symbols: string[] } | null {
+	const re = /(?:require|import)\s*\(\s*["']([^"']+)["']\s*\)/;
+	const m = re.exec(line);
+	if (!m) return null;
+	return { module: m[1] ?? "", symbols: [] };
+}
+
+// ─── Module resolution ────────────────────────────────────────────────────
+
+/**
+ * Try to resolve a module specifier to an absolute source-file path inside
+ * the workspace. Returns null when the specifier looks external (npm) or
+ * cannot be resolved — caller treats that as "skip".
+ */
+function resolveWorkspaceModule(
+	specifier: string,
+	docFile: string,
+	cwd: string,
+): string | null {
+	// Relative imports — resolve against doc directory
+	if (specifier.startsWith(".")) {
+		const docDir = dirname(
+			isAbsolute(docFile) ? docFile : resolve(cwd, docFile),
+		);
+		const base = resolve(docDir, specifier);
+		return firstExisting([
+			base,
+			`${base}.ts`,
+			`${base}.tsx`,
+			`${base}.js`,
+			join(base, "index.ts"),
+			join(base, "index.tsx"),
+			join(base, "index.js"),
+		]);
+	}
+
+	// Workspace package by scanning packages/*. Walks one level deep, plus
+	// one extra level for scoped layouts (`packages/@scope/name`).
+	const packagesRoot = join(cwd, "packages");
+	if (!existsSync(packagesRoot)) return null;
+
+	const candidates = collectPackageDirs(packagesRoot);
+	for (const pkgDir of candidates) {
+		const pkgJsonPath = join(pkgDir, "package.json");
+		if (!existsSync(pkgJsonPath)) continue;
+
+		let pkgJson: { name?: string; main?: string; module?: string };
+		try {
+			pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+		} catch {
+			continue;
+		}
+
+		if (pkgJson.name !== specifier) continue;
+
+		const main = pkgJson.module ?? pkgJson.main ?? "src/index.ts";
+		const resolved = resolve(pkgDir, main);
+		return firstExisting([
+			resolved,
+			`${resolved}.ts`,
+			`${resolved}.tsx`,
+			join(resolved, "index.ts"),
+			join(resolved, "index.tsx"),
+		]);
+	}
+
+	return null;
+}
+
+/**
+ * Return candidate package directories under `packagesRoot`. Top-level entries
+ * count, plus one extra level for `@scope/name` layouts.
+ */
+function collectPackageDirs(packagesRoot: string): string[] {
+	const out: string[] = [];
+	let entries: string[];
+	try {
+		entries = readdirSync(packagesRoot);
+	} catch {
+		return out;
+	}
+
+	for (const entry of entries) {
+		const full = join(packagesRoot, entry);
+		try {
+			if (!statSync(full).isDirectory()) continue;
+		} catch {
+			continue;
+		}
+
+		if (entry.startsWith("@")) {
+			// Scoped: walk one more level
+			let inner: string[];
+			try {
+				inner = readdirSync(full);
+			} catch {
+				continue;
+			}
+			for (const sub of inner) {
+				out.push(join(full, sub));
+			}
+		} else {
+			out.push(full);
+		}
+	}
+
+	return out;
+}
+
+function firstExisting(paths: string[]): string | null {
+	for (const p of paths) {
+		if (!existsSync(p)) continue;
+		try {
+			const s = statSync(p);
+			if (s.isFile()) return p;
+		} catch {
+			// ignore
+		}
+	}
+	return null;
+}
+
+// ─── Export collection ────────────────────────────────────────────────────
+
+/**
+ * Collect every top-level exported identifier from a TS/JS source file.
+ *
+ * We use regex rather than tree-sitter to keep the tool dependency-free; this
+ * intentionally trades a small false-positive risk on exotic syntax for speed.
+ *
+ * Accepts:
+ *   - `export const|let|var|function|class|enum|interface|type X`
+ *   - `export default ...` → registers `default`
+ *   - `export { A, B as C }` (re-exports too)
+ *   - `export * from "./mod"` → returns a sentinel WILDCARD entry meaning
+ *     "we don't know exhaustively, so don't flag missing names"
+ */
+const WILDCARD_REEXPORT = "__wildcard__";
+
+function collectExports(source: string): Set<string> {
+	const exports = new Set<string>();
+
+	// Strip block + line comments to avoid matching examples in JSDoc.
+	const stripped = source
+		.replace(/\/\*[\s\S]*?\*\//g, "")
+		.replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+	// `export * from "..."` — wildcard, give up on exhaustive checking
+	if (/export\s*\*\s*from\s*["'][^"']+["']/.test(stripped)) {
+		exports.add(WILDCARD_REEXPORT);
+	}
+
+	// `export default ...`
+	if (/\bexport\s+default\b/.test(stripped)) {
+		exports.add("default");
+	}
+
+	// `export const|let|var|function|class|enum|interface|type|async function NAME`
+	const declRe =
+		/\bexport\s+(?:async\s+)?(?:const|let|var|function|class|enum|interface|type|abstract\s+class)\s+([A-Za-z_$][\w$]*)/g;
+	for (const m of stripped.matchAll(declRe)) {
+		if (m[1]) exports.add(m[1]);
+	}
+
+	// `export { A, B as C, default as D }` — possibly with `from "..."`
+	const listRe = /\bexport\s*\{([^}]+)\}/g;
+	for (const m of stripped.matchAll(listRe)) {
+		const list = m[1] ?? "";
+		for (const raw of list.split(",")) {
+			const item = raw.trim();
+			if (!item) continue;
+			// `X as Y` — the EXPORTED name is Y (what consumers import).
+			const aliasIdx = item.toLowerCase().indexOf(" as ");
+			const exported = aliasIdx === -1 ? item : item.slice(aliasIdx + 4).trim();
+			if (exported) exports.add(exported);
+		}
+	}
+
+	return exports;
+}
+
+// ─── Main entry point ─────────────────────────────────────────────────────
+
+/**
+ * Run the doc-claims check across the given file list.
+ *
+ * Non-markdown files are skipped silently; markdown files that do not exist
+ * or fail to read produce no findings (the slop-style robustness pattern).
+ */
+export async function detectDocClaims(
+	files: string[],
+	options: DetectOptions,
+): Promise<DocClaimsResult> {
+	const { cwd } = options;
+	const findings: Finding[] = [];
+
+	for (const file of files) {
+		if (!isMarkdown(file)) continue;
+
+		const filePath = isAbsolute(file) ? file : resolve(cwd, file);
+		let content: string;
+		try {
+			content = await Bun.file(filePath).text();
+		} catch {
+			continue;
+		}
+
+		const imports = extractMarkdownImports(content, file);
+		for (const imp of imports) {
+			if (imp.symbols.length === 0) continue; // dynamic import with no symbol claim
+
+			const resolved = resolveWorkspaceModule(imp.module, file, cwd);
+			// External / unresolved → skip silently (documented limitation).
+			if (!resolved) continue;
+
+			let exportSet: Set<string>;
+			try {
+				const src = readFileSync(resolved, "utf-8");
+				exportSet = collectExports(src);
+			} catch {
+				continue;
+			}
+
+			// `export *` swallows everything — do not emit findings against this
+			// module in v1. Better to under-report than to false-positive.
+			if (exportSet.has(WILDCARD_REEXPORT)) continue;
+
+			for (const symbol of imp.symbols) {
+				if (exportSet.has(symbol)) continue;
+				findings.push({
+					tool: "doc-claims",
+					file,
+					line: imp.line,
+					message: `Doc imports \`${symbol}\` from \`${imp.module}\` but the resolved source does not export it. Possible fabricated API claim.`,
+					severity: "warning",
+					ruleId: "doc-claims/missing-export",
+				});
+			}
+		}
+	}
+
+	return { findings };
+}
+
+function isMarkdown(file: string): boolean {
+	return file.endsWith(".md") || file.endsWith(".mdx");
+}

--- a/packages/docs/src/content/docs/engines/verify.mdx
+++ b/packages/docs/src/content/docs/engines/verify.mdx
@@ -106,13 +106,15 @@ The check is mechanical — no LLM in the loop — and runs in parallel with the
 - `export *` re-exports are treated as a wildcard — any symbol claimed against such a package is accepted. This trades precision for fewer false positives.
 - Severity is `warning`, not `error`. Promote it via `.maina/constitution.md` once the false-positive rate is well understood.
 
-**Silencing a finding:** if a flagged import is actually correct (e.g. the source file uses an exotic export form the regex misses), add the rule to your noisy-rules list:
+**Silencing a finding:** if a flagged import is actually correct (for example the source uses an exotic export form the regex misses), tune the rule through `.maina/constitution.md` — drop its severity to `info` or skip it entirely:
 
-```bash
-maina feedback dismiss doc-claims/missing-export
+```md
+## Verification
+
+- `doc-claims/missing-export`: severity = info
 ```
 
-After enough dismissals the rule is auto-downgraded or skipped per the standard noisy-rule preferences.
+The same constitution surface controls every other verify tool, so the silencing path is uniform across the pipeline.
 
 ## Tools
 

--- a/packages/docs/src/content/docs/engines/verify.mdx
+++ b/packages/docs/src/content/docs/engines/verify.mdx
@@ -86,6 +86,34 @@ The AI Slop Detector catches patterns common in AI-generated code:
 
 Slop detection runs as part of the parallel analysis phase and uses the mechanical model tier for cost efficiency.
 
+### Doc-claim verification
+
+The `doc-claims` tool catches a specific class of bug: a subagent asked to summarize a package's "API surface" returns a narrative that mixes real exports with plausible-looking fabrications, and the fabrications ship to docs. (The bug that motivated this gate: workkit#43, which shipped 20+ wrong API claims.)
+
+For each changed `.md` / `.mdx` file the tool:
+
+1. Parses fenced code blocks for `import` and `require` statements.
+2. Resolves the module specifier to a file inside the workspace — relative paths resolve against the doc's directory; workspace package names (`@scope/name`) are resolved by scanning `<cwd>/packages/*` for a matching `package.json#name`.
+3. Collects every top-level exported identifier from the resolved source (direct exports, `export { ... }` lists, re-exports).
+4. Emits a `warning` finding for each imported symbol that is not in the export set, pointing at the import line.
+
+The check is mechanical — no LLM in the loop — and runs in parallel with the other verify tools.
+
+**Limitations (v1):**
+
+- External packages (`react`, `lodash`, anything in `node_modules`) are skipped silently. We do not walk `node_modules`; verification of external surface is a future improvement.
+- Member-access claims (`obj.method()` in a code sample) are not validated. That requires type information, which is out of scope for v1.
+- `export *` re-exports are treated as a wildcard — any symbol claimed against such a package is accepted. This trades precision for fewer false positives.
+- Severity is `warning`, not `error`. Promote it via `.maina/constitution.md` once the false-positive rate is well understood.
+
+**Silencing a finding:** if a flagged import is actually correct (e.g. the source file uses an exotic export form the regex misses), add the rule to your noisy-rules list:
+
+```bash
+maina feedback dismiss doc-claims/missing-export
+```
+
+After enough dismissals the rule is auto-downgraded or skipped per the standard noisy-rule preferences.
+
 ## Tools
 
 | Tool | What it checks | Required |
@@ -100,6 +128,7 @@ Slop detection runs as part of the parallel analysis phase and uses the mechanic
 | **AI Slop Detector** | AI-generated filler, hallucinations, dead code | Built-in |
 | **typecheck** | `tsc --noEmit` type checking with zero extra installs | Built-in (TS projects) |
 | **consistency** | AST-based cross-function consistency check | Built-in |
+| **doc-claims** | Verifies `import` statements in changed `.md` / `.mdx` files reference symbols actually exported by the resolved package source | Built-in |
 | **ZAP** | Dynamic Application Security Testing (Docker-based) | Optional |
 | **Lighthouse** | Performance, accessibility, and SEO auditing | Optional |
 


### PR DESCRIPTION
Closes #180.

## Summary

A new built-in verify tool that runs on changed `.md` / `.mdx` files and warns when an `import` statement references a symbol the resolved package source does not actually export. Catches the class of bug that shipped 20+ wrong API claims in workkit#43 — a subagent asked to summarize a package's "API surface" returned a narrative that mixed real exports with plausible-looking fabrications.

## Why mechanical, not LLM

The author of #180 suggested four approaches. This PR implements **(1)** — a deterministic gate that resolves each `import` to source on disk and greps for the export. It catches the real bug (fabricated symbol names) for zero LLM cost and runs in parallel with the rest of the verify pipeline. Suggestion (3) — type-checking extracted code blocks — is heavyweight and out of scope for v1.

## How it works

1. Filter input to `.md` / `.mdx` (the pipeline's existing diff-only filter narrows further to changed lines).
2. Walk each file, parse fenced code blocks, extract `import` / `require` statements with named/default symbols.
3. Resolve the module specifier:
   - relative paths against the doc's directory
   - workspace packages (`@scope/name`) via `<cwd>/packages/*` → `package.json#name`
   - external packages → skipped silently
4. Read the resolved source and collect every top-level exported identifier (`export const|function|class|...`, `export { ... }` lists, `export { x } from "..."` re-exports). `export * from "..."` is treated as a wildcard.
5. Emit a `warning` finding per missing symbol pointing at the import line.

## v1 scope (deliberate)

- **Skipped:** external npm packages (no `node_modules` walk), member-access claims (`obj.method()` — needs type info), recursive resolution through `export *` re-exports.
- **Severity:** `warning`, not `error`. Users can promote via `.maina/constitution.md` once the false-positive rate is well-understood. Standard noisy-rule downgrades apply (`maina feedback dismiss doc-claims/missing-export`).
- **No LLM call.** Mechanical regex + filesystem reads only.

## Test plan

- [x] Unit tests for `extractMarkdownImports` (empty, prose-only, named, default, dynamic)
- [x] Unit tests for `detectDocClaims` (happy path, fabricated symbol, scoped workspace resolution `@workkit/memory` → `packages/memory`, re-exports, external skip, no-language fence, .mdx parity, missing files, multiple fabrications)
- [x] Pipeline integration test updated (12 → 13 tools)
- [x] `bun run typecheck` — clean
- [x] `bun run check` — clean (no new warnings)
- [x] `bun run build` — clean
- [x] `bun packages/cli/dist/index.js commit` — full pipeline ran on the diff and passed

## Files

- `packages/core/src/verify/tools/doc-claims.ts` (new) — engine
- `packages/core/src/verify/__tests__/doc-claims.test.ts` (new) — 17 tests
- `packages/core/src/verify/pipeline.ts` — wire the tool into the parallel runner
- `packages/core/src/verify/__tests__/pipeline.test.ts` — bumped expected tool count
- `packages/docs/src/content/docs/engines/verify.mdx` — added Doc-claim verification section + table row + limitations + how-to-silence
- `.changeset/doc-claims-verify.md` — minor bump for `@mainahq/cli` and `@mainahq/core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `doc-claims` built-in verification tool that validates code examples in markdown documentation. It checks that imports and requires in code blocks reference symbols actually exported by their modules, emitting warnings for any mismatches. Changed `.md` and `.mdx` files are automatically checked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->