### PR TITLE
fix(cli): harden sync pull loop + DEBUG=1 alias (#196)

### DIFF
--- a/.changeset/sync-pull-hardening.md
+++ b/.changeset/sync-pull-hardening.md
@@ -1,0 +1,15 @@
+---
+"@mainahq/cli": patch
+"@mainahq/core": patch
+"@mainahq/mcp": patch
+"@mainahq/skills": patch
+---
+
+**Harden `maina sync pull` + broaden `--debug`**
+
+Follow-up to #194, addresses #196.
+
+- `DEBUG=1` and `NODE_DEBUG=1` are now honoured as aliases for `MAINA_DEBUG=1`. Users naturally reach for the generic env var first.
+- `maina sync pull` now validates each prompt's `path` and `content` before writing to disk. Malformed records are skipped with a per-record reason instead of throwing out of the loop and leaving `@clack/prompts`' spinner monitor to print a generic `"Something went wrong"`. `mkdirSync` failures are caught and surfaced.
+- Empty-team response now shows `log.info("No team prompts yet.")` instead of a misleading `log.success("Pulled 0 prompt(s)")`.
+- Partial success (some records written, some skipped) surfaces a warning with the skipped count + reasons.

--- a/packages/cli/src/commands/__tests__/sync.test.ts
+++ b/packages/cli/src/commands/__tests__/sync.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for `syncPullAction` — specifically the defensive handling of
+ * malformed PromptRecords from the cloud, so a bad payload can no longer
+ * leak out as `@clack/prompts`' generic "Something went wrong" (#196).
+ *
+ * Uses `mock.module` to stub `@mainahq/core`; requires the repo's isolated
+ * test runner (`bun run test`) so the stub doesn't bleed into other files.
+ */
+
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+type PromptRecord = {
+	id: string;
+	path: string;
+	content: string;
+	hash: string;
+	updatedAt: string;
+};
+
+let mockPrompts: Array<Partial<PromptRecord>> = [];
+
+mock.module("@mainahq/core", () => ({
+	loadAuthConfig: () => ({ ok: true, value: { accessToken: "t" } }),
+	createCloudClient: () => ({
+		getPrompts: async () => ({ ok: true as const, value: mockPrompts }),
+	}),
+}));
+
+// Import AFTER mocking
+const { syncPullAction } = await import("../sync");
+
+function makeTempRoot(): string {
+	return mkdtempSync(join(tmpdir(), "maina-sync-test-"));
+}
+
+const tempRoots: string[] = [];
+
+afterAll(() => {
+	for (const dir of tempRoots) {
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	}
+});
+
+describe("syncPullAction", () => {
+	test("writes well-formed prompts to disk", async () => {
+		const root = makeTempRoot();
+		tempRoots.push(root);
+		mockPrompts = [
+			{
+				id: "commit",
+				path: "commit.md",
+				content: "# Commit",
+				hash: "h",
+				updatedAt: "2026-01-01T00:00:00Z",
+			},
+		];
+
+		const result = await syncPullAction(root);
+
+		expect(result.synced).toBe(true);
+		expect(result.count).toBe(1);
+		expect(existsSync(join(root, ".maina", "prompts", "commit.md"))).toBe(true);
+		expect(
+			readFileSync(join(root, ".maina", "prompts", "commit.md"), "utf-8"),
+		).toBe("# Commit");
+	});
+
+	test("returns friendly reason when team has no prompts", async () => {
+		const root = makeTempRoot();
+		tempRoots.push(root);
+		mockPrompts = [];
+
+		const result = await syncPullAction(root);
+
+		expect(result.synced).toBe(true);
+		expect(result.count).toBe(0);
+		expect(result.reason).toBe("No team prompts yet.");
+	});
+
+	test("skips records with missing path instead of throwing (#196)", async () => {
+		const root = makeTempRoot();
+		tempRoots.push(root);
+		mockPrompts = [
+			{ id: "bad", content: "body" }, // no .path — join() would throw
+			{
+				id: "good",
+				path: "good.md",
+				content: "# Good",
+				hash: "h",
+				updatedAt: "2026-01-01T00:00:00Z",
+			},
+		];
+
+		const result = await syncPullAction(root);
+
+		expect(result.synced).toBe(true);
+		expect(result.count).toBe(1);
+		expect(result.reason).toContain("Skipped 1");
+		expect(existsSync(join(root, ".maina", "prompts", "good.md"))).toBe(true);
+	});
+
+	test("skips records with non-string content", async () => {
+		const root = makeTempRoot();
+		tempRoots.push(root);
+		mockPrompts = [
+			{ id: "bad", path: "bad.md" }, // no .content — writeFileSync would throw
+		];
+
+		const result = await syncPullAction(root);
+
+		expect(result.synced).toBe(false);
+		expect(result.reason).toContain("skipped");
+	});
+
+	test("fails cleanly if every record is malformed", async () => {
+		const root = makeTempRoot();
+		tempRoots.push(root);
+		mockPrompts = [
+			{ id: "a" }, // missing path + content
+			{ id: "b", path: "" }, // empty path
+		];
+
+		const result = await syncPullAction(root);
+
+		expect(result.synced).toBe(false);
+		expect(result.reason).toMatch(/All 2 prompt\(s\) skipped/);
+	});
+});

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -125,14 +125,59 @@ export async function syncPullAction(cwd?: string): Promise<SyncActionResult> {
 		};
 	}
 
