### PR TITLE
fix(core): wiki obsidian links + module-path collision

### DIFF
--- a/packages/core/src/wiki/__tests__/compiler.test.ts
+++ b/packages/core/src/wiki/__tests__/compiler.test.ts
@@ -161,6 +161,21 @@ describe("Wiki Compiler", () => {
 			expect(moduleArticles.length).toBeGreaterThan(0);
 		});
 
+		it("gives every module article a unique path (no cross-community overwrite)", async () => {
+			// leiden-connected can split a Louvain community in two, so two
+			// communities can derive the same `moduleName`. The compiler must
+			// still emit distinct paths — last-write-wins would silently lose
+			// one of the articles.
+			const result = await compile(makeOptions());
+			expect(result.ok).toBe(true);
+			if (!result.ok) return;
+
+			const modulePaths = result.value.articles
+				.filter((a) => a.type === "module")
+				.map((a) => a.path);
+			expect(new Set(modulePaths).size).toBe(modulePaths.length);
+		});
+
 		it("should produce entity articles for top entities", async () => {
 			const result = await compile(makeOptions());
 			expect(result.ok).toBe(true);

--- a/packages/core/src/wiki/__tests__/export.test.ts
+++ b/packages/core/src/wiki/__tests__/export.test.ts
@@ -163,14 +163,45 @@ describe("exportObsidian", () => {
 		expect(matches.length).toBeGreaterThanOrEqual(2);
 	});
 
-	it("includes [[wikilinks]] for outgoing and incoming edges", () => {
+	it("includes [[wikilinks]] that resolve to canonical file paths", () => {
 		const files = exportObsidian(fixture(), NO_ARTICLES);
 		const greeterKey = findPath(files, "entity/entity_Greeter");
 		const greeter = (greeterKey && files[greeterKey]) || "";
+		const versionKey = findPath(files, "entity/entity_VERSION") ?? "";
+		const coreKey = findPath(files, "module/module_core") ?? "";
 		expect(greeter).toContain("## Outgoing");
-		expect(greeter).toContain("- references → [[entity:VERSION|VERSION]]");
+		// Links point at the actual file basename (minus .md), so Obsidian's
+		// resolver can reach the file even when the filename was hash-suffixed.
+		expect(greeter).toContain(
+			`- references → [[${versionKey.replace(/\.md$/, "")}|VERSION]]`,
+		);
 		expect(greeter).toContain("## Incoming");
-		expect(greeter).toContain("- contains ← [[module:core|core]]");
+		expect(greeter).toContain(
+			`- contains ← [[${coreKey.replace(/\.md$/, "")}|core]]`,
+		);
+	});
+
+	it("every wikilink target corresponds to a file the export actually wrote", () => {
+		const files = exportObsidian(fixture(), NO_ARTICLES);
+		// Collect the canonical set of page basenames (minus .md).
+		const pageBasenames = new Set(
+			Object.keys(files)
+				.filter((k) => k.endsWith(".md") && k !== "index.md")
+				.map((k) => k.replace(/\.md$/, "")),
+		);
+		// Every [[link|label]] in every page (including index) must target one
+		// of those basenames — raw ids are not valid on their own because the
+		// filename may carry a disambiguating hash suffix.
+		const linkRe = /\[\[([^|\]]+)\|/g;
+		for (const [, contents] of Object.entries(files)) {
+			for (const match of contents.matchAll(linkRe)) {
+				const target = match[1];
+				if (!target) continue;
+				// Skip Obsidian workspace JSON (not markdown).
+				if (target.startsWith("{")) continue;
+				expect(pageBasenames.has(target)).toBe(true);
+			}
+		}
 	});
 
 	it("frontmatter carries node metadata", () => {

--- a/packages/core/src/wiki/compiler.ts
+++ b/packages/core/src/wiki/compiler.ts
@@ -1121,7 +1121,11 @@ export async function compile(
 		// ── Step 6: Generate template-based articles ───────────────────
 		const articles: WikiArticle[] = [];
 
-		// Module articles — one per community.
+		// Module articles — one per community. leiden-connected can split a
+		// Louvain community in two, so two distinct communities can derive
+		// the same `moduleName`. Track used paths and suffix with the
+		// community id on collision so neither article gets overwritten.
+		const usedModulePaths = new Set<string>();
 		for (const [commId, members] of communityResult.communities) {
 			const moduleNodes = members.filter(
 				(m) => graph.nodes.get(m)?.type === "module",
@@ -1146,8 +1150,12 @@ export async function compile(
 				pageRankScores,
 			);
 
-			const safeName = moduleName.replace(/[^a-zA-Z0-9_-]/g, "-");
+			const safeBase = moduleName.replace(/[^a-zA-Z0-9_-]/g, "-");
+			const safeName = usedModulePaths.has(`wiki/modules/${safeBase}.md`)
+				? `${safeBase}-${commId}`
+				: safeBase;
 			const articlePath = `wiki/modules/${safeName}.md`;
+			usedModulePaths.add(articlePath);
 			const maxPR = Math.max(
 				0,
 				...memberEntities.map(

--- a/packages/core/src/wiki/export.ts
+++ b/packages/core/src/wiki/export.ts
@@ -198,6 +198,16 @@ function obsidianFilenameForNode(node: GraphNode): string {
 }
 
 /**
+ * Wikilink target for a node — same canonical path Obsidian will write,
+ * minus the `.md` extension. Using raw node ids would break navigation
+ * whenever `obsidianFilenameForNode` applies sanitisation or the hash
+ * suffix.
+ */
+function obsidianLinkForNode(node: GraphNode): string {
+	return obsidianFilenameForNode(node).replace(/\.md$/, "");
+}
+
+/**
  * Directory map: `path → file contents`. Caller writes each entry to disk.
  *
  * Layout:
@@ -254,7 +264,9 @@ export function exportObsidian(
 			for (const e of outs) {
 				const tgt = graph.nodes.get(e.target);
 				if (tgt) {
-					lines.push(`- ${e.type} → [[${tgt.id}|${tgt.label}]]`);
+					lines.push(
+						`- ${e.type} → [[${obsidianLinkForNode(tgt)}|${tgt.label}]]`,
+					);
 				}
 			}
 			lines.push("");
@@ -265,7 +277,9 @@ export function exportObsidian(
 			for (const e of ins) {
 				const src = graph.nodes.get(e.source);
 				if (src) {
-					lines.push(`- ${e.type} ← [[${src.id}|${src.label}]]`);
+					lines.push(
+						`- ${e.type} ← [[${obsidianLinkForNode(src)}|${src.label}]]`,
+					);
 				}
 			}
 			lines.push("");
@@ -285,7 +299,7 @@ export function exportObsidian(
 		index.push(`## ${type}`);
 		index.push("");
 		for (const n of byType.get(type) ?? []) {
-			index.push(`- [[${n.id}|${n.label}]]`);
+			index.push(`- [[${obsidianLinkForNode(n)}|${n.label}]]`);
 		}
 		index.push("");
 	}


### PR DESCRIPTION
## Summary
Two fixes from the CodeRabbit review on #203, both addressing real correctness bugs:

### 1. Obsidian wikilinks now target canonical filenames

The follow-up commit in #203 (`20fb642`) added a 6-char hash suffix to `obsidianFilenameForNode()` to prevent collisions like `foo/bar` vs `foo_bar`. It forgot to apply the same helper to the wikilinks inside each page's Outgoing/Incoming sections and the vault index — those still used `[[${node.id}|...]]` (raw id).

Whenever a node id contained a `:` (the normal case — `entity:Greeter`, `module:core`, etc.), `obsidianFilenameForNode` sanitised it and added the hash suffix, so the raw-id link pointed to a file that didn't exist. Dogfood on this repo confirmed the break: `[[entity:ABResolution|ABResolution]]` never resolved because the file is `entity/entity_ABResolution-17vsxy.md`.

Fix: added `obsidianLinkForNode(node)` that returns `obsidianFilenameForNode(node).replace(/\.md$/, "")`. All three link sites (outgoing, incoming, index) now use it.

### 2. Module article paths are deduped across communities

`compiler.ts` was building module paths as `wiki/modules/${safeName}.md` with no collision check. leiden-connected splits a Louvain community into connected components, so two distinct communities can legitimately produce the same `moduleName` (e.g., the two halves of a split cluster). Last-write-wins in `articles.push(...)` would silently lose one.

Fix: track `usedModulePaths` through the loop; on a hit, suffix `-${commId}`.

Didn't surface on this repo's QA (283 communities = 283 unique module names today) but it's latent on any repo where leiden-connected splits a cluster whose two halves share a dominant-label heuristic in `deriveCommunityName`.

## Test plan
- [x] New invariant test: `every wikilink target corresponds to a file the export actually wrote` — walks every `[[target|label]]` across every exported file and checks the target is a page basename the export produced
- [x] Existing `includes [[wikilinks]] for outgoing and incoming edges` rewritten against the canonical form
- [x] New defensive `gives every module article a unique path` regression in the compiler suite
- [x] `bun test packages/core/src/wiki/__tests__/` — 294 pass, 0 fail
- [x] `bun run typecheck` clean
- [x] `maina commit` verify pipeline passed (13 tools, same pre-existing warnings as #203)
- [x] Dogfood: ran `maina wiki compile` + `maina wiki export obsidian` on this repo, confirmed hash-suffixed files (e.g. `entity_ABResolution-17vsxy.md`) now have working `[[entity/entity_ABResolution-17vsxy|ABResolution]]` links and `[[module/module_prompts-1atdpq|prompts]]` references
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed wikilinks in exported content to correctly target generated markdown files
  * Resolved module naming conflicts when different communities produce modules with identical names

<!-- end of auto-generated comment: release notes by coderabbit.ai -->