### PR TITLE
fix(core): drop auto-generated PR-summary comments during feedback ingest

### DIFF
--- a/.changeset/feedback-noise-filter.md
+++ b/.changeset/feedback-noise-filter.md
@@ -1,0 +1,18 @@
+---
+"@mainahq/cli": patch
+"@mainahq/core": patch
+---
+
+fix(feedback): drop auto-generated PR-summary comments during ingest
+
+`maina feedback ingest` now skips comments whose body starts with one of CodeRabbit's auto-generated summary HTML markers:
+
+- `<!-- This is an auto-generated comment: summarize by coderabbit.ai -->`
+- `<!-- This is an auto-generated comment: review in progress by coderabbit.ai -->`
+- `<!-- This is an auto-generated comment: skip review by coderabbit.ai -->`
+
+These issue-level boilerplate comments carry no actionable signal but were being categorised as `security` because their body contains words the keyword classifier picked up — they were dragging the unfiltered categorisation accuracy from ~9/10 down by adding ~10 false-positive `security` rows per session.
+
+Real review comments that merely *mention* "auto-generated" (e.g. discussing a rule that fires on generated code) are unaffected — the marker must appear at the start of the body. New `isAutoSummaryComment(body)` helper is exported so other consumers can run the same filter.
+
+Locked in by 5 new unit tests + one end-to-end ingest test that verifies a summary boilerplate comment and a real review comment from the same reviewer ingest as `(skipped: 1, ingested: 1)`.

--- a/.changeset/feedback-noise-filter.md
+++ b/.changeset/feedback-noise-filter.md
@@ -15,4 +15,4 @@ These issue-level boilerplate comments carry no actionable signal but were being
 
 Real review comments that merely *mention* "auto-generated" (e.g. discussing a rule that fires on generated code) are unaffected — the marker must appear at the start of the body. New `isAutoSummaryComment(body)` helper is exported so other consumers can run the same filter.
 
-Locked in by 5 new unit tests + one end-to-end ingest test that verifies a summary boilerplate comment and a real review comment from the same reviewer ingest as `(skipped: 1, ingested: 1)`.
+Locked in by 5 new `isAutoSummaryComment` unit tests (each known marker, leading-whitespace tolerance, prose-mention rejection, unrelated HTML rejection, empty/whitespace-only body) + one end-to-end ingest test that verifies a summary boilerplate and a real review comment from the same reviewer ingest as `(skipped: 1, ingested: 1)`.

--- a/packages/core/src/feedback/__tests__/external-reviews.test.ts
+++ b/packages/core/src/feedback/__tests__/external-reviews.test.ts
@@ -9,6 +9,7 @@ import {
 	getTopCategoriesByFile,
 	ingestComments,
 	insertFinding,
+	isAutoSummaryComment,
 	parsePaginatedJson,
 	queryFindings,
 } from "../external-reviews";
@@ -162,6 +163,41 @@ describe("DB layer", () => {
 	});
 });
 