-	mkdirSync(promptsDir, { recursive: true });
-
-	for (const prompt of prompts) {
-		const filePath = join(promptsDir, prompt.path);
-		writeFileSync(filePath, prompt.content, "utf-8");
+	try {
+		mkdirSync(promptsDir, { recursive: true });
+	} catch (e) {
+		return {
+			synced: false,
+			count: 0,
+			reason: `Could not create ${promptsDir}: ${e instanceof Error ? e.message : String(e)}`,
+		};
 	}
 
-	return { synced: true, count: prompts.length };
+	let written = 0;
+	const skipped: string[] = [];
+
+	for (const prompt of prompts) {
+		// Defensive: a malformed server payload (missing path/content) used to
+		// throw out of the loop and leave `@clack/prompts`' spinner monitor to
+		// print a generic "Something went wrong" (see #196).
+		if (typeof prompt?.path !== "string" || prompt.path.length === 0) {
+			skipped.push(`<unknown id=${String(prompt?.id ?? "?")}>`);
+			continue;
+		}
+		if (typeof prompt.content !== "string") {
+			skipped.push(prompt.path);
+			continue;
+		}
+
+		try {
+			const filePath = join(promptsDir, prompt.path);
+			writeFileSync(filePath, prompt.content, "utf-8");
+			written++;
+		} catch (e) {
+			skipped.push(
+				`${prompt.path} (${e instanceof Error ? e.message : String(e)})`,
+			);
+		}
+	}
+
+	if (written === 0 && skipped.length > 0) {
+		return {
+			synced: false,
+			count: 0,
+			reason: `All ${skipped.length} prompt(s) skipped: ${skipped.join(", ")}`,
+		};
+	}
+
+	return {
+		synced: true,
+		count: written,
+		reason:
+			skipped.length > 0
+				? `Skipped ${skipped.length}: ${skipped.join(", ")}`
+				: undefined,
+	};
 }
 
 // ── Commander Command ───────────────────────────────────────────────────────
