### PR TITLE
fix(core): wiki-lint accuracy + status freshness (#208-#211)

### DIFF
--- a/.maina/features/052-wiki-lint-fixes/plan.md
+++ b/.maina/features/052-wiki-lint-fixes/plan.md
@@ -1,0 +1,153 @@
+# Implementation Plan
+
+> HOW only — see spec.md for WHAT and WHY.
+
+## Architecture
+
+What is the technical approach? How does it fit into existing architecture?
+Where are the integration points with existing code?
+
+- Pattern: [NEEDS CLARIFICATION]
+- Integration points: [NEEDS CLARIFICATION]
+
+## Key Technical Decisions
+
+What libraries, patterns, or approaches? WHY these and not alternatives?
+
+- [NEEDS CLARIFICATION]
+
+## Files
+
+| File | Purpose | New/Modified |
+|------|---------|-------------|
+| [NEEDS CLARIFICATION] | | |
+
+## Tasks
+
+TDD: every implementation task must have a preceding test task.
+
+- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
+
+## Failure Modes
+
+What can go wrong? How do we handle it gracefully?
+
+- [NEEDS CLARIFICATION]
+
+## Testing Strategy
+
+Unit tests, integration tests, or both? What mocks are needed?
+
+- [NEEDS CLARIFICATION]
+
+
+## Wiki Context
+
+### Related Modules
+
+- **wiki-62** (19 entities) — `modules/wiki-62.md`
+- **git** (11 entities) — `modules/git.md`
+- **wiki-56** (9 entities) — `modules/wiki-56.md`
+- **wiki-129** (8 entities) — `modules/wiki-129.md`
+- **tools-285** (7 entities) — `modules/tools-285.md`
+- **cluster-127** (7 entities) — `modules/cluster-127.md`
+- **wiki-63** (7 entities) — `modules/wiki-63.md`
+- **wiki-196** (7 entities) — `modules/wiki-196.md`
+- **cluster-131** (7 entities) — `modules/cluster-131.md`
+- **wiki-200** (7 entities) — `modules/wiki-200.md`
+- **verify-76** (6 entities) — `modules/verify-76.md`
+- **wiki-80** (6 entities) — `modules/wiki-80.md`
+- **wiki-111** (6 entities) — `modules/wiki-111.md`
+- **wiki-152** (6 entities) — `modules/wiki-152.md`
+- **wiki-71** (6 entities) — `modules/wiki-71.md`
+- **cluster-39** (6 entities) — `modules/cluster-39.md`
+- **wiki-148** (6 entities) — `modules/wiki-148.md`
+- **wiki** (5 entities) — `modules/wiki.md`
+- **wiki-81** (5 entities) — `modules/wiki-81.md`
+- **cluster-140** (5 entities) — `modules/cluster-140.md`
+- **wiki-211** (5 entities) — `modules/wiki-211.md`
+- **cluster-87** (4 entities) — `modules/cluster-87.md`
+- **wiki-150** (4 entities) — `modules/wiki-150.md`
+- **cluster-88** (4 entities) — `modules/cluster-88.md`
+- **wiki-151** (4 entities) — `modules/wiki-151.md`
+- **cluster-89** (4 entities) — `modules/cluster-89.md`
+- **wiki-153** (4 entities) — `modules/wiki-153.md`
+- **cluster-90** (4 entities) — `modules/cluster-90.md`
+- **wiki-149** (4 entities) — `modules/wiki-149.md`
+- **cluster-96** (3 entities) — `modules/cluster-96.md`
+- **context-161** (3 entities) — `modules/context-161.md`
+- **cluster-45** (3 entities) — `modules/cluster-45.md`
+- **tools-202** (3 entities) — `modules/tools-202.md`
+- **cluster-132** (3 entities) — `modules/cluster-132.md`
+- **extractors** (3 entities) — `modules/extractors.md`
+- **extractors-181** (2 entities) — `modules/extractors-181.md`
+- **cluster-138** (2 entities) — `modules/cluster-138.md`
+- **wiki-209** (2 entities) — `modules/wiki-209.md`
+- **wiki-170** (2 entities) — `modules/wiki-170.md`
+- **wiki-212** (2 entities) — `modules/wiki-212.md`
+- **wiki-187** (2 entities) — `modules/wiki-187.md`
+- **cluster-116** (2 entities) — `modules/cluster-116.md`
+- **wiki-91** (2 entities) — `modules/wiki-91.md`
+- **cluster-115** (2 entities) — `modules/cluster-115.md`
+- **cluster-105** (2 entities) — `modules/cluster-105.md`
+- **wiki-201** (2 entities) — `modules/wiki-201.md`
+- **cluster-120** (2 entities) — `modules/cluster-120.md`
+- **extractors-182** (2 entities) — `modules/extractors-182.md`
+
+### Related Decisions
+
+- 0015-cli-mcp-coequal: CLI and MCP are co-equal first-class surfaces [accepted]
+- 0014-experiment-gate-stagehand-orama: Experiment gate criteria for Stagehand and Orama [accepted]
+- 0027-symbol-page-templates-for-wiki: Symbol page templates for wiki [accepted]
+- 0022-wiki-is-a-view-of-the-context-engine: Wiki is a view of the Context engine [proposed]
+- 0029-scip-type-script-ingest-for-wiki: SCIP TypeScript ingest for wiki [accepted]
+- 0022-wiki-is-a-view: Wiki is a view of the Context engine [accepted]
+- 0017-no-workkit-search: Kill decision — @workkit for wiki search [accepted]
+- 0003-fix-host-delegation-for-cli-ai-tasks: Fix host delegation for CLI AI tasks [proposed]
+- 0019-no-fern-no-sdk: Kill decision — Fern + multi-language SDKs [accepted]
+
+### Similar Features
+
+- 027-v10-launch: Implementation Plan
+- 049-wiki-graph-exporters: Implementation Plan
+- 039-lint-config-parsers: Implementation Plan
+- 035-wiki-foundation: Wiki Foundation (Sprint 0)
+- 043-symbol-page-templates: Implementation Plan
+- 038-wiki-is-a-view: Implementation Plan
+- 045-scip-typescript-ingest: Implementation Plan
+- 040-deepwiki-mcp: Implementation Plan
+
+### Suggestions
+
+- Module 'wiki-62' already has 19 entities — consider extending it
+- Module 'git' already has 11 entities — consider extending it
+- Module 'wiki-56' already has 9 entities — consider extending it
+- Module 'wiki-129' already has 8 entities — consider extending it
+- Module 'tools-285' already has 7 entities — consider extending it
+- Module 'cluster-127' already has 7 entities — consider extending it
+- Module 'wiki-63' already has 7 entities — consider extending it
+- Module 'wiki-196' already has 7 entities — consider extending it
+- Module 'cluster-131' already has 7 entities — consider extending it
+- Module 'wiki-200' already has 7 entities — consider extending it
+- Module 'verify-76' already has 6 entities — consider extending it
+- Module 'wiki-80' already has 6 entities — consider extending it
+- Module 'wiki-111' already has 6 entities — consider extending it
+- Module 'wiki-152' already has 6 entities — consider extending it
+- Module 'wiki-71' already has 6 entities — consider extending it
+- Module 'cluster-39' already has 6 entities — consider extending it
+- Module 'wiki-148' already has 6 entities — consider extending it
+- Feature 027-v10-launch did something similar — check wiki/features/027-v10-launch.md
+- Feature 049-wiki-graph-exporters did something similar — check wiki/features/049-wiki-graph-exporters.md
+- Feature 039-lint-config-parsers did something similar — check wiki/features/039-lint-config-parsers.md
+- Feature 035-wiki-foundation did something similar — check wiki/features/035-wiki-foundation.md
+- Feature 043-symbol-page-templates did something similar — check wiki/features/043-symbol-page-templates.md
+- Feature 038-wiki-is-a-view did something similar — check wiki/features/038-wiki-is-a-view.md
+- Feature 045-scip-typescript-ingest did something similar — check wiki/features/045-scip-typescript-ingest.md
+- Feature 040-deepwiki-mcp did something similar — check wiki/features/040-deepwiki-mcp.md
+- ADR 0015-cli-mcp-coequal (CLI and MCP are co-equal first-class surfaces) is accepted — ensure compatibility
+- ADR 0014-experiment-gate-stagehand-orama (Experiment gate criteria for Stagehand and Orama) is accepted — ensure compatibility
+- ADR 0027-symbol-page-templates-for-wiki (Symbol page templates for wiki) is accepted — ensure compatibility
+- ADR 0029-scip-type-script-ingest-for-wiki (SCIP TypeScript ingest for wiki) is accepted — ensure compatibility
+- ADR 0022-wiki-is-a-view (Wiki is a view of the Context engine) is accepted — ensure compatibility
+- ADR 0017-no-workkit-search (Kill decision — @workkit for wiki search) is accepted — ensure compatibility
+- ADR 0019-no-fern-no-sdk (Kill decision — Fern + multi-language SDKs) is accepted — ensure compatibility

--- a/.maina/features/052-wiki-lint-fixes/plan.md
+++ b/.maina/features/052-wiki-lint-fixes/plan.md
@@ -1,153 +1,71 @@
-# Implementation Plan
+# Implementation Plan — Wiki lint accuracy & status freshness fixes
 
 > HOW only — see spec.md for WHAT and WHY.
 
 ## Architecture
 
-What is the technical approach? How does it fit into existing architecture?
-Where are the integration points with existing code?
+All fixes are localized. Three files, one new helper, per-constraint flag, and a compile-time hash-population pass.
 
-- Pattern: [NEEDS CLARIFICATION]
-- Integration points: [NEEDS CLARIFICATION]
+- Pattern: **targeted bugfix** — no new abstractions, extend existing skip-list and constraint shape.
+- Integration points:
+  - `packages/core/src/verify/tools/wiki-lint.ts` — the lint engine.
+  - `packages/core/src/wiki/compiler.ts` — populate `state.fileHashes`.
+  - `packages/cli/src/commands/wiki/status.ts` — fix path join.
 
 ## Key Technical Decisions
 
-What libraries, patterns, or approaches? WHY these and not alternatives?
-
-- [NEEDS CLARIFICATION]
+- **Hardcoded skip list, not `.gitignore`.** `.gitignore` parsing is a future refactor; for this PR we just add `.claude`, `.maina`, `coverage`, `build`, `out`, `.next`, `.turbo`, `.cache` next to the existing `node_modules`/`dist`/`.git`. Rationale: 4 lines vs. pulling in a gitignore parser; behavior matches 99% of repos.
+- **Per-constraint `skipTests` flag.** Tests should still be scanned for `bun:test` (catches a jest import in a test) but not for `result<` (tests legitimately throw). A flag on `TechConstraint` lets each rule declare its policy.
+- **Import-form ESLint detection.** Replace the content regex `/\.eslintrc|eslint\.config/` — which matches any string occurrence — with `/from\s+["']eslint[\w\-\/"']/` + `/require\s*\(\s*["']eslint[\w\-\/"']\s*\)/`. The existing filename-level check at repo root (wiki-lint.ts:508-523) already catches real `.eslintrc` / `eslint.config.*` files, so this tightens without regression.
+- **Populate `fileHashes` during compile.** `WikiState.fileHashes` is declared but never written. Iterate over the source files already enumerated during compile and write `hashFile(path)` into state. That makes coverage = `articleHashCount / fileHashCount` meaningful.
+- **Fix path join in `countStaleArticles`.** Article keys are stored as `wiki/modules/foo.md`; `wikiDir` is `.maina/wiki`. `join(wikiDir, key)` produces `.maina/wiki/wiki/modules/foo.md` which never exists, so every article lands in the `existsSync === false` branch. Strip the leading `wiki/` before joining.
 
 ## Files
 
 | File | Purpose | New/Modified |
 |------|---------|-------------|
-| [NEEDS CLARIFICATION] | | |
+| `packages/core/src/verify/tools/wiki-lint.ts` | Skip-list expansion, `skipTests` flag, ESLint regex | Modified |
+| `packages/core/src/verify/tools/__tests__/wiki-lint.test.ts` | Tests for all three lint fixes | Modified |
+| `packages/core/src/wiki/compiler.ts` | Write `state.fileHashes` on compile | Modified |
+| `packages/core/src/wiki/__tests__/compiler.test.ts` | Test `fileHashes` populated after compile | Modified |
+| `packages/cli/src/commands/wiki/status.ts` | Fix path join, coverage calc | Modified |
+| `packages/cli/src/commands/__tests__/wiki.test.ts` | Test stale count + coverage with realistic state | Modified |
 
 ## Tasks
 
-TDD: every implementation task must have a preceding test task.
+TDD: tests before impl.
 
-- [ ] [NEEDS CLARIFICATION] Break down into small, testable tasks.
+- [ ] Add failing test: `collectSourceFiles` skips `.claude/worktrees/agent-*` and `.maina/features/*`.
+- [ ] Impl: extend skip list in `collectSourceFiles`.
+- [ ] Add failing test: `checkDecisionViolations` does NOT flag `*.test.ts` files against `result<` constraint.
+- [ ] Impl: add `skipTests?: boolean` to `TechConstraint`, default true for `result<` / `never throw`, apply filter at scan site.
+- [ ] Add failing test: `constitution/config-parsers.ts`-style content (string mention of `eslint.config`) is NOT flagged; content with `from "eslint"` IS flagged.
+- [ ] Impl: replace `/\.eslintrc|eslint\.config/` with import/require-form regexes.
+- [ ] Add failing test: after a compile, `state.fileHashes` has at least one entry; `wiki status` reports coverage > 0 and stale < total.
+- [ ] Impl (compiler): populate `state.fileHashes` from the file list already traversed during extraction.
+- [ ] Impl (status): fix `countStaleArticles` path join (strip leading `wiki/` or join against `cwd` instead of `wikiDir`).
 
 ## Failure Modes
 
-What can go wrong? How do we handle it gracefully?
-
-- [NEEDS CLARIFICATION]
+- **Skip list too aggressive** — if a user has legitimate source under `.maina/` or `coverage/`, it's silently skipped. Mitigation: skip list only covers well-known tool-output dirs; document in changelog.
+- **`skipTests` regex false positives/negatives** — pattern `/\.(test|spec)\.[jt]sx?$|\/__tests__\/|\/__mocks__\//` should be tight. Add tests for edge cases (`something.test.utils.ts` shouldn't be skipped).
+- **ESLint regex misses real violations** — the new pattern requires import-form, so a project using eslint via `package.json` scripts with no JS import won't be caught. Acceptable: the repo-root filename check still catches `.eslintrc*` / `eslint.config.*`, which is the real config surface.
+- **`fileHashes` perf regression** — hashing all source files adds IO. Already done in some form for change detection; we're just persisting it. Measure in test.
+- **Path-prefix fix breaks other code** — grep for other consumers of `state.articleHashes` keys before changing key format; safer to strip at read-time (in `countStaleArticles`) than to rewrite state format.
 
 ## Testing Strategy
 
-Unit tests, integration tests, or both? What mocks are needed?
-
-- [NEEDS CLARIFICATION]
-
+- **Unit** tests in the same `__tests__` dirs as the files changed. bun:test.
+- **Regression** check: run `bun packages/cli/dist/index.js wiki lint` on this repo after build. Expect ≤ 25 findings, zero under `.claude/worktrees/` or `.maina/`.
+- **Regression** check: run `wiki compile` then `wiki status`; expect `Coverage: > 0%`, `Stale: < total`, `Last compile: <today>`.
+- No mocks for the lint code — it reads real files. Use `tmpdir` fixtures.
 
 ## Wiki Context
 
-### Related Modules
-
-- **wiki-62** (19 entities) — `modules/wiki-62.md`
-- **git** (11 entities) — `modules/git.md`
-- **wiki-56** (9 entities) — `modules/wiki-56.md`
-- **wiki-129** (8 entities) — `modules/wiki-129.md`
-- **tools-285** (7 entities) — `modules/tools-285.md`
-- **cluster-127** (7 entities) — `modules/cluster-127.md`
-- **wiki-63** (7 entities) — `modules/wiki-63.md`
-- **wiki-196** (7 entities) — `modules/wiki-196.md`
-- **cluster-131** (7 entities) — `modules/cluster-131.md`
-- **wiki-200** (7 entities) — `modules/wiki-200.md`
-- **verify-76** (6 entities) — `modules/verify-76.md`
-- **wiki-80** (6 entities) — `modules/wiki-80.md`
-- **wiki-111** (6 entities) — `modules/wiki-111.md`
-- **wiki-152** (6 entities) — `modules/wiki-152.md`
-- **wiki-71** (6 entities) — `modules/wiki-71.md`
-- **cluster-39** (6 entities) — `modules/cluster-39.md`
-- **wiki-148** (6 entities) — `modules/wiki-148.md`
-- **wiki** (5 entities) — `modules/wiki.md`
-- **wiki-81** (5 entities) — `modules/wiki-81.md`
-- **cluster-140** (5 entities) — `modules/cluster-140.md`
-- **wiki-211** (5 entities) — `modules/wiki-211.md`
-- **cluster-87** (4 entities) — `modules/cluster-87.md`
-- **wiki-150** (4 entities) — `modules/wiki-150.md`
-- **cluster-88** (4 entities) — `modules/cluster-88.md`
-- **wiki-151** (4 entities) — `modules/wiki-151.md`
-- **cluster-89** (4 entities) — `modules/cluster-89.md`
-- **wiki-153** (4 entities) — `modules/wiki-153.md`
-- **cluster-90** (4 entities) — `modules/cluster-90.md`
-- **wiki-149** (4 entities) — `modules/wiki-149.md`
-- **cluster-96** (3 entities) — `modules/cluster-96.md`
-- **context-161** (3 entities) — `modules/context-161.md`
-- **cluster-45** (3 entities) — `modules/cluster-45.md`
-- **tools-202** (3 entities) — `modules/tools-202.md`
-- **cluster-132** (3 entities) — `modules/cluster-132.md`
-- **extractors** (3 entities) — `modules/extractors.md`
-- **extractors-181** (2 entities) — `modules/extractors-181.md`
-- **cluster-138** (2 entities) — `modules/cluster-138.md`
-- **wiki-209** (2 entities) — `modules/wiki-209.md`
-- **wiki-170** (2 entities) — `modules/wiki-170.md`
-- **wiki-212** (2 entities) — `modules/wiki-212.md`
-- **wiki-187** (2 entities) — `modules/wiki-187.md`
-- **cluster-116** (2 entities) — `modules/cluster-116.md`
-- **wiki-91** (2 entities) — `modules/wiki-91.md`
-- **cluster-115** (2 entities) — `modules/cluster-115.md`
-- **cluster-105** (2 entities) — `modules/cluster-105.md`
-- **wiki-201** (2 entities) — `modules/wiki-201.md`
-- **cluster-120** (2 entities) — `modules/cluster-120.md`
-- **extractors-182** (2 entities) — `modules/extractors-182.md`
+(Context block from `maina plan` preserved below for reference.)
 
 ### Related Decisions
 
-- 0015-cli-mcp-coequal: CLI and MCP are co-equal first-class surfaces [accepted]
-- 0014-experiment-gate-stagehand-orama: Experiment gate criteria for Stagehand and Orama [accepted]
-- 0027-symbol-page-templates-for-wiki: Symbol page templates for wiki [accepted]
-- 0022-wiki-is-a-view-of-the-context-engine: Wiki is a view of the Context engine [proposed]
-- 0029-scip-type-script-ingest-for-wiki: SCIP TypeScript ingest for wiki [accepted]
-- 0022-wiki-is-a-view: Wiki is a view of the Context engine [accepted]
-- 0017-no-workkit-search: Kill decision — @workkit for wiki search [accepted]
-- 0003-fix-host-delegation-for-cli-ai-tasks: Fix host delegation for CLI AI tasks [proposed]
-- 0019-no-fern-no-sdk: Kill decision — Fern + multi-language SDKs [accepted]
-
-### Similar Features
-
-- 027-v10-launch: Implementation Plan
-- 049-wiki-graph-exporters: Implementation Plan
-- 039-lint-config-parsers: Implementation Plan
-- 035-wiki-foundation: Wiki Foundation (Sprint 0)
-- 043-symbol-page-templates: Implementation Plan
-- 038-wiki-is-a-view: Implementation Plan
-- 045-scip-typescript-ingest: Implementation Plan
-- 040-deepwiki-mcp: Implementation Plan
-
-### Suggestions
-
-- Module 'wiki-62' already has 19 entities — consider extending it
-- Module 'git' already has 11 entities — consider extending it
-- Module 'wiki-56' already has 9 entities — consider extending it
-- Module 'wiki-129' already has 8 entities — consider extending it
-- Module 'tools-285' already has 7 entities — consider extending it
-- Module 'cluster-127' already has 7 entities — consider extending it
-- Module 'wiki-63' already has 7 entities — consider extending it
-- Module 'wiki-196' already has 7 entities — consider extending it
-- Module 'cluster-131' already has 7 entities — consider extending it
-- Module 'wiki-200' already has 7 entities — consider extending it
-- Module 'verify-76' already has 6 entities — consider extending it
-- Module 'wiki-80' already has 6 entities — consider extending it
-- Module 'wiki-111' already has 6 entities — consider extending it
-- Module 'wiki-152' already has 6 entities — consider extending it
-- Module 'wiki-71' already has 6 entities — consider extending it
-- Module 'cluster-39' already has 6 entities — consider extending it
-- Module 'wiki-148' already has 6 entities — consider extending it
-- Feature 027-v10-launch did something similar — check wiki/features/027-v10-launch.md
-- Feature 049-wiki-graph-exporters did something similar — check wiki/features/049-wiki-graph-exporters.md
-- Feature 039-lint-config-parsers did something similar — check wiki/features/039-lint-config-parsers.md
-- Feature 035-wiki-foundation did something similar — check wiki/features/035-wiki-foundation.md
-- Feature 043-symbol-page-templates did something similar — check wiki/features/043-symbol-page-templates.md
-- Feature 038-wiki-is-a-view did something similar — check wiki/features/038-wiki-is-a-view.md
-- Feature 045-scip-typescript-ingest did something similar — check wiki/features/045-scip-typescript-ingest.md
-- Feature 040-deepwiki-mcp did something similar — check wiki/features/040-deepwiki-mcp.md
-- ADR 0015-cli-mcp-coequal (CLI and MCP are co-equal first-class surfaces) is accepted — ensure compatibility
-- ADR 0014-experiment-gate-stagehand-orama (Experiment gate criteria for Stagehand and Orama) is accepted — ensure compatibility
-- ADR 0027-symbol-page-templates-for-wiki (Symbol page templates for wiki) is accepted — ensure compatibility
-- ADR 0029-scip-type-script-ingest-for-wiki (SCIP TypeScript ingest for wiki) is accepted — ensure compatibility
-- ADR 0022-wiki-is-a-view (Wiki is a view of the Context engine) is accepted — ensure compatibility
-- ADR 0017-no-workkit-search (Kill decision — @workkit for wiki search) is accepted — ensure compatibility
-- ADR 0019-no-fern-no-sdk (Kill decision — Fern + multi-language SDKs) is accepted — ensure compatibility
+- 0019-no-fern-no-sdk — "requires biome" keyword — the rule this PR makes more accurate.
+- 0012-v050-cloud-client-maina-cloud — "requires result<" keyword — the rule this PR restricts to non-test files.
+- 0022-wiki-is-a-view — wiki is a view of the Context engine; coverage/staleness signals feed it.

--- a/.maina/features/052-wiki-lint-fixes/spec.md
+++ b/.maina/features/052-wiki-lint-fixes/spec.md
@@ -1,0 +1,45 @@
+# Feature: [Name]
+
+## Problem Statement
+
+What specific problem does this solve? Who experiences it? What happens if we don't solve it?
+
+- [NEEDS CLARIFICATION] Define the problem clearly.
+
+## Target User
+
+Who benefits? What is their current workflow? What frustrates them about it?
+
+- Primary: [NEEDS CLARIFICATION]
+- Secondary: [NEEDS CLARIFICATION]
+
+## User Stories
+
+- As a [role], I want [capability] so that [benefit].
+
+## Success Criteria
+
+How do we know this works? Every criterion must be testable — if you can't write
+an assertion for it, the requirement isn't clear enough.
+
+- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+
+## Scope
+
+### In Scope
+
+- [NEEDS CLARIFICATION] What this feature does.
+
+### Out of Scope
+
+- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
+
+## Design Decisions
+
+Key choices made and WHY. Record tradeoffs — future you will thank you.
+
+- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
+
+## Open Questions
+
+- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.

--- a/.maina/features/052-wiki-lint-fixes/spec.md
+++ b/.maina/features/052-wiki-lint-fixes/spec.md
@@ -51,7 +51,7 @@ Closes #208, #209, #210, #211.
 - **Skip list over `.gitignore` parsing.** Hardcoded skip list is boring and correct; honoring `.gitignore` is better long-term but out of scope — single-PR constraint.
 - **Per-constraint `skipTests` flag** (default `true` for `result<` / `never throw`, `false` for import-form checks like `bun:test`). This preserves existing catches where tests *should* be scanned (e.g. a test importing jest is still a violation).
 - **ESLint detection: require import-form.** Switch `/\.eslintrc|eslint\.config/` content regex to `/from\s+["']eslint(["']|\/)/` + `/require\s*\(\s*["']eslint(["']|\/)\s*\)/`. Filename-level check at root already catches real eslint config files — no regression.
-- **Compile writes `lastCompile` timestamp.** Simplest fix — existing state file already has fields; add one more and read it from status.
+- **Compile populates `state.fileHashes` + status reads existing `state.lastFullCompile`/`state.lastIncrementalCompile`.** The last-compile timestamp fields already exist and are written by compile; status just had the wrong path join and the coverage denominator (`fileHashCount`) was always 0 because compile never wrote `fileHashes`. Populate the field on full compile and fix the path join — no new state fields needed.
 
 ## Open Questions
 

--- a/.maina/features/052-wiki-lint-fixes/spec.md
+++ b/.maina/features/052-wiki-lint-fixes/spec.md
@@ -22,8 +22,8 @@ Closes #208, #209, #210, #211.
 - [ ] Running `wiki lint` on this repo produces ≤ 25 findings (vs. 77 today), and **zero** findings come from paths under `.claude/worktrees/` or `.maina/`.
 - [ ] No `*.test.ts` / `*.spec.ts` / `__tests__/` file is flagged by the `result<` (throw-based) constraint.
 - [ ] `packages/core/src/constitution/config-parsers.ts` and `packages/core/src/verify/tools/wiki-lint.ts` are **not** flagged as "uses ESLint configuration".
-- [ ] After `wiki compile`, `wiki status` shows `Last compile` ≥ the compile run's timestamp, and `Stale` reflects only articles whose source mtime is newer than the compile timestamp.
-- [ ] Unit tests cover: worktree/`.claude`/`.maina` exclusion, test-file exclusion for production-code constraints, ESLint detection requires import-form or real config filename, status freshness updated on compile success.
+- [ ] After `wiki compile`, `wiki status` reports `Coverage > 0%`, `Stale == 0`, and a `Last compile` timestamp from the run. Staleness is computed by hashing each on-disk article and comparing against the hash recorded in `state.articleHashes` at compile time (mismatches / missing files count as stale); coverage is `articleCount / fileHashCount`, where `fileHashCount` is populated by the compile run. `Last compile` is the last successful compile's ISO timestamp from `state.lastFullCompile` / `state.lastIncrementalCompile`.
+- [ ] Unit tests cover: worktree/`.claude`/`.maina` exclusion, test-file exclusion for production-code constraints, ESLint detection requires import-form or real config filename, status reports non-zero coverage and zero stale immediately after compile.
 
 ## Scope
 
@@ -35,8 +35,9 @@ Closes #208, #209, #210, #211.
   - Rewrite the `biome`-vs-ESLint content regex to match only real usage signals (import/require of `eslint*` packages), not any occurrence of the string.
   - Keep the root-config filename check (already correct at ~L508-523).
 - Wiki compile/status freshness:
-  - On successful compile, persist a `lastCompile` timestamp to `.maina/wiki/.state.json` (or wherever the state lives).
-  - `wiki status` computes staleness against that timestamp.
+  - Populate `state.fileHashes` on a full compile — the field exists in the schema but was never written, so coverage was stuck at 0%. Skip on sample compiles so a truncated file set doesn't overwrite a prior full compile's canonical state.
+  - Fix `countStaleArticles`'s path join: article keys in state are `wiki/modules/foo.md` but `wikiDir` is `.maina/wiki`, so `join(wikiDir, key)` produced `.maina/wiki/wiki/modules/foo.md` — a path that never exists. Strip the leading `wiki/` before joining.
+  - `wiki status` reads the last compile timestamp from `state.lastFullCompile` / `state.lastIncrementalCompile`, which compile already writes.
 - Tests for each fix (TDD).
 
 ### Out of Scope

--- a/.maina/features/052-wiki-lint-fixes/spec.md
+++ b/.maina/features/052-wiki-lint-fixes/spec.md
@@ -1,45 +1,57 @@
-# Feature: [Name]
+# Feature: Wiki lint accuracy & status freshness fixes
+
+Closes #208, #209, #210, #211.
 
 ## Problem Statement
 
-What specific problem does this solve? Who experiences it? What happens if we don't solve it?
-
-- [NEEDS CLARIFICATION] Define the problem clearly.
+`maina wiki lint` reports 77 decision-violation errors on our own repo — roughly 65 of them are false positives. `maina wiki status` reports 100% stale articles and 0% coverage immediately after a successful compile. Users cannot trust either signal, and CI/pre-push gates built on them would block on noise. This is a credibility bug: the wiki tooling actively fails on its own codebase.
 
 ## Target User
 
-Who benefits? What is their current workflow? What frustrates them about it?
-
-- Primary: [NEEDS CLARIFICATION]
-- Secondary: [NEEDS CLARIFICATION]
+- Primary: any maina user running `wiki lint` or `wiki status` in a repo that has agent worktrees, test files that `throw`, or code that parses ESLint configs (i.e. most repos using maina).
+- Secondary: CI/pre-push automation that gates merges on lint severity and coverage.
 
 ## User Stories
 
-- As a [role], I want [capability] so that [benefit].
+- As a developer, I want `wiki lint` to report only real decision violations, so the output is trustworthy.
+- As a developer, I want `wiki status` to reflect reality right after I compile, so I can tell when the wiki is actually stale.
+- As a CI author, I want lint counts to be stable and meaningful, so I can gate on them without flakes.
 
 ## Success Criteria
 
-How do we know this works? Every criterion must be testable — if you can't write
-an assertion for it, the requirement isn't clear enough.
-
-- [ ] [NEEDS CLARIFICATION] Define measurable, testable criteria.
+- [ ] Running `wiki lint` on this repo produces ≤ 25 findings (vs. 77 today), and **zero** findings come from paths under `.claude/worktrees/` or `.maina/`.
+- [ ] No `*.test.ts` / `*.spec.ts` / `__tests__/` file is flagged by the `result<` (throw-based) constraint.
+- [ ] `packages/core/src/constitution/config-parsers.ts` and `packages/core/src/verify/tools/wiki-lint.ts` are **not** flagged as "uses ESLint configuration".
+- [ ] After `wiki compile`, `wiki status` shows `Last compile` ≥ the compile run's timestamp, and `Stale` reflects only articles whose source mtime is newer than the compile timestamp.
+- [ ] Unit tests cover: worktree/`.claude`/`.maina` exclusion, test-file exclusion for production-code constraints, ESLint detection requires import-form or real config filename, status freshness updated on compile success.
 
 ## Scope
 
 ### In Scope
 
-- [NEEDS CLARIFICATION] What this feature does.
+- `packages/core/src/verify/tools/wiki-lint.ts`:
+  - Extend `collectSourceFiles` skip list to cover `.claude`, `.maina`, `coverage`, `build`, `out`, `.next`, `.turbo`, `.cache`.
+  - Skip test files (`*.test.*`, `*.spec.*`, `__tests__/`, `__mocks__/`) for constraints whose `keyword` implies production-code semantics (`result<`, `never throw`).
+  - Rewrite the `biome`-vs-ESLint content regex to match only real usage signals (import/require of `eslint*` packages), not any occurrence of the string.
+  - Keep the root-config filename check (already correct at ~L508-523).
+- Wiki compile/status freshness:
+  - On successful compile, persist a `lastCompile` timestamp to `.maina/wiki/.state.json` (or wherever the state lives).
+  - `wiki status` computes staleness against that timestamp.
+- Tests for each fix (TDD).
 
 ### Out of Scope
 
-- [NEEDS CLARIFICATION] What this feature explicitly does NOT do (prevents over-building).
+- Redesigning the `TechConstraint` schema beyond adding a `skipTests` flag.
+- Fixing unrelated checks (spec_drift, orphan_entity, etc.) — only the four reported bugs.
+- The count-mismatch between compile (287 modules) and status (441 modules) beyond what fixing worktree-scan fixes automatically. If the discrepancy persists after the fix, leave a follow-up note in #211 rather than widening scope here.
 
 ## Design Decisions
 
-Key choices made and WHY. Record tradeoffs — future you will thank you.
-
-- [NEEDS CLARIFICATION] What alternatives were considered? Why was this one chosen?
+- **Skip list over `.gitignore` parsing.** Hardcoded skip list is boring and correct; honoring `.gitignore` is better long-term but out of scope — single-PR constraint.
+- **Per-constraint `skipTests` flag** (default `true` for `result<` / `never throw`, `false` for import-form checks like `bun:test`). This preserves existing catches where tests *should* be scanned (e.g. a test importing jest is still a violation).
+- **ESLint detection: require import-form.** Switch `/\.eslintrc|eslint\.config/` content regex to `/from\s+["']eslint(["']|\/)/` + `/require\s*\(\s*["']eslint(["']|\/)\s*\)/`. Filename-level check at root already catches real eslint config files — no regression.
+- **Compile writes `lastCompile` timestamp.** Simplest fix — existing state file already has fields; add one more and read it from status.
 
 ## Open Questions
 
-- [NEEDS CLARIFICATION] List ambiguities. Every question here must be resolved before implementation.
+None — all four issues are well-characterized and the root causes are in code I've already read.

--- a/.maina/features/052-wiki-lint-fixes/tasks.md
+++ b/.maina/features/052-wiki-lint-fixes/tasks.md
@@ -1,0 +1,23 @@
+# Task Breakdown
+
+## Tasks
+
+Each task should be completable in one commit. Test tasks precede implementation tasks.
+
+- [ ] [NEEDS CLARIFICATION] Define tasks.
+
+## Dependencies
+
+Which tasks block which? Draw the critical path.
+
+- [NEEDS CLARIFICATION]
+
+## Definition of Done
+
+How do we know this feature is complete?
+
+- [ ] All tests pass
+- [ ] Biome lint clean
+- [ ] TypeScript compiles
+- [ ] maina analyze shows no errors
+- [ ] [NEEDS CLARIFICATION] Feature-specific criteria

--- a/.maina/features/052-wiki-lint-fixes/tasks.md
+++ b/.maina/features/052-wiki-lint-fixes/tasks.md
@@ -2,22 +2,28 @@
 
 ## Tasks
 
-Each task should be completable in one commit. Test tasks precede implementation tasks.
+All tests precede implementation — each `T*` below was a failing test before the corresponding `I*`.
 
-- [ ] [NEEDS CLARIFICATION] Define tasks.
+- [x] **T1** — Tests for `.claude/worktrees/` and `.maina/` exclusion in `collectSourceFiles`.
+- [x] **I1** — Extend `SKIP_DIRS` set in `packages/core/src/verify/tools/wiki-lint.ts` to cover `.claude`, `.maina`, `coverage`, `build`, `out`, `.next`, `.turbo`, `.cache`.
+- [x] **T2** — Test that `*.test.ts` / `__tests__/` / `tests/` files are NOT flagged by the `result<` constraint, plus a regression guard that a test file importing `jest` IS still flagged.
+- [x] **I2** — Add `skipTests?: boolean` on `TechConstraint`; set true for `result<` and `never throw`. Add `isTestFile()` helper matching `*.test.*`, `*.spec.*`, `__tests__/`, `__mocks__/`, `test/`, `tests/`.
+- [x] **T3** — Test that files mentioning `eslint.config` in a string literal are NOT flagged; static import, side-effect import, top-level `await import(...)`, and bare `require("eslint")` ARE flagged.
+- [x] **I3** — Replace `biome` constraint's content regex with line-anchored import/require-form patterns. Move repo-root config-file detection to `configFilenameRules` keyed by constraint keyword.
+- [x] **T4** — Test that `wiki status` after compile reports `coverage > 0` and `staleCount == 0`.
+- [x] **I4** — Populate `state.fileHashes` on a full compile (skip on sample compiles). Strip leading `wiki/` prefix from article keys in `countStaleArticles` before joining against `wikiDir`.
 
 ## Dependencies
 
-Which tasks block which? Draw the critical path.
-
-- [NEEDS CLARIFICATION]
+- Independent tasks: `T1/I1`, `T2/I2`, `T3/I3`, `T4/I4` don't block each other.
+- Within each pair: `T*` must fail before `I*` lands.
+- Smoke: after all `I*` merged, run `maina wiki compile` + `wiki status` + `wiki lint` on this repo to confirm the success criteria in `spec.md`.
 
 ## Definition of Done
 
-How do we know this feature is complete?
-
-- [ ] All tests pass
-- [ ] Biome lint clean
-- [ ] TypeScript compiles
-- [ ] maina analyze shows no errors
-- [ ] [NEEDS CLARIFICATION] Feature-specific criteria
+- [x] All tests pass (`bun test packages/core/src/verify/tools/__tests__/wiki-lint.test.ts`, `bun test packages/cli/src/commands/__tests__/wiki.test.ts`).
+- [x] `bun run check` (Biome) clean on touched files.
+- [x] `bun run typecheck` clean.
+- [x] `maina wiki lint` on this repo drops from 77 → ≤ 5 decision-violation findings, with zero under `.claude/worktrees/` or `.maina/`.
+- [x] `maina wiki status` on this repo reports `Coverage > 0%`, `Stale == 0`, `Last compile` populated from the most recent compile run.
+- [x] `packages/core/src/verify/tools/wiki-lint.ts` no longer self-flags against ADR 0002/0019.

--- a/packages/cli/src/commands/__tests__/wiki.test.ts
+++ b/packages/cli/src/commands/__tests__/wiki.test.ts
@@ -349,6 +349,23 @@ describe("maina wiki status", () => {
 		// Should be a valid ISO date
 		expect(new Date(result.lastCompile).getTime()).toBeGreaterThan(0);
 	});
+
+	test("after a full compile, staleCount is 0 and coverage > 0 — #211", async () => {
+		createSampleProject(tmpDir);
+
+		await wikiInitAction({ cwd: tmpDir });
+		const result = await wikiStatusAction({ cwd: tmpDir });
+
+		expect(result.initialized).toBe(true);
+		// Coverage should reflect source files hashed vs articles written.
+		// Bug #211: compile never populated state.fileHashes, so coverage
+		// was stuck at 0 and status was useless as a health signal.
+		expect(result.coveragePercent).toBeGreaterThan(0);
+		// Bug #211: countStaleArticles used `join(wikiDir, articlePath)` with
+		// articlePath `wiki/modules/foo.md`, producing `.maina/wiki/wiki/modules/foo.md`
+		// which never exists → every article reported stale.
+		expect(result.staleCount).toBe(0);
+	});
 });
 
 describe("maina wiki query", () => {

--- a/packages/cli/src/commands/wiki/status.ts
+++ b/packages/cli/src/commands/wiki/status.ts
@@ -42,6 +42,11 @@ const ARTICLE_TYPES = [
 /**
  * Count stale articles — articles whose source files have changed since compilation.
  * An article is stale if its content hash in state doesn't match the current file.
+ *
+ * Article keys in state are of the form `wiki/modules/foo.md`; on disk the files
+ * live at `<wikiDir>/modules/foo.md`. The leading `wiki/` segment must be stripped
+ * before joining against wikiDir — otherwise every article appears stale because
+ * the lookup path `<wikiDir>/wiki/modules/foo.md` never exists (#211).
  */
 function countStaleArticles(
 	wikiDir: string,
@@ -52,7 +57,8 @@ function countStaleArticles(
 	for (const [articlePath, expectedHash] of Object.entries(
 		state.articleHashes,
 	)) {
-		const fullPath = join(wikiDir, articlePath);
+		const onDiskPath = articlePath.replace(/^wiki\//, "");
+		const fullPath = join(wikiDir, onDiskPath);
 		if (!existsSync(fullPath)) {
 			staleCount++;
 			continue;

--- a/packages/cli/src/commands/wiki/status.ts
+++ b/packages/cli/src/commands/wiki/status.ts
@@ -40,8 +40,10 @@ const ARTICLE_TYPES = [
 ];
 
 /**
- * Count stale articles — articles whose source files have changed since compilation.
- * An article is stale if its content hash in state doesn't match the current file.
+ * Count stale articles — articles whose on-disk markdown has drifted from the
+ * hash recorded at compile time. For each entry in `state.articleHashes`, read
+ * the article file and compare its hash to the recorded one. A missing file or
+ * a hash mismatch counts as stale.
  *
  * Article keys in state are of the form `wiki/modules/foo.md`; on disk the files
  * live at `<wikiDir>/modules/foo.md`. The leading `wiki/` segment must be stripped

--- a/packages/core/src/verify/tools/__tests__/wiki-lint.test.ts
+++ b/packages/core/src/verify/tools/__tests__/wiki-lint.test.ts
@@ -588,6 +588,155 @@ describe("Wiki Lint Tool", () => {
 
 			expect(result.decisionViolations).toHaveLength(0);
 		});
+
+		it("should not scan .claude/worktrees/ (agent worktree duplicates) — #208", () => {
+			const adrDir = join(tmpDir, "adr");
+			mkdirSync(adrDir, { recursive: true });
+			writeFileSync(
+				join(adrDir, "0001-testing.md"),
+				"# ADR-0001: Use Bun Test\n\n## Status\n\nAccepted\n\n## Context\n\nTests.\n\n## Decision\n\nUse bun:test for tests.\n",
+			);
+
+			// Put a violating file under .claude/worktrees/
+			writeSourceFile(
+				".claude/worktrees/agent-abc/src/a.test.ts",
+				'import { describe } from "jest";\n',
+			);
+
+			const result = runWikiLint({ wikiDir, repoRoot, adrDir });
+
+			const underWorktree = result.decisionViolations.filter((f) =>
+				f.source?.includes(".claude/worktrees/"),
+			);
+			expect(underWorktree).toHaveLength(0);
+		});
+
+		it("should not scan .maina/ (own tooling state) — #208", () => {
+			const adrDir = join(tmpDir, "adr");
+			mkdirSync(adrDir, { recursive: true });
+			writeFileSync(
+				join(adrDir, "0001-testing.md"),
+				"# ADR-0001: Use Bun Test\n\n## Status\n\nAccepted\n\n## Context\n\nTests.\n\n## Decision\n\nUse bun:test.\n",
+			);
+
+			writeSourceFile(
+				".maina/features/050-foo/scratch.ts",
+				'import { describe } from "jest";\n',
+			);
+
+			const result = runWikiLint({ wikiDir, repoRoot, adrDir });
+
+			const underMaina = result.decisionViolations.filter((f) =>
+				f.source?.includes("/.maina/"),
+			);
+			expect(underMaina).toHaveLength(0);
+		});
+
+		it("should NOT flag *.test.ts files that throw against a result< ADR — #210", () => {
+			const adrDir = join(tmpDir, "adr");
+			mkdirSync(adrDir, { recursive: true });
+			writeFileSync(
+				join(adrDir, "0012-result.md"),
+				"# ADR-0012: Result pattern\n\n## Status\n\nAccepted\n\n## Context\n\nError handling.\n\n## Decision\n\nAll functions return Result<T,E>.\n",
+			);
+
+			// Test file throws — this is legitimate (e.g. expected-throw assertion setup)
+			writeSourceFile(
+				"src/thing.test.ts",
+				'import { expect, it } from "bun:test";\nit("x", () => { throw new Error("boom"); });\n',
+			);
+
+			const result = runWikiLint({ wikiDir, repoRoot, adrDir });
+
+			const resultViolations = result.decisionViolations.filter((f) =>
+				f.message.includes("throws instead of returning Result"),
+			);
+			expect(resultViolations).toHaveLength(0);
+		});
+
+		it("should still flag production *.ts files that throw against result< — #210 regression guard", () => {
+			const adrDir = join(tmpDir, "adr");
+			mkdirSync(adrDir, { recursive: true });
+			writeFileSync(
+				join(adrDir, "0012-result.md"),
+				"# ADR-0012: Result pattern\n\n## Status\n\nAccepted\n\n## Context\n\nErrors.\n\n## Decision\n\nUse Result<T,E>.\n",
+			);
+
+			writeSourceFile(
+				"src/thing.ts",
+				'export function x() { throw new Error("boom"); }\n',
+			);
+
+			const result = runWikiLint({ wikiDir, repoRoot, adrDir });
+
+			const resultViolations = result.decisionViolations.filter((f) =>
+				f.message.includes("throws instead of returning Result"),
+			);
+			expect(resultViolations.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it("should still flag jest import in a test file (bun:test constraint applies to tests) — #210 regression guard", () => {
+			// skipTests must NOT apply to import-form constraints like bun:test —
+			// a test file importing jest is still a violation.
+			const adrDir = join(tmpDir, "adr");
+			mkdirSync(adrDir, { recursive: true });
+			writeFileSync(
+				join(adrDir, "0001-testing.md"),
+				"# ADR-0001: Use bun:test\n\n## Status\n\nAccepted\n\n## Context\n\nTests.\n\n## Decision\n\nUse bun:test only.\n",
+			);
+
+			writeSourceFile("src/a.test.ts", 'import { describe } from "jest";\n');
+
+			const result = runWikiLint({ wikiDir, repoRoot, adrDir });
+
+			expect(result.decisionViolations.length).toBeGreaterThanOrEqual(1);
+			expect(result.decisionViolations[0]?.message).toContain("jest");
+		});
+
+		it("should NOT flag files that merely mention 'eslint.config' as strings — #209", () => {
+			const adrDir = join(tmpDir, "adr");
+			mkdirSync(adrDir, { recursive: true });
+			writeFileSync(
+				join(adrDir, "0002-linting.md"),
+				"# ADR-0002: Use Biome\n\n## Status\n\nAccepted\n\n## Context\n\nLinting.\n\n## Decision\n\nUse Biome only.\n",
+			);
+
+			// A file that detects/parses ESLint configs for other repos — should NOT self-flag.
+			writeSourceFile(
+				"src/config-parsers.ts",
+				'export const ESLINT_CONFIG_NAMES = [".eslintrc", "eslint.config.js"];\n',
+			);
+
+			const result = runWikiLint({ wikiDir, repoRoot, adrDir });
+
+			const eslintContentHits = result.decisionViolations.filter(
+				(f) =>
+					f.message.includes("uses ESLint configuration") &&
+					f.source?.endsWith("config-parsers.ts"),
+			);
+			expect(eslintContentHits).toHaveLength(0);
+		});
+
+		it("should still flag real ESLint imports against a Biome ADR — #209 regression guard", () => {
+			const adrDir = join(tmpDir, "adr");
+			mkdirSync(adrDir, { recursive: true });
+			writeFileSync(
+				join(adrDir, "0002-linting.md"),
+				"# ADR-0002: Use Biome\n\n## Status\n\nAccepted\n\n## Context\n\nLinting.\n\n## Decision\n\nUse Biome only.\n",
+			);
+
+			writeSourceFile(
+				"src/real-usage.ts",
+				'import { ESLint } from "eslint";\nconst e = new ESLint();\n',
+			);
+
+			const result = runWikiLint({ wikiDir, repoRoot, adrDir });
+
+			const eslintHits = result.decisionViolations.filter((f) =>
+				f.message.toLowerCase().includes("eslint"),
+			);
+			expect(eslintHits.length).toBeGreaterThanOrEqual(1);
+		});
 	});
 
 	// ─── Check 8: Missing Rationale ─────────────────────────────────────

--- a/packages/core/src/verify/tools/__tests__/wiki-lint.test.ts
+++ b/packages/core/src/verify/tools/__tests__/wiki-lint.test.ts
@@ -737,6 +737,68 @@ describe("Wiki Lint Tool", () => {
 			);
 			expect(eslintHits.length).toBeGreaterThanOrEqual(1);
 		});
+
+		it('should flag side-effect `import "eslint"` against a Biome ADR — PR #212 review', () => {
+			const adrDir = join(tmpDir, "adr");
+			mkdirSync(adrDir, { recursive: true });
+			writeFileSync(
+				join(adrDir, "0002-linting.md"),
+				"# ADR-0002: Use Biome\n\n## Status\n\nAccepted\n\n## Context\n\nLinting.\n\n## Decision\n\nUse Biome only.\n",
+			);
+
+			writeSourceFile("src/side-effect.ts", 'import "eslint";\n');
+
+			const result = runWikiLint({ wikiDir, repoRoot, adrDir });
+
+			const hits = result.decisionViolations.filter((f) =>
+				f.message.toLowerCase().includes("eslint"),
+			);
+			expect(hits.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('should flag top-level dynamic `await import("eslint")` against a Biome ADR — PR #212 review', () => {
+			// Line-anchored detection catches dynamic imports that appear as a
+			// top-level statement. Deeply-nested dynamic imports (e.g. inside a
+			// function body, on the same line as other tokens) are not matched
+			// — that's a deliberate trade-off to keep string-literal fixtures
+			// and docs from self-flagging (#209).
+			const adrDir = join(tmpDir, "adr");
+			mkdirSync(adrDir, { recursive: true });
+			writeFileSync(
+				join(adrDir, "0002-linting.md"),
+				"# ADR-0002: Use Biome\n\n## Status\n\nAccepted\n\n## Context\n\nLinting.\n\n## Decision\n\nUse Biome only.\n",
+			);
+
+			writeSourceFile("src/dynamic.ts", 'await import("eslint");\n');
+
+			const result = runWikiLint({ wikiDir, repoRoot, adrDir });
+
+			const hits = result.decisionViolations.filter((f) =>
+				f.message.toLowerCase().includes("eslint"),
+			);
+			expect(hits.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('should flag bare `require("eslint")` against a Biome ADR — PR #212 review', () => {
+			const adrDir = join(tmpDir, "adr");
+			mkdirSync(adrDir, { recursive: true });
+			writeFileSync(
+				join(adrDir, "0002-linting.md"),
+				"# ADR-0002: Use Biome\n\n## Status\n\nAccepted\n\n## Context\n\nLinting.\n\n## Decision\n\nUse Biome only.\n",
+			);
+
+			writeSourceFile(
+				"src/bare-require.ts",
+				'module.exports = require("eslint");\n',
+			);
+
+			const result = runWikiLint({ wikiDir, repoRoot, adrDir });
+
+			const hits = result.decisionViolations.filter((f) =>
+				f.message.toLowerCase().includes("eslint"),
+			);
+			expect(hits.length).toBeGreaterThanOrEqual(1);
+		});
 	});
 
 	// ─── Check 8: Missing Rationale ─────────────────────────────────────

--- a/packages/core/src/verify/tools/__tests__/wiki-lint.test.ts
+++ b/packages/core/src/verify/tools/__tests__/wiki-lint.test.ts
@@ -799,6 +799,68 @@ describe("Wiki Lint Tool", () => {
 			);
 			expect(hits.length).toBeGreaterThanOrEqual(1);
 		});
+
+		it("should still flag a real eslint import inside a test file (no skipTests on biome) — PR #212 review", () => {
+			// CodeRabbit flagged that a blanket skipTests on biome would turn
+			// a genuine eslint static import inside a test file into a false
+			// negative. The tightened regex excludes lines whose prefix
+			// contains a quote char (meaning the match is inside a string
+			// literal), so real imports in test files are still caught.
+			const adrDir = join(tmpDir, "adr");
+			mkdirSync(adrDir, { recursive: true });
+			writeFileSync(
+				join(adrDir, "0002-linting.md"),
+				"# ADR-0002: Use Biome\n\n## Status\n\nAccepted\n\n## Context\n\nLinting.\n\n## Decision\n\nUse Biome only.\n",
+			);
+
+			// A `.test.ts` file that genuinely imports eslint (not a fixture).
+			writeSourceFile(
+				"src/check.test.ts",
+				'import { ESLint } from "eslint";\ntest("x", () => { new ESLint(); });\n',
+			);
+
+			const result = runWikiLint({ wikiDir, repoRoot, adrDir });
+
+			const hits = result.decisionViolations.filter((f) =>
+				f.message.toLowerCase().includes("eslint"),
+			);
+			expect(hits.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it("should NOT flag fixture strings that LOOK like eslint imports inside quoted literals — PR #212 review", () => {
+			// Reciprocal guard: a test file whose content quotes a fake import
+			// like `'import { X } from "eslint"'` must not self-flag. This is
+			// exactly the shape wiki-lint's own tests use.
+			const adrDir = join(tmpDir, "adr");
+			mkdirSync(adrDir, { recursive: true });
+			writeFileSync(
+				join(adrDir, "0002-linting.md"),
+				"# ADR-0002: Use Biome\n\n## Status\n\nAccepted\n\n## Context\n\nLinting.\n\n## Decision\n\nUse Biome only.\n",
+			);
+
+			writeSourceFile(
+				"src/fixture.test.ts",
+				[
+					'import { test } from "bun:test";',
+					'test("fixture", () => {',
+					"\tconst fixture = 'import { ESLint } from \"eslint\";';",
+					"\tconst fixture2 = 'module.exports = require(\"eslint\");';",
+					"\texpect(fixture).toBeTruthy();",
+					"\texpect(fixture2).toBeTruthy();",
+					"});",
+					"",
+				].join("\n"),
+			);
+
+			const result = runWikiLint({ wikiDir, repoRoot, adrDir });
+
+			const hits = result.decisionViolations.filter(
+				(f) =>
+					f.source?.endsWith("fixture.test.ts") &&
+					f.message.toLowerCase().includes("eslint"),
+			);
+			expect(hits).toHaveLength(0);
+		});
 	});
 
 	// ─── Check 8: Missing Rationale ─────────────────────────────────────

--- a/packages/core/src/verify/tools/wiki-lint.ts
+++ b/packages/core/src/verify/tools/wiki-lint.ts
@@ -291,6 +291,21 @@ function calculateCoverage(
 
 // ─── Check 6: Spec Drift Detection ──────────────────────────────────────
 
+/** Directories never to recurse into when scanning for source files. */
+const SKIP_DIRS = new Set([
+	"node_modules",
+	"dist",
+	"build",
+	"out",
+	"coverage",
+	".git",
+	".claude",
+	".maina",
+	".next",
+	".turbo",
+	".cache",
+]);
+
 /** Recursively collect source files (.ts, .js, .tsx, .jsx) under a directory. */
 function collectSourceFiles(dir: string): string[] {
 	const results: string[] = [];
@@ -300,14 +315,7 @@ function collectSourceFiles(dir: string): string[] {
 		for (const entry of entries) {
 			const full = join(dir, entry.name);
 			if (entry.isDirectory()) {
-				// Skip node_modules, dist, .git
-				if (
-					entry.name === "node_modules" ||
-					entry.name === "dist" ||
-					entry.name === ".git"
-				) {
-					continue;
-				}
+				if (SKIP_DIRS.has(entry.name)) continue;
 				results.push(...collectSourceFiles(full));
 			} else if (/\.(ts|js|tsx|jsx)$/.test(entry.name)) {
 				results.push(full);
@@ -317,6 +325,18 @@ function collectSourceFiles(dir: string): string[] {
 		// Directory read failure — skip gracefully
 	}
 	return results;
+}
+
+/**
+ * True if the file is a test/spec file or under a tests directory.
+ * Test files legitimately use throw (e.g. inside it(..., () => { throw }))
+ * so production-code rules like "returns Result<>" should skip them.
+ */
+function isTestFile(filePath: string): boolean {
+	return (
+		/\.(test|spec)\.[jt]sx?$/.test(filePath) ||
+		/[\\/](__tests__|__mocks__)[\\/]/.test(filePath)
+	);
 }
 
 /**
@@ -402,6 +422,15 @@ function checkSpecDrift(
 interface TechConstraint {
 	keyword: string;
 	violations: { pattern: RegExp; description: string }[];
+	/**
+	 * When true, skip *.test.* / *.spec.* / __tests__ files.
+	 * Applies to rules that describe production-code behaviour (e.g. "return
+	 * Result<> instead of throwing") — tests legitimately throw as part of
+	 * fixture setup or expected-throw assertions.
+	 * Import-form constraints (e.g. "don't import jest") should leave this
+	 * off so a rogue jest import in a test file is still caught.
+	 */
+	skipTests?: boolean;
 }
 
 const TECH_CONSTRAINTS: TechConstraint[] = [
@@ -419,15 +448,28 @@ const TECH_CONSTRAINTS: TechConstraint[] = [
 		],
 	},
 	{
+		// Import/require of eslint/prettier only — NOT string mentions in content
+		// (see #209). Anchored start-of-line to skip test fixtures and docs.
+		// Repo-root config files are checked separately via configFilenameRules.
 		keyword: "biome",
 		violations: [
 			{
-				pattern: /\.eslintrc|eslint\.config/,
-				description: "uses ESLint configuration",
+				pattern: /^\s*import\b[^\n]*\bfrom\s+["']eslint(?:["']|\/)/m,
+				description: "imports from eslint",
 			},
 			{
-				pattern: /\.prettierrc|prettier\.config/,
-				description: "uses Prettier configuration",
+				pattern:
+					/^\s*(?:const|let|var)\b[^\n]*\brequire\s*\(\s*["']eslint(?:["']|\/)/m,
+				description: "requires eslint",
+			},
+			{
+				pattern: /^\s*import\b[^\n]*\bfrom\s+["']prettier(?:["']|\/)/m,
+				description: "imports from prettier",
+			},
+			{
+				pattern:
+					/^\s*(?:const|let|var)\b[^\n]*\brequire\s*\(\s*["']prettier(?:["']|\/)/m,
+				description: "requires prettier",
 			},
 		],
 	},
@@ -442,6 +484,7 @@ const TECH_CONSTRAINTS: TechConstraint[] = [
 	},
 	{
 		keyword: "result<",
+		skipTests: true,
 		violations: [
 			{
 				pattern: /\bthrow\s+new\b/,
@@ -451,6 +494,7 @@ const TECH_CONSTRAINTS: TechConstraint[] = [
 	},
 	{
 		keyword: "never throw",
+		skipTests: true,
 		violations: [
 			{
 				pattern: /\bthrow\s+/,
@@ -522,17 +566,38 @@ function checkDecisionViolations(
 		// Root dir read failure — skip
 	}
 
-	// Check config file names against constraints
+	// Check config file names against constraints. This catches the presence of
+	// a real .eslintrc / eslint.config file at the repo root — a structural
+	// signal that ESLint is in use, independent of any source-file content.
+	const configFilenameRules: Record<
+		string,
+		{ pattern: RegExp; description: string }[]
+	> = {
+		biome: [
+			{
+				pattern: /^\.eslintrc|^eslint\.config/,
+				description:
+					"has .eslintrc / eslint.config at repo root (uses ESLint configuration)",
+			},
+			{
+				pattern: /^\.prettierrc|^prettier\.config/,
+				description:
+					"has .prettierrc / prettier.config at repo root (uses Prettier configuration)",
+			},
+		],
+	};
 	for (const configFile of configFiles) {
 		const fileName = relative(repoRoot, configFile);
 		for (const { decisionId, constraint } of activeConstraints) {
-			for (const violation of constraint.violations) {
-				if (violation.pattern.test(fileName)) {
+			const rules = configFilenameRules[constraint.keyword];
+			if (!rules) continue;
+			for (const rule of rules) {
+				if (rule.pattern.test(fileName)) {
 					findings.push({
 						check: "decision_violation",
 						severity: "error",
 						article: decisionId,
-						message: `Decision violation: ADR "${decisionId}" requires ${constraint.keyword}, but "${fileName}" ${violation.description}`,
+						message: `Decision violation: ADR "${decisionId}" requires ${constraint.keyword}, but "${fileName}" ${rule.description}`,
 						source: configFile,
 					});
 				}
@@ -545,8 +610,10 @@ function checkDecisionViolations(
 		try {
 			const content = readFileSync(filePath, "utf-8");
 			const relPath = relative(repoRoot, filePath);
+			const fileIsTest = isTestFile(filePath);
 
 			for (const { decisionId, constraint } of activeConstraints) {
+				if (constraint.skipTests && fileIsTest) continue;
 				for (const violation of constraint.violations) {
 					if (violation.pattern.test(content)) {
 						findings.push({

--- a/packages/core/src/verify/tools/wiki-lint.ts
+++ b/packages/core/src/verify/tools/wiki-lint.ts
@@ -328,14 +328,14 @@ function collectSourceFiles(dir: string): string[] {
 }
 
 /**
- * True if the file is a test/spec file or under a tests directory.
- * Test files legitimately use throw (e.g. inside it(..., () => { throw }))
+ * True if the file is a test/spec file or under a test/tests/__tests__/__mocks__
+ * directory. Test files legitimately throw (e.g. inside it(..., () => { throw }))
  * so production-code rules like "returns Result<>" should skip them.
  */
 function isTestFile(filePath: string): boolean {
 	return (
 		/\.(test|spec)\.[jt]sx?$/.test(filePath) ||
-		/[\\/](__tests__|__mocks__)[\\/]/.test(filePath)
+		/[\\/](tests?|__tests__|__mocks__)[\\/]/.test(filePath)
 	);
 }
 
@@ -448,27 +448,27 @@ const TECH_CONSTRAINTS: TechConstraint[] = [
 		],
 	},
 	{
-		// Import/require of eslint/prettier only — NOT string mentions in content
-		// (see #209). Anchored start-of-line to skip test fixtures and docs.
-		// Repo-root config files are checked separately via configFilenameRules.
+		// Import/require of eslint/prettier only — see #209 and PR #212 review.
+		// skipTests avoids self-flags on fixture strings in lint's own tests.
 		keyword: "biome",
+		skipTests: true,
 		violations: [
 			{
-				pattern: /^\s*import\b[^\n]*\bfrom\s+["']eslint(?:["']|\/)/m,
+				pattern:
+					/^\s*import\b[^\n]*["']eslint(?:["']|\/)|^\s*(?:await\s+)?import\s*\(\s*["']eslint(?:["']|\/)/m,
 				description: "imports from eslint",
 			},
 			{
-				pattern:
-					/^\s*(?:const|let|var)\b[^\n]*\brequire\s*\(\s*["']eslint(?:["']|\/)/m,
+				pattern: /^\s*[^\n]*\brequire\s*\(\s*["']eslint(?:["']|\/)/m,
 				description: "requires eslint",
 			},
 			{
-				pattern: /^\s*import\b[^\n]*\bfrom\s+["']prettier(?:["']|\/)/m,
+				pattern:
+					/^\s*import\b[^\n]*["']prettier(?:["']|\/)|^\s*(?:await\s+)?import\s*\(\s*["']prettier(?:["']|\/)/m,
 				description: "imports from prettier",
 			},
 			{
-				pattern:
-					/^\s*(?:const|let|var)\b[^\n]*\brequire\s*\(\s*["']prettier(?:["']|\/)/m,
+				pattern: /^\s*[^\n]*\brequire\s*\(\s*["']prettier(?:["']|\/)/m,
 				description: "requires prettier",
 			},
 		],

--- a/packages/core/src/verify/tools/wiki-lint.ts
+++ b/packages/core/src/verify/tools/wiki-lint.ts
@@ -449,26 +449,26 @@ const TECH_CONSTRAINTS: TechConstraint[] = [
 	},
 	{
 		// Import/require of eslint/prettier only — see #209 and PR #212 review.
-		// skipTests avoids self-flags on fixture strings in lint's own tests.
+		// The `^[^"'\n]*` prefix rejects matches whose line already contains a
+		// quote (meaning we're inside a string literal — i.e. a test fixture).
+		// Real imports/requires still match because the line prefix before the
+		// keyword has no quote.
 		keyword: "biome",
-		skipTests: true,
 		violations: [
 			{
-				pattern:
-					/^\s*import\b[^\n]*["']eslint(?:["']|\/)|^\s*(?:await\s+)?import\s*\(\s*["']eslint(?:["']|\/)/m,
+				pattern: /^[^"'\n]*\bimport\b[^\n]*["']eslint(?:["']|\/)/m,
 				description: "imports from eslint",
 			},
 			{
-				pattern: /^\s*[^\n]*\brequire\s*\(\s*["']eslint(?:["']|\/)/m,
+				pattern: /^[^"'\n]*\brequire\s*\(\s*["']eslint(?:["']|\/)/m,
 				description: "requires eslint",
 			},
 			{
-				pattern:
-					/^\s*import\b[^\n]*["']prettier(?:["']|\/)|^\s*(?:await\s+)?import\s*\(\s*["']prettier(?:["']|\/)/m,
+				pattern: /^[^"'\n]*\bimport\b[^\n]*["']prettier(?:["']|\/)/m,
 				description: "imports from prettier",
 			},
 			{
-				pattern: /^\s*[^\n]*\brequire\s*\(\s*["']prettier(?:["']|\/)/m,
+				pattern: /^[^"'\n]*\brequire\s*\(\s*["']prettier(?:["']|\/)/m,
 				description: "requires prettier",
 			},
 		],

--- a/packages/core/src/wiki/compiler.ts
+++ b/packages/core/src/wiki/compiler.ts
@@ -35,7 +35,13 @@ import { buildKnowledgeGraph, computePageRank, mapToArticles } from "./graph";
 import { generateIndex } from "./indexer";
 import { generateLinks } from "./linker";
 import { generateGraphReport, generateGraphReportJson } from "./report";
-import { createEmptyState, hashContent, loadState, saveState } from "./state";
+import {
+	createEmptyState,
+	hashContent,
+	hashFile,
+	loadState,
+	saveState,
+} from "./state";
 import type {
 	ArticleType,
 	ExtractedDecision,
@@ -1338,6 +1344,16 @@ export async function compile(
 
 		for (const article of articles) {
 			state.articleHashes[article.path] = article.contentHash;
+		}
+
+		// Persist source-file hashes so `wiki status` can compute coverage
+		// (articleCount / sourceFileCount) and so incremental compile can
+		// detect source changes in future runs. Previously this field was
+		// declared but never written, leaving coverage stuck at 0% (#211).
+		state.fileHashes = {};
+		for (const rel of sourceFiles) {
+			const h = hashFile(join(repoRoot, rel));
+			if (h) state.fileHashes[rel] = h;
 		}
 
 		if (!dryRun) {

--- a/packages/core/src/wiki/compiler.ts
+++ b/packages/core/src/wiki/compiler.ts
@@ -1350,10 +1350,17 @@ export async function compile(
 		// (articleCount / sourceFileCount) and so incremental compile can
 		// detect source changes in future runs. Previously this field was
 		// declared but never written, leaving coverage stuck at 0% (#211).
-		state.fileHashes = {};
-		for (const rel of sourceFiles) {
-			const h = hashFile(join(repoRoot, rel));
-			if (h) state.fileHashes[rel] = h;
+		//
+		// Skip on sampled compiles (options.sample truncates sourceFiles to
+		// SAMPLE_FILE_LIMIT — persisting that truncated set as canonical state
+		// would make coverage look fake-high on subsequent runs). Preserve any
+		// existing fileHashes from a prior full compile in that case.
+		if (options.sample !== true) {
+			state.fileHashes = {};
+			for (const rel of sourceFiles) {
+				const h = hashFile(join(repoRoot, rel));
+				if (h) state.fileHashes[rel] = h;
+			}
 		}
 
 		if (!dryRun) {


### PR DESCRIPTION
## Summary

Fixes four wiki bugs I filed earlier today: #208, #209, #210, #211.

Before: `maina wiki lint` reported **77 findings** on this repo (≥65 false positives), and `maina wiki status` reported **100% stale / 0% coverage** immediately after a successful compile.

After: **2 findings** (both real — pre-existing `throw` in `packages/cli/src/commands/{feedback,mcp}.ts` against ADR 0012's Result pattern, out of scope for this PR), and status shows **Coverage 100%, Stale 0, Last compile: <now>**.

## What changed

- **#208 (wiki-lint scans agent worktrees):** `collectSourceFiles` now skips `.claude/`, `.maina/`, `coverage/`, `build/`, `out/`, `.next/`, `.turbo/`, `.cache/` in addition to the pre-existing `node_modules/`, `dist/`, `.git/`. Eliminates 3x-duplicated findings across `.claude/worktrees/agent-*/` copies of the same files.
- **#209 (ESLint detection matched string contents):** `biome` constraint's content regex was `/\.eslintrc|eslint\.config/` — it fired on any file that mentioned those strings, including `wiki-lint.ts` itself and `constitution/config-parsers.ts` (which *parses* other repos' ESLint configs). Replaced with line-anchored import/require-form regexes for `eslint` / `prettier`. Repo-root config-file detection (`.eslintrc*`, `eslint.config.*`) moved to a dedicated `configFilenameRules` table keyed by constraint keyword — that's the structural signal for "this project actually uses ESLint".
- **#210 (Result-pattern flagged test files):** Tests legitimately `throw` inside `it(..., () => { throw })`. Added `skipTests?: boolean` on `TechConstraint`, set true for `result<` and `never throw`. Import-form constraints like `bun:test` deliberately leave it off — a rogue `jest` import in a test file is still a real violation we want to catch.
- **#211 (status reported 100% stale after compile):** Two root causes:
  - `countStaleArticles` did `join(wikiDir, articlePath)` where articlePath keys are `wiki/modules/foo.md` and wikiDir is `.maina/wiki`, producing `.maina/wiki/wiki/modules/foo.md` — a path that never exists, so every article landed in the `existsSync === false` branch. Fix: strip the leading `wiki/` before the join.
  - `state.fileHashes` was declared in the schema but never written by `compile`. Coverage = `articleHashCount / fileHashCount` was always `N/0 = 0%`. Fix: populate `fileHashes` from the `sourceFiles` list the compiler already traverses in step 1.

## Test plan

- [x] `bun test packages/core/src/verify/tools/__tests__/wiki-lint.test.ts` — 42/42 pass (9 new: 4 red-phase + 5 regression guards that keep pre-existing catches working).
- [x] `bun test packages/cli/src/commands/__tests__/wiki.test.ts` — 29/29 pass (1 new covering staleCount=0 + coverage>0 after compile).
- [x] Full `bun run test` — 2274 pass; 5 pre-existing timeouts in `trivy.test.ts` / `engine.test.ts` that reproduce on master (unrelated to this diff).
- [x] `bun run typecheck` — clean.
- [x] `bun run check` — biome clean.
- [x] `maina commit` verify gate passed (13 tools).
- [x] End-to-end smoke on this repo:
  - `wiki compile` → 601 articles, writes state.
  - `wiki status` → Coverage 100%, Stale 0, `Last compile` updated.
  - `wiki lint` → 77 → 2 findings; 0 from `.claude/worktrees/` or `.maina/`; `wiki-lint.ts` and `config-parsers.ts` no longer self-flag.

Closes #208, #209, #210, #211.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Status reporting now reflects successful compilation, with coverage and stale-article counts computed correctly; fixed path handling to avoid false stale reports and preserve compiled file-hash data.

* **Improvements**
  * Excluded common build/cache and worktree dirs from lint scans.
  * Skipped production-focused checks in test files.
  * Tightened ESLint/Prettier detection to reduce false positives.
  * Preserve persisted file-hash data in sample mode.

* **Tests**
  * Added regression and end-to-end tests covering lint exclusions and status/coverage behavior.

* **Documentation**
  * Added implementation plan, spec, and task list for the fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->