+describe("isAutoSummaryComment", () => {
+	test("matches each known CodeRabbit summary marker", () => {
+		const markers = [
+			"<!-- This is an auto-generated comment: summarize by coderabbit.ai -->",
+			"<!-- This is an auto-generated comment: review in progress by coderabbit.ai -->",
+			"<!-- This is an auto-generated comment: skip review by coderabbit.ai -->",
+		];
+		for (const m of markers) {
+			expect(isAutoSummaryComment(`${m}\n\nLots of body content.`)).toBe(true);
+		}
+	});
+
+	test("tolerates leading whitespace before the marker", () => {
+		expect(
+			isAutoSummaryComment(
+				"   \n\n<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\nbody",
+			),
+		).toBe(true);
+	});
+
+	test("does not match real review comments that merely mention 'auto-generated'", () => {
+		// Make sure we don't accidentally swallow a real review comment that
+		// happens to discuss auto-generation. The marker must be at the start.
+		expect(
+			isAutoSummaryComment(
+				"This rule fires on auto-generated code; consider an exception.",
+			),
+		).toBe(false);
+	});
+
+	test("does not match unrelated HTML comments", () => {
+		expect(isAutoSummaryComment("<!-- TODO: refactor -->\nbody")).toBe(false);
+	});
+});
+
 describe("ingestComments", () => {
 	test("filters non-allowed reviewers", () => {
 		const comments: ExternalReviewComment[] = [
@@ -193,6 +229,46 @@ describe("ingestComments", () => {
 		if (!result.ok) return;
 		expect(result.value.ingested).toBe(1);
 		expect(result.value.skipped).toBe(1);
+	});
+
+	test("drops auto-generated CodeRabbit summary headers, keeps real comments", () => {
+		const comments: ExternalReviewComment[] = [
+			// The summary boilerplate — should be dropped (counts as skipped).
+			{
+				sourceId: "summary-1",
+				prNumber: 9,
+				prRepo: "x/y",
+				filePath: null, // summary comments are issue-level
+				line: null,
+				reviewer: "coderabbitai",
+				body: "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n\n## Walkthrough\n\nReally long auto summary here.",
+				diffAtReview: undefined,
+			},
+			// A real review comment from the same reviewer — should be kept.
+			{
+				sourceId: "real-1",
+				prNumber: 9,
+				prRepo: "x/y",
+				filePath: "src/foo.ts",
+				line: 42,
+				reviewer: "coderabbitai",
+				body: "This export doesn't exist on the resolved module.",
+				diffAtReview: undefined,
+			},
+		];
+		const result = ingestComments(tmpDir, comments, {
+			allowedReviewers: ALLOWED_REVIEWERS,
+		});
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.value.ingested).toBe(1);
+		expect(result.value.skipped).toBe(1);
+
+		const all = queryFindings(tmpDir, {});
+		expect(all.ok).toBe(true);
+		if (!all.ok) return;
+		expect(all.value).toHaveLength(1);
+		expect(all.value[0]?.sourceId).toBe("real-1");
 	});
 
 	test("explicit human reviewer is allowed and stored as kind=human", () => {

--- a/packages/core/src/feedback/__tests__/external-reviews.test.ts
+++ b/packages/core/src/feedback/__tests__/external-reviews.test.ts
@@ -196,6 +196,11 @@ describe("isAutoSummaryComment", () => {
 	test("does not match unrelated HTML comments", () => {
 		expect(isAutoSummaryComment("<!-- TODO: refactor -->\nbody")).toBe(false);
 	});
+
+	test("does not match empty / whitespace-only bodies", () => {
+		expect(isAutoSummaryComment("")).toBe(false);
+		expect(isAutoSummaryComment("   \n\n\t")).toBe(false);
+	});
 });
 
 describe("ingestComments", () => {

--- a/packages/core/src/feedback/external-reviews.ts
+++ b/packages/core/src/feedback/external-reviews.ts
@@ -217,8 +217,37 @@ export function getTopCategoriesByFile(
 // ── Ingestion ───────────────────────────────────────────────────────────────
 
 /**
+ * Markers that identify auto-generated PR-summary comments which carry no
+ * actionable signal but trip our keyword categoriser (CodeRabbit's summary
+ * header contains words like "auto-generated" and substrings the
+ * `security` / `style` rules grab onto). These are issue-level (no
+ * `path`), so they show up in the DB as 10 false-positive `security`
+ * findings per session.
+ *
+ * Marker source: CodeRabbit emits these literal HTML comments at the top
+ * of every summary it posts. The list is intentionally narrow — only
+ * comments whose body STARTS WITH one of these markers is dropped, so we
+ * don't accidentally swallow a real review comment that quotes the marker.
+ */
+const NOISE_MARKERS: readonly string[] = [
+	"<!-- This is an auto-generated comment: summarize by coderabbit.ai -->",
+	"<!-- This is an auto-generated comment: review in progress by coderabbit.ai -->",
+	"<!-- This is an auto-generated comment: skip review by coderabbit.ai -->",
+];
+
+/** True if the comment body is a known auto-generated PR-summary header. */
+export function isAutoSummaryComment(body: string): boolean {
+	const head = body.trimStart();
+	for (const marker of NOISE_MARKERS) {
+		if (head.startsWith(marker)) return true;
+	}
+	return false;
+}
+
+/**
  * Ingest a batch of pre-fetched comments into the local DB. Skips comments
- * from reviewers not in the allow-list. Idempotent on `sourceId`.
+ * from reviewers not in the allow-list AND comments whose body is an
+ * auto-generated PR-summary header. Idempotent on `sourceId`.
  *
  * This split (fetch vs ingest) keeps the heavy network code (`gh api`) out
  * of the hot test path and out of the categorisation logic.
@@ -233,6 +262,12 @@ export function ingestComments(
 	let skipped = 0;
 	for (const c of comments) {
 		if (!allowed.has(c.reviewer.toLowerCase())) {
+			skipped += 1;
+			continue;
+		}
+		if (isAutoSummaryComment(c.body)) {
+			// Auto-generated PR-summary header — no actionable signal, and
+			// would otherwise pollute the categoriser with false positives.
 			skipped += 1;
 			continue;
 		}

--- a/packages/core/src/feedback/external-reviews.ts
+++ b/packages/core/src/feedback/external-reviews.ts
@@ -221,8 +221,8 @@ export function getTopCategoriesByFile(
  * actionable signal but trip our keyword categoriser (CodeRabbit's summary
  * header contains words like "auto-generated" and substrings the
  * `security` / `style` rules grab onto). These are issue-level (no
- * `path`), so they show up in the DB as 10 false-positive `security`
- * findings per session.
+ * `path`), so they show up in the DB as a steady stream of false-positive
+ * `security` findings — roughly one per merged PR with a CodeRabbit run.
  *
  * Marker source: CodeRabbit emits these literal HTML comments at the top
  * of every summary it posts. The list is intentionally narrow — only

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -196,6 +196,7 @@ export {
 	ingestComments,
 	ingestPrReviews,
 	insertFinding,
+	isAutoSummaryComment,
 	parsePaginatedJson,
 	type QueryFindingsOptions,
 	queryFindings,


### PR DESCRIPTION
## Summary

v1.5.0 dogfood test of \`maina feedback ingest\` ingested 115 findings across this session's PRs and surfaced a real categoriser-noise problem:

| Category | Count | Notes |
|---|---|---|
| other | 79 | The natural keyword-classifier ceiling — fixed by the v2 LLM reclassifier |
| style | 22 | Mostly correct |
| **security** | **10** | **~all from CodeRabbit summary boilerplate, not real security findings** |
| signature-drift | 3 | Correct |
| dead-code | 1 | Correct |

CodeRabbit posts an issue-level summary comment on every PR whose body starts with literal HTML markers like \`<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\`. The body is long boilerplate that contains words our keyword classifier picks up, so each one becomes a false-positive \`security\` finding with \`file_path = null\`.

## Fix

\`isAutoSummaryComment(body)\` returns true when the comment body **starts with** one of three known CodeRabbit markers (summary / review-in-progress / skip-review). \`ingestComments\` skips matches before the categoriser runs.

Real review comments that merely *mention* "auto-generated" are unaffected — the marker has to be at the start. New helper is exported from \`@mainahq/core\` so other consumers can run the same filter.

## Test plan

- [x] **5 new \`isAutoSummaryComment\` tests** — each known marker matches; tolerates leading whitespace; doesn't match prose mentioning "auto-generated"; doesn't match unrelated HTML comments
- [x] **1 end-to-end ingest test** — same reviewer (\`coderabbitai\`) posting both a summary boilerplate and a real review comment ingests as \`(skipped: 1, ingested: 1)\`, with only the real comment in the DB
- [x] All 30 external-reviews tests pass
- [x] \`bun run typecheck\` clean; \`bun run check\` clean for changed files
- [ ] After publish: re-run \`maina feedback ingest --json\` against this repo and confirm \`security\` count drops by ~10

## Note on the second item from the user-reported list

The user originally flagged "stats --json keys don't match SQL row shape" — investigation showed that was my misdiagnosis. \`stats --json\` already outputs camelCase \`filePath\` consistently with the rest of the public API; my python verification snippet had used \`file_path\` (snake_case). No real bug there, no fix needed.

## Changeset

Patch bump for cli + core (next release will be **v1.5.1**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Feedback ingest pipeline now filters and excludes auto-generated PR summary comments during ingestion.

* **New Features**
  * Exported a new helper function to detect auto-generated PR summary comments for reuse across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->