@@ -179,7 +224,16 @@ export function syncCommand(): Command {
 
 			if (result.synced) {
 				s.stop("Done");
-				log.success(`Pulled ${result.count} prompt(s) from cloud.`);
+				if (result.count === 0 && result.reason) {
+					// Empty team — show the friendly message instead of "Pulled 0".
+					log.info(result.reason);
+				} else {
+					log.success(`Pulled ${result.count} prompt(s) from cloud.`);
+					if (result.reason) {
+						// Partial success: some records were malformed and skipped.
+						log.warning(result.reason);
+					}
+				}
 				outro("Sync complete.");
 			} else {
 				s.stop("Failed");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,8 +5,13 @@ import pkg from "../package.json" with { type: "json" };
 
 // ── Top-level error handling ────────────────────────────────────────────────
 
+// `DEBUG=1` and `NODE_DEBUG=1` are honoured as aliases — users naturally
+// reach for the generic env vars before discovering our prefixed one.
 const DEBUG =
-	process.argv.includes("--debug") || process.env.MAINA_DEBUG === "1";
+	process.argv.includes("--debug") ||
+	process.env.MAINA_DEBUG === "1" ||
+	process.env.DEBUG === "1" ||
+	process.env.NODE_DEBUG === "1";
 
 function printAndReport(err: unknown, origin: string): void {
 	const e = err instanceof Error ? err : new Error(String(err ?? "unknown"));
@@ -20,7 +25,7 @@ function printAndReport(err: unknown, origin: string): void {
 		process.stderr.write(`${e.stack}\n`);
 	} else {
 		process.stderr.write(
-			"(run with --debug or MAINA_DEBUG=1 for full stack)\n",
+			"(run with --debug, MAINA_DEBUG=1, or DEBUG=1 for full stack)\n",
 		);
 	}
 

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -72,7 +72,7 @@ Setup & Config:
 		.version(pkg.version)
 		.option(
 			"--debug",
-			"print full stack traces and error codes on failure (also MAINA_DEBUG=1)",
+			"print full stack traces and error codes on failure (also MAINA_DEBUG=1 or DEBUG=1)",
 		);
 
 	// ── Workflow ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #194, addressing the two gaps surfaced in #196.

Closes #196.

## Root cause

v1.6.0 guarded `result.value ?? []` at the client layer, but the write loop in `syncPullAction` was still un-guarded:

```ts
for (const prompt of prompts) {
  const filePath = join(promptsDir, prompt.path);     // throws if prompt.path is undefined
  writeFileSync(filePath, prompt.content, "utf-8");   // throws if prompt.content is undefined
}
```

A single malformed `PromptRecord` — e.g. a server response with `{ content: "...", path: null }` — threw out of the loop, the action rejected, and `@clack/prompts`' spinner monitor printed its generic `"Something went wrong"` and exited 0 (Commander swallowed the async rejection before `process.on("unhandledRejection", ...)` could fire in every path).

## Changes

- **Per-record validation + isolation** in the pull loop. `path` and `content` are type-checked; any failure is recorded in `skipped[]` and the loop continues. `mkdirSync` is wrapped too.
- **Empty-team UX.** `pull` with zero prompts now prints `log.info("No team prompts yet.")` instead of `log.success("Pulled 0 prompt(s)")` which read like it missed something.
- **Partial-success warning.** If some records are written and some skipped, the count appears as success and the skip list as a warning.
- **`DEBUG=1` / `NODE_DEBUG=1` aliases** for `MAINA_DEBUG=1`. Users reach for the generic env var first; we now honour both. Help text updated.

## Test plan

- [x] 5 new tests in `packages/cli/src/commands/__tests__/sync.test.ts` covering: well-formed, empty-team, missing `.path`, missing `.content`, all-malformed.
- [x] `bun test packages/cli/src/commands/__tests__/sync.test.ts` — 5 pass
- [x] 86 pass across touched suites (sync, telemetry, cloud client/auth, cli)
- [x] `bun run typecheck` — clean
- [x] `bun run check` (Biome) — clean
- [x] `maina commit` — verify pipeline green

## Notes

- Slop detector flagged two 3-line comment blocks, both explanatory WHY context (why the defensive guards exist; why we accept `DEBUG=1`). Keeping per CLAUDE.md ("add a comment when the WHY is non-obvious").
- CodeRabbit's pending nit from #194 (persist `memberId`/`teamId`/`githubLogin` to `AuthConfig`) is still deferred — belongs with a `whoami` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `maina sync pull` now validates prompts before writing and gracefully skips malformed records instead of failing the entire operation.
  * Improved error handling for directory creation failures.
  * Fixed misleading success reports when no prompts are synced.

* **New Features**
  * Debug mode can now be enabled via `DEBUG=1` or `NODE_DEBUG=1` environment variables (in addition to existing `--debug` flag and `MAINA_DEBUG=1`).

* **Tests**
  * Added comprehensive tests for `sync pull` defensive behavior against malformed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->