### PR TITLE
feat(cli,core): github login + unmask cli errors + crash telemetry

### DIFF
--- a/.changeset/cli-errors-and-github-login.md
+++ b/.changeset/cli-errors-and-github-login.md
@@ -1,0 +1,14 @@
+---
+"@mainahq/cli": minor
+"@mainahq/core": minor
+"@mainahq/mcp": minor
+"@mainahq/skills": minor
+---
+
+**CLI errors & GitHub login**
+
+- `maina login --github` — sign in with GitHub via device flow, then exchange for a maina token at `/auth/github/exchange`. Fixes the duplicate-account bug where the device flow created UUID+email members while the web flow keyed by `github_id` (#193).
+- Top-level `uncaughtException` / `unhandledRejection` handler prints `err.code` + `err.message` instead of the generic `"Something went wrong"`. Pass `--debug` (or set `MAINA_DEBUG=1`) for the full stack trace (#192).
+- Anonymous CLI crash reporting — fire-and-forget POST to `/v1/cli/errors` with a scrubbed payload (paths → basenames, secrets/emails/IPs redacted). Opt out via `MAINA_TELEMETRY=0`, `DO_NOT_TRACK=1`, or `~/.maina/telemetry.json` `{ "optOut": true }` (#192).
+- `maina sync pull` no longer crashes when the team has no prompts — prints `"No team prompts yet."` instead.
+- `maina team` falls back to the server's `plan_display` label, then to `plan`, then to `"Free"`, so a missing or legacy response never renders `Plan: undefined`.

--- a/README.md
+++ b/README.md
@@ -230,6 +230,17 @@ export default defineConfig({
 });
 ```
 
+## Privacy & Telemetry
+
+Maina sends **anonymous CLI crash reports** when an uncaught error terminates the process. The payload contains the error class/message/stack (absolute file paths rewritten to basenames, emails/IPs/API keys redacted), the subcommand, the maina/node versions, platform/arch, and a CI flag — **no code, no project names, no authentication tokens**.
+
+Opt out any of these three ways:
+
+```bash
+export MAINA_TELEMETRY=0                 # or DO_NOT_TRACK=1
+echo '{"optOut": true}' > ~/.maina/telemetry.json
+```
+
 ## Development
 
 ```bash

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -7,10 +7,13 @@ import { intro, log, outro, spinner, text } from "@clack/prompts";
 import {
 	clearAuthConfig,
 	createCloudClient,
+	exchangeGitHubToken,
 	loadAuthConfig,
 	pollForToken,
+	pollGitHubToken,
 	saveAuthConfig,
 	startDeviceFlow,
+	startGitHubDeviceFlow,
 } from "@mainahq/core";
 import { Command } from "commander";
 
@@ -24,6 +27,77 @@ const DEFAULT_CLOUD_URL =
 export interface LoginActionResult {
 	loggedIn: boolean;
 	reason?: string;
+}
+
+// ── GitHub Login Action ─────────────────────────────────────────────────────
+
+export async function loginWithGitHubAction(): Promise<LoginActionResult> {
+	const existing = loadAuthConfig();
+	if (existing.ok) {
+		log.info("Already logged in. Use `maina logout` to clear credentials.");
+		return { loggedIn: true };
+	}
+
+	const s = spinner();
+	s.start("Requesting GitHub device code...");
+
+	const flow = await startGitHubDeviceFlow();
+	if (!flow.ok) {
+		s.stop("Failed");
+		log.error(flow.error);
+		return { loggedIn: false, reason: flow.error };
+	}
+
+	s.stop("Ready");
+
+	log.info(
+		`To sign in, open ${flow.value.verificationUri} and enter:\n\n    ${flow.value.userCode}\n`,
+	);
+
+	s.start("Waiting for GitHub authorization...");
+
+	const gh = await pollGitHubToken({
+		deviceCode: flow.value.deviceCode,
+		interval: flow.value.interval,
+		expiresIn: flow.value.expiresIn,
+	});
+	if (!gh.ok) {
+		s.stop("Failed");
+		log.error(gh.error);
+		return { loggedIn: false, reason: gh.error };
+	}
+
+	s.message("Exchanging token...");
+	const exchange = await exchangeGitHubToken(
+		DEFAULT_CLOUD_URL,
+		gh.value.accessToken,
+	);
+	if (!exchange.ok) {
+		s.stop("Failed");
+		log.error(exchange.error);
+		return { loggedIn: false, reason: exchange.error };
+	}
+
+	s.stop("Authorized");
+
+	const saveResult = saveAuthConfig({
+		accessToken: exchange.value.accessToken,
+		expiresAt: exchange.value.expiresAt || undefined,
+	});
+	if (!saveResult.ok) {
+		log.error(saveResult.error);
+		return { loggedIn: false, reason: saveResult.error };
+	}
+
+	if (exchange.value.firstTime) {
+		log.success(
+			`Welcome, @${exchange.value.githubLogin}! Your maina account is ready.`,
+		);
+	} else {
+		log.success(`Logged in as @${exchange.value.githubLogin}.`);
+	}
+
+	return { loggedIn: true };
 }
 
 export async function loginAction(): Promise<LoginActionResult> {
@@ -174,10 +248,13 @@ export async function logoutAction(): Promise<LogoutActionResult> {
 export function loginCommand(): Command {
 	return new Command("login")
 		.description("Log in to maina cloud via device authorization")
-		.action(async () => {
-			intro("maina login");
+		.option("--github", "Log in with GitHub (device flow)")
+		.action(async (opts: { github?: boolean }) => {
+			intro(opts.github ? "maina login --github" : "maina login");
 
-			const result = await loginAction();
+			const result = opts.github
+				? await loginWithGitHubAction()
+				: await loginAction();
 
 			if (result.loggedIn) {
 				outro("Logged in!");

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -116,9 +116,13 @@ export async function syncPullAction(cwd?: string): Promise<SyncActionResult> {
 		return { synced: false, count: 0, reason: errMsg };
 	}
 
-	const prompts = result.value;
+	const prompts = result.value ?? [];
 	if (prompts.length === 0) {
-		return { synced: true, count: 0 };
+		return {
+			synced: true,
+			count: 0,
+			reason: "No team prompts yet.",
+		};
 	}
 
 	mkdirSync(promptsDir, { recursive: true });

--- a/packages/cli/src/commands/team.ts
+++ b/packages/cli/src/commands/team.ts
@@ -36,8 +36,9 @@ export async function teamAction(): Promise<TeamActionResult> {
 	}
 
 	const team = teamResult.value;
+	const planLabel = team.planDisplay ?? team.plan ?? "Free";
 	log.info(`Team: ${team.name}`);
-	log.info(`Plan: ${team.plan}`);
+	log.info(`Plan: ${planLabel}`);
 	log.info(`Seats: ${team.seats.used}/${team.seats.total}`);
 
 	const membersResult = await client.getTeamMembers();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,16 +24,31 @@ function printAndReport(err: unknown, origin: string): void {
 		);
 	}
 
-	// Fire-and-forget; swallow everything so the crash path isn't blocked.
+	// Preserve the original failure code when one is available: a numeric
+	// `err.code`, or whatever the app has already set on `process.exitCode`.
+	// Fall back to 1.
+	const existing = process.exitCode;
+	const exitCode =
+		typeof code === "number"
+			? code
+			: typeof existing === "number" && existing !== 0
+				? existing
+				: 1;
+	process.exitCode = exitCode;
+
+	// Fire-and-forget; never block the crash path on the network call.
+	// `sendCliErrorReport` already swallows its own errors and times out at 1s.
 	void sendCliErrorReport(e, {
 		mainaVersion: pkg.version,
 		argv: process.argv,
 	}).finally(() => {
-		process.exit(1);
+		process.exit(exitCode);
 	});
 
-	// Safety net: if telemetry somehow hangs past its timeout, force exit.
-	setTimeout(() => process.exit(1), 1500).unref?.();
+	// Safety net: if telemetry somehow hangs past its own timeout, force exit
+	// with the preserved code. `.unref()` lets Node terminate early if the
+	// telemetry promise resolved first.
+	setTimeout(() => process.exit(exitCode), 1500).unref?.();
 }
 
 process.on("uncaughtException", (err) =>

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,47 @@
 #!/usr/bin/env bun
-export {};
+
+import { sendCliErrorReport } from "@mainahq/core";
+import pkg from "../package.json" with { type: "json" };
+
+// ── Top-level error handling ────────────────────────────────────────────────
+
+const DEBUG =
+	process.argv.includes("--debug") || process.env.MAINA_DEBUG === "1";
+
+function printAndReport(err: unknown, origin: string): void {
+	const e = err instanceof Error ? err : new Error(String(err ?? "unknown"));
+	// biome-ignore lint/suspicious/noExplicitAny: err.code is platform-specific
+	const code = (e as any).code as string | undefined;
+	const prefix =
+		origin === "unhandledRejection" ? "Unhandled rejection" : "Error";
+	const codeStr = code ? ` [${code}]` : "";
+	process.stderr.write(`${prefix}${codeStr}: ${e.message}\n`);
+	if (DEBUG && e.stack) {
+		process.stderr.write(`${e.stack}\n`);
+	} else {
+		process.stderr.write(
+			"(run with --debug or MAINA_DEBUG=1 for full stack)\n",
+		);
+	}
+
+	// Fire-and-forget; swallow everything so the crash path isn't blocked.
+	void sendCliErrorReport(e, {
+		mainaVersion: pkg.version,
+		argv: process.argv,
+	}).finally(() => {
+		process.exit(1);
+	});
+
+	// Safety net: if telemetry somehow hangs past its timeout, force exit.
+	setTimeout(() => process.exit(1), 1500).unref?.();
+}
+
+process.on("uncaughtException", (err) =>
+	printAndReport(err, "uncaughtException"),
+);
+process.on("unhandledRejection", (reason) =>
+	printAndReport(reason, "unhandledRejection"),
+);
 
 // MCP server mode: `maina --mcp` starts the MCP server instead of the CLI
 if (process.argv.includes("--mcp")) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,11 +10,11 @@ const DEBUG =
 
 function printAndReport(err: unknown, origin: string): void {
 	const e = err instanceof Error ? err : new Error(String(err ?? "unknown"));
-	// biome-ignore lint/suspicious/noExplicitAny: err.code is platform-specific
-	const code = (e as any).code as string | undefined;
+	const code = (e as Error & { code?: unknown }).code;
 	const prefix =
 		origin === "unhandledRejection" ? "Unhandled rejection" : "Error";
-	const codeStr = code ? ` [${code}]` : "";
+	const codeStr =
+		typeof code === "string" || typeof code === "number" ? ` [${code}]` : "";
 	process.stderr.write(`${prefix}${codeStr}: ${e.message}\n`);
 	if (DEBUG && e.stack) {
 		process.stderr.write(`${e.stack}\n`);

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -69,7 +69,11 @@ Setup & Config:
   mcp remove    Uninstall maina MCP server from clients
   mcp list      Show maina MCP install status per client`,
 		)
-		.version(pkg.version);
+		.version(pkg.version)
+		.option(
+			"--debug",
+			"print full stack traces and error codes on failure (also MAINA_DEBUG=1)",
+		);
 
 	// ── Workflow ─────────────────────────────────────────────────────────
 	program.addCommand(brainstormCommand());

--- a/packages/core/src/cloud/__tests__/auth.test.ts
+++ b/packages/core/src/cloud/__tests__/auth.test.ts
@@ -3,10 +3,14 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
 	clearAuthConfig,
+	exchangeGitHubToken,
+	GITHUB_CLIENT_ID,
 	getAuthConfigPath,
 	loadAuthConfig,
+	pollGitHubToken,
 	saveAuthConfig,
 	startDeviceFlow,
+	startGitHubDeviceFlow,
 } from "../auth";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -160,5 +164,197 @@ describe("startDeviceFlow", () => {
 		if (!result.ok) {
 			expect(result.error).toContain("503");
 		}
+	});
+});
+
+// ── GitHub Device Flow ──────────────────────────────────────────────────────
+
+describe("startGitHubDeviceFlow", () => {
+	test("POSTs client_id + scope to github.com/login/device/code", async () => {
+		const seen: { url: string; body: string } = { url: "", body: "" };
+		mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+			seen.url = url;
+			seen.body = String(init?.body ?? "");
+			return Promise.resolve(
+				jsonResponse({
+					device_code: "dev-xyz",
+					user_code: "ABCD-1234",
+					verification_uri: "https://github.com/login/device",
+					expires_in: 900,
+					interval: 5,
+				}),
+			);
+		});
+
+		const result = await startGitHubDeviceFlow();
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.deviceCode).toBe("dev-xyz");
+			expect(result.value.userCode).toBe("ABCD-1234");
+			expect(result.value.verificationUri).toBe(
+				"https://github.com/login/device",
+			);
+			expect(result.value.interval).toBe(5);
+		}
+		expect(seen.url).toBe("https://github.com/login/device/code");
+		expect(seen.body).toContain(`client_id=${GITHUB_CLIENT_ID}`);
+		expect(seen.body).toContain("scope=read%3Auser");
+	});
+
+	test("surfaces device_flow_disabled with an actionable message", async () => {
+		mockFetch.mockImplementation(() =>
+			Promise.resolve(jsonResponse({ error: "device_flow_disabled" })),
+		);
+
+		const result = await startGitHubDeviceFlow();
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("Device Flow");
+	});
+
+	test("returns error on malformed response", async () => {
+		mockFetch.mockImplementation(() =>
+			Promise.resolve(jsonResponse({ user_code: "ABCD-1234" })),
+		);
+
+		const result = await startGitHubDeviceFlow();
+		expect(result.ok).toBe(false);
+	});
+});
+
+describe("pollGitHubToken", () => {
+	test("keeps polling on authorization_pending, then returns token", async () => {
+		let calls = 0;
+		mockFetch.mockImplementation(() => {
+			calls++;
+			if (calls < 2) {
+				return Promise.resolve(
+					jsonResponse({ error: "authorization_pending" }),
+				);
+			}
+			return Promise.resolve(
+				jsonResponse({
+					access_token: "gho_abc123",
+					scope: "read:user",
+					token_type: "bearer",
+				}),
+			);
+		});
+
+		const result = await pollGitHubToken({
+			deviceCode: "dev-xyz",
+			interval: 0, // poll as fast as possible
+			expiresIn: 5,
+		});
+
+		expect(result.ok).toBe(true);
+		expect(calls).toBe(2);
+		if (result.ok) {
+			expect(result.value.accessToken).toBe("gho_abc123");
+			expect(result.value.scope).toBe("read:user");
+		}
+	});
+
+	test("aborts on expired_token", async () => {
+		mockFetch.mockImplementation(() =>
+			Promise.resolve(jsonResponse({ error: "expired_token" })),
+		);
+		const result = await pollGitHubToken({
+			deviceCode: "dev-xyz",
+			interval: 0,
+			expiresIn: 5,
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("expired");
+	});
+
+	test("aborts on access_denied", async () => {
+		mockFetch.mockImplementation(() =>
+			Promise.resolve(jsonResponse({ error: "access_denied" })),
+		);
+		const result = await pollGitHubToken({
+			deviceCode: "dev-xyz",
+			interval: 0,
+			expiresIn: 5,
+		});
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("denied");
+	});
+
+	test("backs off on slow_down before eventually succeeding", async () => {
+		let calls = 0;
+		mockFetch.mockImplementation(() => {
+			calls++;
+			if (calls === 1) {
+				return Promise.resolve(jsonResponse({ error: "slow_down" }));
+			}
+			return Promise.resolve(
+				jsonResponse({ access_token: "gho_tok", scope: "read:user" }),
+			);
+		});
+		const result = await pollGitHubToken({
+			deviceCode: "dev-xyz",
+			interval: 0,
+			expiresIn: 30,
+			slowDownIncreaseMs: 10,
+		});
+		expect(result.ok).toBe(true);
+		expect(calls).toBe(2);
+	});
+});
+
+describe("exchangeGitHubToken", () => {
+	test("sends github_access_token and parses snake_case response", async () => {
+		const seen: { url: string; body: string } = { url: "", body: "" };
+		mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+			seen.url = url;
+			seen.body = String(init?.body ?? "");
+			return Promise.resolve(
+				jsonResponse({
+					data: {
+						access_token: "maina_tok",
+						first_time: true,
+						member_id: "member_1",
+						team_id: "team_1",
+						github_login: "alice",
+						email: "alice@example.com",
+						expires_at: "2026-05-18T00:00:00Z",
+					},
+					error: null,
+				}),
+			);
+		});
+
+		const result = await exchangeGitHubToken(
+			"https://api.maina.dev",
+			"gho_abc",
+		);
+
+		expect(result.ok).toBe(true);
+		expect(seen.url).toBe("https://api.maina.dev/auth/github/exchange");
+		expect(seen.body).toContain("gho_abc");
+		if (result.ok) {
+			expect(result.value.accessToken).toBe("maina_tok");
+			expect(result.value.firstTime).toBe(true);
+			expect(result.value.githubLogin).toBe("alice");
+		}
+	});
+
+	test("maps invalid_github_token to an actionable message", async () => {
+		mockFetch.mockImplementation(() =>
+			Promise.resolve(jsonResponse({ error: "invalid_github_token" }, 401)),
+		);
+		const result = await exchangeGitHubToken("https://api.maina.dev", "t");
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("revoked");
+	});
+
+	test("maps provision_failed", async () => {
+		mockFetch.mockImplementation(() =>
+			Promise.resolve(jsonResponse({ error: "provision_failed" }, 502)),
+		);
+		const result = await exchangeGitHubToken("https://api.maina.dev", "t");
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("provision");
 	});
 });

--- a/packages/core/src/cloud/__tests__/client.test.ts
+++ b/packages/core/src/cloud/__tests__/client.test.ts
@@ -173,6 +173,82 @@ describe("createCloudClient", () => {
 		}
 	});
 
+	test("getTeam maps plan_display from snake_case server response", async () => {
+		mockFetch.mockImplementation(() =>
+			Promise.resolve(
+				jsonResponse({
+					data: {
+						id: "team_1",
+						name: "Acme",
+						plan: "team",
+						plan_display: "Team",
+						seats: { used: 3, total: 5 },
+					},
+				}),
+			),
+		);
+
+		const client = setupClient();
+		const result = await client.getTeam();
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.plan).toBe("team");
+			expect(result.value.planDisplay).toBe("Team");
+		}
+	});
+
+	test("getTeam falls back to 'free' when plan is missing", async () => {
+		mockFetch.mockImplementation(() =>
+			Promise.resolve(
+				jsonResponse({
+					data: {
+						id: "team_1",
+						name: "Acme",
+						seats: { used: 1, total: 1 },
+					},
+				}),
+			),
+		);
+
+		const client = setupClient();
+		const result = await client.getTeam();
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.plan).toBe("free");
+			expect(result.value.planDisplay).toBeUndefined();
+		}
+	});
+
+	test("getPrompts returns [] when server sends data: null", async () => {
+		mockFetch.mockImplementation(() =>
+			Promise.resolve(jsonResponse({ data: null, error: null })),
+		);
+
+		const client = setupClient();
+		const result = await client.getPrompts();
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value).toEqual([]);
+		}
+	});
+
+	test("getPrompts returns [] when data is missing", async () => {
+		mockFetch.mockImplementation(() =>
+			Promise.resolve(jsonResponse({ meta: {} })),
+		);
+
+		const client = setupClient();
+		const result = await client.getPrompts();
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value).toEqual([]);
+		}
+	});
+
 	test("putPrompts sends prompts array", async () => {
 		mockFetch.mockImplementation(() =>
 			Promise.resolve(new Response(null, { status: 204 })),

--- a/packages/core/src/cloud/__tests__/client.test.ts
+++ b/packages/core/src/cloud/__tests__/client.test.ts
@@ -198,7 +198,7 @@ describe("createCloudClient", () => {
 		}
 	});
 
-	test("getTeam falls back to 'free' when plan is missing", async () => {
+	test("getTeam falls back to plan='free' + derives planDisplay='Free' when server omits both", async () => {
 		mockFetch.mockImplementation(() =>
 			Promise.resolve(
 				jsonResponse({
@@ -217,7 +217,31 @@ describe("createCloudClient", () => {
 		expect(result.ok).toBe(true);
 		if (result.ok) {
 			expect(result.value.plan).toBe("free");
-			expect(result.value.planDisplay).toBeUndefined();
+			// Derived so the CLI always renders `Plan: Free`, never `Plan: free`.
+			expect(result.value.planDisplay).toBe("Free");
+		}
+	});
+
+	test("getTeam derives planDisplay from plan when server omits plan_display", async () => {
+		mockFetch.mockImplementation(() =>
+			Promise.resolve(
+				jsonResponse({
+					data: {
+						id: "team_1",
+						name: "Acme",
+						plan: "team",
+						seats: { used: 3, total: 5 },
+					},
+				}),
+			),
+		);
+
+		const client = setupClient();
+		const result = await client.getTeam();
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.value.planDisplay).toBe("Team");
 		}
 	});
 

--- a/packages/core/src/cloud/auth.ts
+++ b/packages/core/src/cloud/auth.ts
@@ -15,7 +15,13 @@ import {
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { Result } from "../db/index";
-import type { DeviceCodeResponse, TokenResponse } from "./types";
+import type {
+	DeviceCodeResponse,
+	GitHubDeviceCodeResponse,
+	GitHubExchangeResponse,
+	GitHubTokenResponse,
+	TokenResponse,
+} from "./types";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -242,4 +248,256 @@ export async function pollForToken(
 	}
 
 	return err("Device code expired. Please try logging in again.");
+}
+
+// ── GitHub Device Flow ──────────────────────────────────────────────────────
+
+/**
+ * GitHub OAuth App client id used for CLI device flow.
+ * Public value; OAuth apps have no client secret for the device flow.
+ */
+export const GITHUB_CLIENT_ID = "Iv23liUKmzMG4WYZITEk";
+const GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code";
+const GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+
+export interface StartGitHubFlowOptions {
+	/** Override the client id (for tests or alternate apps). */
+	clientId?: string;
+	/** Scopes to request. Defaults to "read:user". */
+	scope?: string;
+}
+
+/**
+ * Initiate the GitHub device authorization flow.
+ *
+ * See https://docs.github.com/en/apps/creating-github-apps/writing-code-for-a-github-app/building-a-cli-with-a-github-app
+ */
+export async function startGitHubDeviceFlow(
+	opts: StartGitHubFlowOptions = {},
+): Promise<Result<GitHubDeviceCodeResponse, string>> {
+	const clientId = opts.clientId ?? GITHUB_CLIENT_ID;
+	const scope = opts.scope ?? "read:user";
+
+	try {
+		const response = await fetch(GITHUB_DEVICE_CODE_URL, {
+			method: "POST",
+			headers: {
+				Accept: "application/json",
+				"Content-Type": "application/x-www-form-urlencoded",
+			},
+			body: new URLSearchParams({ client_id: clientId, scope }).toString(),
+		});
+
+		if (!response.ok) {
+			const text = await response.text();
+			return err(
+				`GitHub device code request failed (HTTP ${response.status}): ${text}`,
+			);
+		}
+
+		const body = (await response.json()) as Record<string, unknown>;
+
+		if (body.error === "device_flow_disabled") {
+			return err(
+				"GitHub Device Flow is not enabled for this OAuth app. Ask an admin to enable it in the app's settings.",
+			);
+		}
+		if (typeof body.error === "string") {
+			return err(`GitHub device flow rejected: ${body.error}`);
+		}
+
+		const userCode = body.user_code;
+		const deviceCode = body.device_code;
+		const verificationUri = body.verification_uri;
+		if (
+			typeof userCode !== "string" ||
+			typeof deviceCode !== "string" ||
+			typeof verificationUri !== "string"
+		) {
+			return err("GitHub returned a malformed device code response.");
+		}
+
+		return ok({
+			userCode,
+			deviceCode,
+			verificationUri,
+			interval: typeof body.interval === "number" ? body.interval : 5,
+			expiresIn: typeof body.expires_in === "number" ? body.expires_in : 900,
+		});
+	} catch (e) {
+		return err(
+			`GitHub device code request failed: ${e instanceof Error ? e.message : String(e)}`,
+		);
+	}
+}
+
+export interface PollGitHubTokenOptions {
+	/** Override the client id (for tests). */
+	clientId?: string;
+	/** Device code returned from `startGitHubDeviceFlow`. */
+	deviceCode: string;
+	/** Initial polling interval (seconds). */
+	interval: number;
+	/** Seconds until the device code expires. */
+	expiresIn: number;
+	/**
+	 * Milliseconds to add to the polling interval when GitHub returns
+	 * `slow_down`. Defaults to 5000 (GitHub's recommended minimum).
+	 * Tests can lower this to keep runs fast.
+	 */
+	slowDownIncreaseMs?: number;
+}
+
+/**
+ * Poll GitHub for an access token once the user completes the device flow.
+ *
+ * Respects the documented error responses:
+ *   authorization_pending → keep polling
+ *   slow_down             → increase interval by 5s, keep polling
+ *   expired_token         → abort
+ *   access_denied         → abort
+ */
+export async function pollGitHubToken(
+	opts: PollGitHubTokenOptions,
+): Promise<Result<GitHubTokenResponse, string>> {
+	const clientId = opts.clientId ?? GITHUB_CLIENT_ID;
+	const slowDownIncreaseMs = opts.slowDownIncreaseMs ?? 5_000;
+	let intervalMs = Math.max(opts.interval, 0) * 1000;
+	const deadline = Date.now() + opts.expiresIn * 1000;
+
+	while (Date.now() < deadline) {
+		await sleep(intervalMs);
+
+		let body: Record<string, unknown>;
+		try {
+			const response = await fetch(GITHUB_ACCESS_TOKEN_URL, {
+				method: "POST",
+				headers: {
+					Accept: "application/json",
+					"Content-Type": "application/x-www-form-urlencoded",
+				},
+				body: new URLSearchParams({
+					client_id: clientId,
+					device_code: opts.deviceCode,
+					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+				}).toString(),
+			});
+
+			if (!response.ok) {
+				// Network-layer failure. Keep polling if we have time left.
+				if (Date.now() >= deadline) {
+					return err(`GitHub token request failed (HTTP ${response.status}).`);
+				}
+				continue;
+			}
+
+			body = (await response.json()) as Record<string, unknown>;
+		} catch (e) {
+			// Transient network error — keep polling until deadline
+			if (Date.now() >= deadline) {
+				return err(
+					`GitHub token request failed: ${e instanceof Error ? e.message : String(e)}`,
+				);
+			}
+			continue;
+		}
+
+		const errorCode = body.error;
+		if (typeof errorCode === "string") {
+			if (errorCode === "authorization_pending") continue;
+			if (errorCode === "slow_down") {
+				intervalMs += slowDownIncreaseMs;
+				continue;
+			}
+			if (errorCode === "expired_token") {
+				return err("Device code expired. Run `maina login --github` again.");
+			}
+			if (errorCode === "access_denied") {
+				return err("Authorization denied on GitHub.");
+			}
+			return err(`GitHub rejected the token request: ${errorCode}`);
+		}
+
+		const accessToken = body.access_token;
+		if (typeof accessToken !== "string") {
+			return err("GitHub returned a malformed token response.");
+		}
+
+		return ok({
+			accessToken,
+			scope: typeof body.scope === "string" ? body.scope : "",
+		});
+	}
+
+	return err("Device code expired. Run `maina login --github` again.");
+}
+
+/**
+ * Exchange a GitHub access token for a maina bearer token.
+ *
+ * Calls `POST /auth/github/exchange` on the maina cloud API. The server
+ * validates the token with GitHub and either creates or reuses the maina
+ * member record keyed by `github_id`.
+ */
+export async function exchangeGitHubToken(
+	baseUrl: string,
+	githubAccessToken: string,
+): Promise<Result<GitHubExchangeResponse, string>> {
+	try {
+		const response = await fetch(`${baseUrl}/auth/github/exchange`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Accept: "application/json",
+			},
+			body: JSON.stringify({ github_access_token: githubAccessToken }),
+		});
+
+		const rawText = await response.text();
+		let body: { data?: Record<string, unknown>; error?: string } = {};
+		try {
+			body = rawText ? JSON.parse(rawText) : {};
+		} catch {
+			return err(
+				`GitHub token exchange failed (HTTP ${response.status}): ${rawText}`,
+			);
+		}
+
+		if (!response.ok) {
+			const serverError = body.error ?? `HTTP ${response.status}`;
+			if (serverError === "invalid_github_token") {
+				return err(
+					"GitHub rejected the token (it may have been revoked). Try `maina login --github` again.",
+				);
+			}
+			if (serverError === "github_user_lookup_failed") {
+				return err("GitHub user lookup failed. Please retry in a moment.");
+			}
+			if (serverError === "provision_failed") {
+				return err(
+					"Maina cloud failed to provision your account. Please retry.",
+				);
+			}
+			return err(serverError);
+		}
+
+		const d = body.data ?? {};
+		const accessToken = d.access_token ?? d.accessToken;
+		if (typeof accessToken !== "string") {
+			return err("Maina cloud returned a malformed exchange response.");
+		}
+		return ok({
+			accessToken,
+			firstTime: Boolean(d.first_time ?? d.firstTime ?? false),
+			memberId: String(d.member_id ?? d.memberId ?? ""),
+			teamId: String(d.team_id ?? d.teamId ?? ""),
+			githubLogin: String(d.github_login ?? d.githubLogin ?? ""),
+			email: String(d.email ?? ""),
+			expiresAt: String(d.expires_at ?? d.expiresAt ?? ""),
+		});
+	} catch (e) {
+		return err(
+			`GitHub token exchange failed: ${e instanceof Error ? e.message : String(e)}`,
+		);
+	}
 }

--- a/packages/core/src/cloud/client.ts
+++ b/packages/core/src/cloud/client.ts
@@ -44,6 +44,12 @@ function isRetryable(status: number): boolean {
 	return status === 429 || status >= 500;
 }
 
+/** Title-case a machine-readable plan id for display. `free` → `Free`. */
+function titleCasePlan(plan: string): string {
+	if (!plan) return "Free";
+	return plan.charAt(0).toUpperCase() + plan.slice(1);
+}
+
 /**
  * Sleep for the given number of milliseconds.
  * Extracted so tests can verify backoff behaviour.
@@ -265,11 +271,20 @@ export function createCloudClient(config: CloudConfig): CloudClient {
 			const result = await request<any>("GET", "/team");
 			if (!result.ok) return result;
 			const d = result.value ?? {};
+			const plan = d.plan ?? "free";
+			// Prefer an explicit server-supplied label; otherwise derive one from
+			// the machine-readable id so older / partial responses still render a
+			// human-friendly `Plan: Free` instead of `Plan: free` in the CLI.
+			const serverLabel = d.planDisplay ?? d.plan_display;
+			const planDisplay =
+				typeof serverLabel === "string" && serverLabel.length > 0
+					? serverLabel
+					: titleCasePlan(plan);
 			return ok({
 				id: d.id,
 				name: d.name,
-				plan: d.plan ?? "free",
-				planDisplay: d.planDisplay ?? d.plan_display,
+				plan,
+				planDisplay,
 				seats: d.seats ?? { used: 0, total: 0 },
 			} satisfies TeamInfo);
 		},

--- a/packages/core/src/cloud/client.ts
+++ b/packages/core/src/cloud/client.ts
@@ -242,7 +242,11 @@ export function createCloudClient(config: CloudConfig): CloudClient {
 			});
 		},
 
-		getPrompts: () => request<PromptRecord[]>("GET", "/prompts"),
+		getPrompts: async () => {
+			const result = await request<PromptRecord[] | null>("GET", "/prompts");
+			if (!result.ok) return result;
+			return ok(Array.isArray(result.value) ? result.value : []);
+		},
 
 		putPrompts: async (prompts) => {
 			for (const p of prompts) {
@@ -256,7 +260,19 @@ export function createCloudClient(config: CloudConfig): CloudClient {
 			return { ok: true as const, value: undefined };
 		},
 
-		getTeam: () => request<TeamInfo>("GET", "/team"),
+		getTeam: async () => {
+			// biome-ignore lint/suspicious/noExplicitAny: snake_case API mapping
+			const result = await request<any>("GET", "/team");
+			if (!result.ok) return result;
+			const d = result.value ?? {};
+			return ok({
+				id: d.id,
+				name: d.name,
+				plan: d.plan ?? "free",
+				planDisplay: d.planDisplay ?? d.plan_display,
+				seats: d.seats ?? { used: 0, total: 0 },
+			} satisfies TeamInfo);
+		},
 
 		getTeamMembers: () => request<TeamMember[]>("GET", "/team/members"),
 

--- a/packages/core/src/cloud/types.ts
+++ b/packages/core/src/cloud/types.ts
@@ -40,8 +40,10 @@ export interface TeamInfo {
 	id: string;
 	/** Display name. */
 	name: string;
-	/** Current billing plan. */
+	/** Current billing plan (machine-readable id, e.g. "free", "team"). */
 	plan: string;
+	/** Human-readable plan label, e.g. "Free", "Team". Optional — older servers may omit. */
+	planDisplay?: string;
 	/** Number of seats used / total. */
 	seats: { used: number; total: number };
 }
@@ -79,6 +81,45 @@ export interface TokenResponse {
 	expiresIn: number;
 	/** True when the user has no email set (first-time signup). */
 	firstTime?: boolean;
+}
+
+// ── GitHub Device Flow ──────────────────────────────────────────────────────
+
+export interface GitHubDeviceCodeResponse {
+	/** Short code the user types into github.com/login/device. */
+	userCode: string;
+	/** Opaque code used to poll GitHub for the access token. */
+	deviceCode: string;
+	/** URL the user visits in the browser. */
+	verificationUri: string;
+	/** Polling interval (seconds). */
+	interval: number;
+	/** Seconds until the device code expires. */
+	expiresIn: number;
+}
+
+export interface GitHubTokenResponse {
+	/** GitHub bearer token. Short-lived; used only to exchange for a maina token. */
+	accessToken: string;
+	/** Scopes granted to the access token (space-separated). */
+	scope: string;
+}
+
+export interface GitHubExchangeResponse {
+	/** Maina bearer token. */
+	accessToken: string;
+	/** True when the server just provisioned a new maina member. */
+	firstTime: boolean;
+	/** Maina member identifier (member_...). */
+	memberId: string;
+	/** Maina team identifier (team_...). */
+	teamId: string;
+	/** GitHub login of the authenticated user. */
+	githubLogin: string;
+	/** Email on file for the user (from GitHub). */
+	email: string;
+	/** ISO-8601 timestamp when the token expires. */
+	expiresAt: string;
 }
 
 // ── Profile ────────────────────────────────────────────────────────────────

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,10 +55,14 @@ export {
 export {
 	type AuthConfig,
 	clearAuthConfig,
+	exchangeGitHubToken,
+	GITHUB_CLIENT_ID,
 	loadAuthConfig,
 	pollForToken,
+	pollGitHubToken,
 	saveAuthConfig,
 	startDeviceFlow,
+	startGitHubDeviceFlow,
 } from "./cloud/auth";
 export { type CloudClient, createCloudClient } from "./cloud/client";
 export type {
@@ -72,6 +76,9 @@ export type {
 	FeedbackBatchPayload,
 	FeedbackEvent,
 	FeedbackImprovementsResponse,
+	GitHubDeviceCodeResponse,
+	GitHubExchangeResponse,
+	GitHubTokenResponse,
 	PromptRecord,
 	SubmitVerifyPayload,
 	TeamInfo,
@@ -397,6 +404,14 @@ export {
 	type TrendsReport,
 	trackToolUsage,
 } from "./stats/tracker";
+// CLI crash telemetry
+export {
+	buildCliErrorPayload,
+	type CliErrorPayload,
+	isCliTelemetryOptedOut,
+	type SendOptions,
+	sendCliErrorReport,
+} from "./telemetry/cli-error-reporter";
 // Ticket
 export {
 	buildIssueBody,

--- a/packages/core/src/telemetry/__tests__/cli-error-reporter.test.ts
+++ b/packages/core/src/telemetry/__tests__/cli-error-reporter.test.ts
@@ -10,9 +10,16 @@ import {
 
 // ── Env hygiene ─────────────────────────────────────────────────────────────
 
-const ORIGINAL_ENV = { ...process.env };
+// Only capture and restore the specific keys this suite touches — assigning to
+// `process.env` wholesale isn't portable across runtimes and flakes in CI.
+const MANAGED_ENV_KEYS = [
+	"MAINA_TELEMETRY",
+	"DO_NOT_TRACK",
+	"CI",
+	"HOME",
+] as const;
+const savedEnv: Record<string, string | undefined> = {};
 const originalFetch = globalThis.fetch;
-const originalHome = process.env.HOME;
 
 function makeTempHome(): string {
 	const dir = join(
@@ -24,6 +31,9 @@ function makeTempHome(): string {
 }
 
 beforeEach(() => {
+	for (const key of MANAGED_ENV_KEYS) {
+		savedEnv[key] = process.env[key];
+	}
 	delete process.env.MAINA_TELEMETRY;
 	delete process.env.DO_NOT_TRACK;
 	delete process.env.CI;
@@ -31,12 +41,14 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	if (originalHome === undefined) {
-		delete process.env.HOME;
-	} else {
-		process.env.HOME = originalHome;
+	for (const key of MANAGED_ENV_KEYS) {
+		const prev = savedEnv[key];
+		if (prev === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = prev;
+		}
 	}
-	process.env = { ...ORIGINAL_ENV };
 	globalThis.fetch = originalFetch;
 });
 
@@ -112,6 +124,25 @@ describe("buildCliErrorPayload", () => {
 			command: "verify",
 		});
 		expect(payload.errorMessage).toContain("5/10");
+	});
+
+	test("leaves API routes like /v1/cli/errors intact", () => {
+		const err = new Error("POST /v1/cli/errors returned 502");
+		const payload = buildCliErrorPayload(err, {
+			mainaVersion: "1.5.1",
+			command: "verify",
+		});
+		expect(payload.errorMessage).toContain("/v1/cli/errors");
+	});
+
+	test("stops command derivation at the first flag so option VALUES don't leak", () => {
+		const payload = buildCliErrorPayload(new Error("boom"), {
+			mainaVersion: "1.5.1",
+			argv: ["bun", "/path/cli.js", "commit", "-m", "secret message"],
+		});
+		// Must not include "secret" from the -m value
+		expect(payload.command).toBe("commit");
+		expect(payload.command).not.toContain("secret");
 	});
 
 	test("wraps non-Error throws", () => {

--- a/packages/core/src/telemetry/__tests__/cli-error-reporter.test.ts
+++ b/packages/core/src/telemetry/__tests__/cli-error-reporter.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	buildCliErrorPayload,
+	isCliTelemetryOptedOut,
+	sendCliErrorReport,
+} from "../cli-error-reporter";
+
+// ── Env hygiene ─────────────────────────────────────────────────────────────
+
+const ORIGINAL_ENV = { ...process.env };
+const originalFetch = globalThis.fetch;
+const originalHome = process.env.HOME;
+
+function makeTempHome(): string {
+	const dir = join(
+		tmpdir(),
+		`maina-cli-tel-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	mkdirSync(join(dir, ".maina"), { recursive: true });
+	return dir;
+}
+
+beforeEach(() => {
+	delete process.env.MAINA_TELEMETRY;
+	delete process.env.DO_NOT_TRACK;
+	delete process.env.CI;
+	process.env.HOME = makeTempHome();
+});
+
+afterEach(() => {
+	if (originalHome === undefined) {
+		delete process.env.HOME;
+	} else {
+		process.env.HOME = originalHome;
+	}
+	process.env = { ...ORIGINAL_ENV };
+	globalThis.fetch = originalFetch;
+});
+
+// ── Payload shape ──────────────────────────────────────────────────────────
+
+describe("buildCliErrorPayload", () => {
+	test("produces payload matching server validator shape", () => {
+		const err = new TypeError(
+			"Cannot read properties of undefined (reading 'toLowerCase')",
+		);
+		const payload = buildCliErrorPayload(err, {
+			mainaVersion: "1.5.1",
+			command: "sync pull",
+		});
+
+		expect(payload.errorClass).toBe("TypeError");
+		expect(payload.errorMessage).toContain("Cannot read properties");
+		expect(payload.mainaVersion).toBe("1.5.1");
+		expect(payload.command).toBe("sync pull");
+		expect(payload.platform).toBe(process.platform);
+		expect(payload.arch).toBe(process.arch);
+		expect(payload.nodeVersion).toBe(process.version);
+		expect(payload.ci).toBe(false);
+		expect(payload.errorId).toMatch(/^[a-f0-9]{32}$/);
+	});
+
+	test("derives command from argv when not passed explicitly", () => {
+		const payload = buildCliErrorPayload(new Error("boom"), {
+			mainaVersion: "1.5.1",
+			argv: ["bun", "/path/cli.js", "team", "info", "--verbose"],
+		});
+
+		expect(payload.command).toBe("team info");
+	});
+
+	test("ci flag reflects CI env var", () => {
+		process.env.CI = "true";
+		const payload = buildCliErrorPayload(new Error("x"), {
+			mainaVersion: "1.5.1",
+			command: "verify",
+		});
+		expect(payload.ci).toBe(true);
+	});
+
+	test("scrubs absolute /Users/... paths from message and stack", () => {
+		const err = new Error("failed to read /Users/bikash/secret/file.ts");
+		err.stack =
+			"Error: boom\n    at parse (/Users/bikash/code/maina/packages/core/src/verify/typecheck.ts:42:10)";
+
+		const payload = buildCliErrorPayload(err, {
+			mainaVersion: "1.5.1",
+			command: "verify",
+		});
+
+		expect(payload.errorMessage).not.toContain("/Users/bikash");
+		expect(payload.errorStack).not.toContain("/Users/bikash");
+	});
+
+	test("scrubs /tmp/... paths down to basenames", () => {
+		const err = new Error("read /tmp/weird/secret.txt failed");
+		const payload = buildCliErrorPayload(err, {
+			mainaVersion: "1.5.1",
+			command: "verify",
+		});
+		expect(payload.errorMessage).not.toContain("/tmp/weird");
+		expect(payload.errorMessage).toContain("secret.txt");
+	});
+
+	test("leaves fraction-looking tokens like 5/10 intact", () => {
+		const err = new Error("retry 5/10 timed out");
+		const payload = buildCliErrorPayload(err, {
+			mainaVersion: "1.5.1",
+			command: "verify",
+		});
+		expect(payload.errorMessage).toContain("5/10");
+	});
+
+	test("wraps non-Error throws", () => {
+		const payload = buildCliErrorPayload("raw string boom", {
+			mainaVersion: "1.5.1",
+			command: "x",
+		});
+		expect(payload.errorClass).toBe("Error");
+		expect(payload.errorMessage).toContain("raw string boom");
+	});
+
+	test("errorId is unique across calls (pid + hrtime + uuid)", () => {
+		const a = buildCliErrorPayload(new Error("x"), {
+			mainaVersion: "1.5.1",
+			command: "y",
+		});
+		const b = buildCliErrorPayload(new Error("x"), {
+			mainaVersion: "1.5.1",
+			command: "y",
+		});
+		expect(a.errorId).not.toBe(b.errorId);
+	});
+});
+
+// ── Opt-out ─────────────────────────────────────────────────────────────────
+
+describe("isCliTelemetryOptedOut", () => {
+	test("returns false by default", () => {
+		expect(isCliTelemetryOptedOut()).toBe(false);
+	});
+
+	test("respects MAINA_TELEMETRY=0", () => {
+		process.env.MAINA_TELEMETRY = "0";
+		expect(isCliTelemetryOptedOut()).toBe(true);
+	});
+
+	test("respects DO_NOT_TRACK=1", () => {
+		process.env.DO_NOT_TRACK = "1";
+		expect(isCliTelemetryOptedOut()).toBe(true);
+	});
+
+	test("respects ~/.maina/telemetry.json { optOut: true }", () => {
+		const home = process.env.HOME;
+		if (!home) throw new Error("test HOME not set");
+		writeFileSync(
+			join(home, ".maina", "telemetry.json"),
+			JSON.stringify({ optOut: true }),
+			"utf-8",
+		);
+		expect(isCliTelemetryOptedOut()).toBe(true);
+	});
+
+	test("does not opt out for { optOut: false }", () => {
+		const home = process.env.HOME;
+		if (!home) throw new Error("test HOME not set");
+		writeFileSync(
+			join(home, ".maina", "telemetry.json"),
+			JSON.stringify({ optOut: false }),
+			"utf-8",
+		);
+		expect(isCliTelemetryOptedOut()).toBe(false);
+	});
+
+	test("handles malformed telemetry.json gracefully", () => {
+		const home = process.env.HOME;
+		if (!home) throw new Error("test HOME not set");
+		writeFileSync(
+			join(home, ".maina", "telemetry.json"),
+			"{ not valid json",
+			"utf-8",
+		);
+		expect(isCliTelemetryOptedOut()).toBe(false);
+	});
+});
+
+// ── Transport ───────────────────────────────────────────────────────────────
+
+describe("sendCliErrorReport", () => {
+	test("POSTs payload to /v1/cli/errors", async () => {
+		const seen: { url: string; body: unknown } = { url: "", body: null };
+		const mockFetch = mock((url: string, init?: RequestInit) => {
+			seen.url = url;
+			seen.body = JSON.parse(String(init?.body ?? "null"));
+			return Promise.resolve(new Response(null, { status: 202 }));
+		});
+		globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+		await sendCliErrorReport(new Error("kaboom"), {
+			mainaVersion: "1.5.1",
+			command: "sync pull",
+			baseUrl: "https://api.test.maina.dev",
+		});
+
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+		expect(seen.url).toBe("https://api.test.maina.dev/v1/cli/errors");
+		expect((seen.body as { command: string }).command).toBe("sync pull");
+	});
+
+	test("skips POST when opted out", async () => {
+		process.env.MAINA_TELEMETRY = "0";
+		const mockFetch = mock(() =>
+			Promise.resolve(new Response(null, { status: 202 })),
+		);
+		globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+		await sendCliErrorReport(new Error("x"), {
+			mainaVersion: "1.5.1",
+			command: "verify",
+			baseUrl: "https://api.test.maina.dev",
+		});
+
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+
+	test("swallows network errors (never throws)", async () => {
+		globalThis.fetch = (() =>
+			Promise.reject(
+				new Error("network unreachable"),
+			)) as unknown as typeof fetch;
+
+		await expect(
+			sendCliErrorReport(new Error("x"), {
+				mainaVersion: "1.5.1",
+				command: "y",
+				baseUrl: "https://api.test.maina.dev",
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	test("resolves within timeout when server hangs", async () => {
+		globalThis.fetch = ((_url: string, init?: RequestInit) =>
+			new Promise((_resolve, reject) => {
+				// Honour abort so AbortController can short-circuit the hang
+				init?.signal?.addEventListener("abort", () =>
+					reject(new Error("aborted")),
+				);
+			})) as unknown as typeof fetch;
+
+		const start = Date.now();
+		await sendCliErrorReport(new Error("x"), {
+			mainaVersion: "1.5.1",
+			command: "y",
+			baseUrl: "https://api.test.maina.dev",
+			timeoutMs: 50,
+		});
+		const elapsed = Date.now() - start;
+		expect(elapsed).toBeLessThan(500);
+	});
+});

--- a/packages/core/src/telemetry/__tests__/cli-error-reporter.test.ts
+++ b/packages/core/src/telemetry/__tests__/cli-error-reporter.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {

--- a/packages/core/src/telemetry/cli-error-reporter.ts
+++ b/packages/core/src/telemetry/cli-error-reporter.ts
@@ -19,7 +19,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, join, win32 as winPath } from "node:path";
 import { scrubPii, scrubStackTrace } from "./scrubber";
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -76,12 +76,27 @@ export function isCliTelemetryOptedOut(): boolean {
 
 /**
  * Best-effort derivation of the command name from argv.
- * `bun /path/to/cli.js sync pull --flag` → `"sync pull"`.
+ *
+ * Stops at the first flag so a call like `maina commit -m "secret msg"` is
+ * reported as `"commit"`, not `"commit secret"` — option VALUES must never
+ * leak into telemetry.
  */
 function deriveCommand(argv: string[]): string {
-	const positional = argv.slice(2).filter((a) => !a.startsWith("-"));
+	const positional: string[] = [];
+	for (const arg of argv.slice(2)) {
+		if (arg.startsWith("-")) break;
+		positional.push(arg);
+	}
 	return positional.slice(0, 2).join(" ") || "(unknown)";
 }
+
+/**
+ * Unix roots whose contents are always filesystem paths (and never valid
+ * API-route or URL-path tokens). Anything else is left alone to avoid
+ * mangling strings like `/v1/cli/errors`.
+ */
+const UNIX_FILESYSTEM_ROOT =
+	/^\/(?:tmp|var|opt|etc|usr|bin|sbin|lib|srv|run|mnt|proc|sys|private|Volumes|dev|root)(?:\/|$)/;
 
 /**
  * Rewrite any absolute-looking path tokens to basenames. Runs AFTER the
@@ -91,16 +106,29 @@ function deriveCommand(argv: string[]): string {
 function pathsToBasenames(text: string): string {
 	return text.replace(
 		/(?:\/[A-Za-z0-9_.-][^\s:()"'<>]*|[A-Z]:\\[A-Za-z0-9_.-][^\s:()"'<>]*)/g,
-		(match) => {
-			// Leave already-scrubbed markers alone
+		(match, offset: number, source: string) => {
+			// Leave already-scrubbed markers alone, including repo-relative
+			// segments where the existing scrubber produced `<repo>/path/...`:
+			// the inner regex matches `/path/...` which doesn't contain `<repo>`.
 			if (match.includes("<repo>") || match.includes("<redacted")) return match;
-			// Only rewrite tokens that actually look like paths: either ending in
-			// a file extension, or containing two or more separators. This avoids
-			// mangling fractions like `5/10` in error messages.
+			if (source.slice(Math.max(0, offset - 6), offset) === "<repo>") {
+				return match;
+			}
+
+			const isWindowsPath = /^[A-Z]:\\/.test(match);
+			const isUnixFilesystemPath = UNIX_FILESYSTEM_ROOT.test(match);
+
+			// Only rewrite tokens that look like real filesystem paths. Leaves
+			// API routes (`/v1/cli/errors`), URLs (`http://...` — already skipped
+			// by leading slash check), and other slash-delimited non-paths alone.
+			if (!isWindowsPath && !isUnixFilesystemPath) return match;
+
+			// Secondary guard against short non-path tokens like `5/10`.
 			const hasExtension = /\.[A-Za-z]{1,10}$/.test(match);
 			const hasTwoSeparators = /[/\\].+[/\\]/.test(match);
 			if (!hasExtension && !hasTwoSeparators) return match;
-			return basename(match);
+
+			return isWindowsPath ? winPath.basename(match) : basename(match);
 		},
 	);
 }

--- a/packages/core/src/telemetry/cli-error-reporter.ts
+++ b/packages/core/src/telemetry/cli-error-reporter.ts
@@ -1,0 +1,178 @@
+/**
+ * CLI crash reporter — fire-and-forget anonymous telemetry for CLI errors.
+ *
+ * Consent model is opt-OUT, mirroring the `cloud-reporter` posture.
+ * User can opt out in three ways (any one suffices):
+ *   - `~/.maina/telemetry.json` with `{ "optOut": true }`
+ *   - `MAINA_TELEMETRY=0`
+ *   - `DO_NOT_TRACK=1`
+ *
+ * Payload matches the server validator at maina-cloud `POST /v1/cli/errors`.
+ * All string fields are scrubbed (paths → basenames, secrets → [REDACTED], etc.)
+ * defensively; the server scrubs again.
+ *
+ * The send is fire-and-forget: 1s timeout, all errors swallowed, never blocks
+ * the crash path. Callers print the original error to the user BEFORE calling
+ * this.
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import { scrubPii, scrubStackTrace } from "./scrubber";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface CliErrorPayload {
+	errorId: string;
+	command: string;
+	errorClass: string;
+	errorMessage: string;
+	errorStack: string;
+	mainaVersion: string;
+	nodeVersion: string;
+	platform: string;
+	arch: string;
+	ci: boolean;
+}
+
+export interface SendOptions {
+	mainaVersion: string;
+	command?: string;
+	argv?: string[];
+	baseUrl?: string;
+	timeoutMs?: number;
+}
+
+// ── Consent ─────────────────────────────────────────────────────────────────
+
+function telemetryConfigPath(): string {
+	// Honour $HOME first so tests (and container users overriding $HOME) work;
+	// fall back to the OS-reported home directory.
+	return join(process.env.HOME ?? homedir(), ".maina", "telemetry.json");
+}
+
+/**
+ * Returns true when the user has opted out of CLI telemetry.
+ * Any one of env var, DO_NOT_TRACK, or file flag is sufficient.
+ */
+export function isCliTelemetryOptedOut(): boolean {
+	if (process.env.MAINA_TELEMETRY === "0") return true;
+	if (process.env.DO_NOT_TRACK === "1") return true;
+
+	try {
+		const path = telemetryConfigPath();
+		if (!existsSync(path)) return false;
+		const raw = readFileSync(path, "utf-8");
+		const parsed = JSON.parse(raw) as { optOut?: boolean };
+		return parsed.optOut === true;
+	} catch {
+		return false;
+	}
+}
+
+// ── Payload ────────────────────────────────────────────────────────────────
+
+/**
+ * Best-effort derivation of the command name from argv.
+ * `bun /path/to/cli.js sync pull --flag` → `"sync pull"`.
+ */
+function deriveCommand(argv: string[]): string {
+	const positional = argv.slice(2).filter((a) => !a.startsWith("-"));
+	return positional.slice(0, 2).join(" ") || "(unknown)";
+}
+
+/**
+ * Rewrite any absolute-looking path tokens to basenames. Runs AFTER the
+ * existing scrubber which already handles `/Users/`, `/home/`, `C:\\Users\\`.
+ * This catches unusual roots (`/tmp`, `/opt`, `/var`, etc.).
+ */
+function pathsToBasenames(text: string): string {
+	return text.replace(
+		/(?:\/[A-Za-z0-9_.-][^\s:()"'<>]*|[A-Z]:\\[A-Za-z0-9_.-][^\s:()"'<>]*)/g,
+		(match) => {
+			// Leave already-scrubbed markers alone
+			if (match.includes("<repo>") || match.includes("<redacted")) return match;
+			// Only rewrite tokens that actually look like paths: either ending in
+			// a file extension, or containing two or more separators. This avoids
+			// mangling fractions like `5/10` in error messages.
+			const hasExtension = /\.[A-Za-z]{1,10}$/.test(match);
+			const hasTwoSeparators = /[/\\].+[/\\]/.test(match);
+			if (!hasExtension && !hasTwoSeparators) return match;
+			return basename(match);
+		},
+	);
+}
+
+export function buildCliErrorPayload(
+	error: unknown,
+	opts: SendOptions,
+): CliErrorPayload {
+	const errObj =
+		error instanceof Error ? error : new Error(String(error ?? "unknown"));
+
+	const errorId = createHash("sha256")
+		.update(`${process.pid}:${process.hrtime.bigint()}:${randomUUID()}`)
+		.digest("hex")
+		.slice(0, 32);
+
+	const command = opts.command ?? deriveCommand(opts.argv ?? process.argv);
+	const message = pathsToBasenames(scrubPii(errObj.message ?? ""));
+	const stack = pathsToBasenames(scrubStackTrace(errObj.stack ?? ""));
+
+	return {
+		errorId,
+		command,
+		errorClass: errObj.constructor.name,
+		errorMessage: message,
+		errorStack: stack,
+		mainaVersion: opts.mainaVersion,
+		nodeVersion: process.version,
+		platform: process.platform,
+		arch: process.arch,
+		ci: !!process.env.CI,
+	};
+}
+
+// ── Transport ───────────────────────────────────────────────────────────────
+
+/**
+ * Send a CLI error report to the cloud. Fire-and-forget: resolves whether or
+ * not the POST succeeded, never throws, never blocks longer than `timeoutMs`.
+ */
+export async function sendCliErrorReport(
+	error: unknown,
+	opts: SendOptions,
+): Promise<void> {
+	if (isCliTelemetryOptedOut()) return;
+
+	const baseUrl =
+		opts.baseUrl ?? process.env.MAINA_CLOUD_URL ?? "https://api.mainahq.com";
+	const timeoutMs = opts.timeoutMs ?? 1000;
+
+	let payload: CliErrorPayload;
+	try {
+		payload = buildCliErrorPayload(error, opts);
+	} catch {
+		return; // Never let telemetry amplify the crash
+	}
+
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		await fetch(`${baseUrl}/v1/cli/errors`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Accept: "application/json",
+			},
+			body: JSON.stringify(payload),
+			signal: controller.signal,
+		});
+	} catch {
+		// Swallow network/timeout/abort — never block the crash path
+	} finally {
+		clearTimeout(timer);
+	}
+}


### PR DESCRIPTION
## Summary

Addresses the two newest CLI gaps in one PR. First-principles rationale: issues #192 items 1–3 are pure user wins (today, users hit `Plan: undefined`, `sync pull` crashes, and an opaque `"Something went wrong"`). Telemetry (#192 item 4) and GitHub login (#193) unblock the structural fixes the cloud already shipped, so bundling them avoids a second round-trip.

### Closes
- Closes #192
- Closes #193

### Changes
- **`maina login --github`** — GitHub Device Flow. Polls `github.com/login/device/code` → `github.com/login/oauth/access_token`, then exchanges at `/auth/github/exchange`. Handles `authorization_pending`, `slow_down` (configurable backoff), `expired_token`, `access_denied`, and maps `invalid_github_token` / `provision_failed` / `github_user_lookup_failed` to actionable messages.
- **Unmask errors** — Top-level `uncaughtException` / `unhandledRejection` handler prints `err.code` + `err.message`. `--debug` (or `MAINA_DEBUG=1`) prints full stack. Registered as a global `--debug` option on the program.
- **Crash telemetry** — New `sendCliErrorReport` fire-and-forget POST to `/v1/cli/errors`. 1s timeout. Payload scrubs PII via the existing scrubber and rewrites remaining absolute paths (e.g. `/tmp/...`) to basenames, skipping fraction-like tokens such as `5/10`. Opt out via `MAINA_TELEMETRY=0`, `DO_NOT_TRACK=1`, or `~/.maina/telemetry.json` `{ "optOut": true }`. Opt-out design matches existing `cloud-reporter`.
- **`sync pull` no-crash** — Client returns `[]` when server sends `{ data: null }` or omits `data`. Action surfaces `"No team prompts yet."`
- **`team info` plan fallback** — Client maps `plan_display` (snake_case) and falls back to `plan`, then `"Free"`. Never renders `Plan: undefined`.

## Test plan

- [x] `bun test packages/core/src/cloud packages/core/src/telemetry packages/cli/src/__tests__` — 132 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run check` (Biome) — clean (pre-existing warnings only)
- [x] `maina commit` — verify pipeline passed (13 tools, 15s)
- [ ] CI green
- [ ] Manual: `maina sync pull` against a brand-new empty team exits 0 with "No team prompts yet."
- [ ] Manual: `maina team` renders `Plan: Free` when the server omits `plan_display`
- [ ] Manual: `maina --debug verify` prints a full stack on a synthesized throw
- [ ] Manual: once the OAuth app has Device Flow enabled, `maina login --github` completes end-to-end

## Notes

- **Opt-out vs opt-in for telemetry:** existing `reporter.ts` is opt-in (`~/.maina/config.yml` `errors: true`). The new crash reporter is opt-out, matching the issue spec, the existing `cloud-reporter`, and dev-tool norms (Sentry, VS Code, Rust). Scrubbing + README disclosure + three opt-out paths cover privacy concerns.
- **Legacy login path preserved.** Old `/auth/device` flow remains the default; `--github` is additive. Per issue #193's "Option 1" recommendation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub login adds a device-flow option and exchanges the GitHub token for a cloud session.
  * Anonymous CLI crash reporting (scrubbed payload) with opt-out via MAINA_TELEMETRY=0, DO_NOT_TRACK=1, or ~/.maina/telemetry.json.
  * Global --debug option to enable full stack traces on CLI errors.

* **Bug Fixes**
  * Prevented duplicate accounts by aligning identity with GitHub ID.
  * maina sync pull no longer crashes when a team has no prompts.
  * Plan display now falls back sensibly when server fields are missing.

* **Documentation**
  * Added Privacy & Telemetry section documenting crash reporting and opt-outs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->