### PR TITLE
refactor(cli): parsePrNumbers + parseClientList + parseScope return Result<>

### DIFF
--- a/packages/cli/src/commands/__tests__/feedback.test.ts
+++ b/packages/cli/src/commands/__tests__/feedback.test.ts
@@ -10,55 +10,70 @@ import {
 // ── parsePrNumbers ─────────────────────────────────────────────────────────
 
 describe("parsePrNumbers", () => {
-	test("returns [] for undefined", () => {
-		expect(parsePrNumbers(undefined)).toEqual([]);
+	test("returns ok([]) for undefined", () => {
+		const r = parsePrNumbers(undefined);
+		expect(r.ok).toBe(true);
+		if (r.ok) expect(r.value).toEqual([]);
 	});
 
 	test("parses a single numeric token", () => {
-		expect(parsePrNumbers(["123"])).toEqual([123]);
+		const r = parsePrNumbers(["123"]);
+		expect(r.ok).toBe(true);
+		if (r.ok) expect(r.value).toEqual([123]);
 	});
 
 	test("parses comma-separated tokens within one entry", () => {
-		expect(parsePrNumbers(["1,2,3"])).toEqual([1, 2, 3]);
+		const r = parsePrNumbers(["1,2,3"]);
+		expect(r.ok).toBe(true);
+		if (r.ok) expect(r.value).toEqual([1, 2, 3]);
 	});
 
 	test("parses repeated --pr entries", () => {
-		expect(parsePrNumbers(["1", "2", "3,4"])).toEqual([1, 2, 3, 4]);
+		const r = parsePrNumbers(["1", "2", "3,4"]);
+		expect(r.ok).toBe(true);
+		if (r.ok) expect(r.value).toEqual([1, 2, 3, 4]);
 	});
 
-	test("throws InvalidPrNumberError on non-numeric token", () => {
-		expect(() => parsePrNumbers(["foo"])).toThrow(InvalidPrNumberError);
+	test("err(InvalidPrNumberError) on non-numeric token", () => {
+		const r = parsePrNumbers(["foo"]);
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toBeInstanceOf(InvalidPrNumberError);
 	});
 
-	test("throws on mixed valid + invalid token (must NOT fall back to auto-mode)", () => {
+	test("err on mixed valid + invalid token (must NOT fall back to auto-mode)", () => {
 		// Critical case from CodeRabbit: `--pr foo,123` previously returned
-		// [123] silently dropping foo. Now it throws.
-		expect(() => parsePrNumbers(["1,foo"])).toThrow(InvalidPrNumberError);
+		// [123] silently dropping foo. Now it returns err.
+		const r = parsePrNumbers(["1,foo"]);
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toBeInstanceOf(InvalidPrNumberError);
 	});
 
-	test("throws on negative integer", () => {
-		expect(() => parsePrNumbers(["-5"])).toThrow(InvalidPrNumberError);
+	test("err on negative integer", () => {
+		const r = parsePrNumbers(["-5"]);
+		expect(r.ok).toBe(false);
 	});
 
-	test("throws on zero", () => {
-		expect(() => parsePrNumbers(["0"])).toThrow(InvalidPrNumberError);
+	test("err on zero", () => {
+		const r = parsePrNumbers(["0"]);
+		expect(r.ok).toBe(false);
 	});
 
-	test("throws on decimal", () => {
-		expect(() => parsePrNumbers(["1.5"])).toThrow(InvalidPrNumberError);
+	test("err on decimal", () => {
+		const r = parsePrNumbers(["1.5"]);
+		expect(r.ok).toBe(false);
 	});
 
-	test("throws on empty token (e.g. trailing comma)", () => {
-		expect(() => parsePrNumbers(["1,"])).toThrow(InvalidPrNumberError);
+	test("err on empty token (e.g. trailing comma)", () => {
+		const r = parsePrNumbers(["1,"]);
+		expect(r.ok).toBe(false);
 	});
 
 	test("error message includes the offending token", () => {
-		try {
-			parsePrNumbers(["foo"]);
-			throw new Error("expected to throw");
-		} catch (e) {
-			expect(e).toBeInstanceOf(InvalidPrNumberError);
-			expect((e as Error).message).toContain("foo");
+		const r = parsePrNumbers(["foo"]);
+		expect(r.ok).toBe(false);
+		if (!r.ok) {
+			expect(r.error).toBeInstanceOf(InvalidPrNumberError);
+			expect(r.error.message).toContain("foo");
 		}
 	});
 });

--- a/packages/cli/src/commands/__tests__/mcp.test.ts
+++ b/packages/cli/src/commands/__tests__/mcp.test.ts
@@ -31,41 +31,55 @@ afterEach(() => {
 // ── parseClientList ────────────────────────────────────────────────────────
 
 describe("parseClientList", () => {
-	test("returns undefined when no value passed (auto-detect)", () => {
-		expect(parseClientList(undefined)).toBeUndefined();
-		expect(parseClientList("")).toBeUndefined();
+	test("ok(undefined) when no value passed (auto-detect)", () => {
+		const r1 = parseClientList(undefined);
+		expect(r1.ok).toBe(true);
+		if (r1.ok) expect(r1.value).toBeUndefined();
+		const r2 = parseClientList("");
+		expect(r2.ok).toBe(true);
+		if (r2.ok) expect(r2.value).toBeUndefined();
 	});
 
 	test("splits on commas, trims, lowercases", () => {
-		expect(parseClientList("Claude, Cursor, Windsurf")).toEqual([
-			"claude",
-			"cursor",
-			"windsurf",
-		]);
+		const r = parseClientList("Claude, Cursor, Windsurf");
+		expect(r.ok).toBe(true);
+		if (r.ok) expect(r.value).toEqual(["claude", "cursor", "windsurf"]);
 	});
 
-	test("throws on unknown client with helpful list", () => {
-		expect(() => parseClientList("claude,nope")).toThrow(
-			/Unknown client: nope/,
-		);
+	test("err on unknown client with helpful list", () => {
+		const r = parseClientList("claude,nope");
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toMatch(/Unknown client: nope/);
 	});
 
-	test("returns undefined for empty list after trimming", () => {
-		expect(parseClientList(", ,")).toBeUndefined();
+	test("ok(undefined) for empty list after trimming", () => {
+		const r = parseClientList(", ,");
+		expect(r.ok).toBe(true);
+		if (r.ok) expect(r.value).toBeUndefined();
 	});
 });
 
 describe("parseScope", () => {
 	test("defaults to global when undefined", () => {
-		expect(parseScope(undefined)).toBe("global");
+		const r = parseScope(undefined);
+		expect(r.ok).toBe(true);
+		if (r.ok) expect(r.value).toBe("global");
 	});
 	test("accepts global / project / both case-insensitive", () => {
-		expect(parseScope("GLOBAL")).toBe("global");
-		expect(parseScope("project")).toBe("project");
-		expect(parseScope("Both")).toBe("both");
+		for (const [input, expected] of [
+			["GLOBAL", "global"],
+			["project", "project"],
+			["Both", "both"],
+		] as const) {
+			const r = parseScope(input);
+			expect(r.ok).toBe(true);
+			if (r.ok) expect(r.value).toBe(expected);
+		}
 	});
-	test("throws on unknown scope", () => {
-		expect(() => parseScope("user")).toThrow(/Unknown scope/);
+	test("err on unknown scope", () => {
+		const r = parseScope("user");
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.error).toMatch(/Unknown scope/);
 	});
 });
 

--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -7,7 +7,12 @@
 
 import { join } from "node:path";
 import { intro, log, outro, spinner } from "@clack/prompts";
-import { ALLOWED_REVIEWERS, getRepoSlug, ingestPrReviews } from "@mainahq/core";
+import {
+	ALLOWED_REVIEWERS,
+	getRepoSlug,
+	ingestPrReviews,
+	type Result,
+} from "@mainahq/core";
 import { Command } from "commander";
 
 export interface FeedbackIngestOptions {
@@ -41,34 +46,34 @@ export class InvalidPrNumberError extends Error {
  * Parse `--pr` values (Commander collects them into a string[]), allowing
  * comma-separated tokens within each entry.
  *
- * Throws {@link InvalidPrNumberError} on any non-positive-integer token.
+ * Returns `err(InvalidPrNumberError)` on any non-positive-integer token.
  * Silently dropping bad input would be dangerous: an empty result switches
  * the command to auto-discovery, which could ingest from unrelated PRs.
- *
- * Exported for testability.
  */
-export function parsePrNumbers(raw: string[] | undefined): number[] {
-	if (!raw) return [];
+export function parsePrNumbers(
+	raw: string[] | undefined,
+): Result<number[], InvalidPrNumberError> {
+	if (!raw) return { ok: true, value: [] };
 	const out: number[] = [];
 	for (const r of raw) {
 		for (const part of r.split(",")) {
 			const trimmed = part.trim();
 			if (trimmed.length === 0) {
-				throw new InvalidPrNumberError(part);
+				return { ok: false, error: new InvalidPrNumberError(part) };
 			}
 			// Require a pure positive-integer string — reject leading +, decimals,
 			// scientific notation, etc.
 			if (!/^\d+$/.test(trimmed)) {
-				throw new InvalidPrNumberError(trimmed);
+				return { ok: false, error: new InvalidPrNumberError(trimmed) };
 			}
 			const n = Number.parseInt(trimmed, 10);
 			if (!Number.isFinite(n) || n <= 0) {
-				throw new InvalidPrNumberError(trimmed);
+				return { ok: false, error: new InvalidPrNumberError(trimmed) };
 			}
 			out.push(n);
 		}
 	}
-	return out;
+	return { ok: true, value: out };
 }
 
 /**
@@ -82,25 +87,18 @@ export async function feedbackIngestAction(
 	const mainaDir = join(cwd, ".maina");
 
 	const repo = options.repo ?? (await getRepoSlug(cwd));
-	let prNumbers: number[];
-	try {
-		prNumbers = parsePrNumbers(options.pr);
-	} catch (e) {
-		const message =
-			e instanceof InvalidPrNumberError
-				? e.message
-				: e instanceof Error
-					? e.message
-					: String(e);
+	const parsed = parsePrNumbers(options.pr);
+	if (!parsed.ok) {
 		return {
 			ok: false,
 			repo,
 			prNumbers: [],
 			ingested: 0,
 			skipped: 0,
-			error: message,
+			error: parsed.error.message,
 		};
 	}
+	const prNumbers = parsed.value;
 	const since = options.since ? Number.parseInt(options.since, 10) : 14;
 	const reviewers = [...ALLOWED_REVIEWERS, ...(options.reviewer ?? [])];
 

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -21,6 +21,7 @@ import {
 	listClientIds,
 	type McpClientId,
 	type McpScope,
+	type Result,
 	type RunOptions,
 	type RunReport,
 	runAdd,
@@ -36,8 +37,8 @@ const VALID_CLIENTS = new Set<McpClientId>(listClientIds());
 
 export function parseClientList(
 	raw: string | undefined,
-): McpClientId[] | undefined {
-	if (!raw) return undefined;
+): Result<McpClientId[] | undefined, string> {
+	if (!raw) return { ok: true, value: undefined };
 	const parts = raw
 		.split(",")
 		.map((s) => s.trim().toLowerCase())
@@ -45,20 +46,29 @@ export function parseClientList(
 	const validated: McpClientId[] = [];
 	for (const p of parts) {
 		if (!VALID_CLIENTS.has(p as McpClientId)) {
-			throw new Error(
-				`Unknown client: ${p}. Valid clients: ${listClientIds().join(", ")}`,
-			);
+			return {
+				ok: false,
+				error: `Unknown client: ${p}. Valid clients: ${listClientIds().join(", ")}`,
+			};
 		}
 		validated.push(p as McpClientId);
 	}
-	return validated.length > 0 ? validated : undefined;
+	return {
+		ok: true,
+		value: validated.length > 0 ? validated : undefined,
+	};
 }
 
-export function parseScope(raw: string | undefined): McpScope {
-	if (raw === undefined) return "global";
+export function parseScope(raw: string | undefined): Result<McpScope, string> {
+	if (raw === undefined) return { ok: true, value: "global" };
 	const v = raw.toLowerCase();
-	if (v === "global" || v === "project" || v === "both") return v;
-	throw new Error(`Unknown scope: ${raw}. Use one of: global, project, both`);
+	if (v === "global" || v === "project" || v === "both") {
+		return { ok: true, value: v };
+	}
+	return {
+		ok: false,
+		error: `Unknown scope: ${raw}. Use one of: global, project, both`,
+	};
 }
 
 // ── Pretty printing ────────────────────────────────────────────────────────
@@ -133,17 +143,16 @@ export async function mcpAction(
 ): Promise<McpActionResult> {
 	const cwd = options.cwd ?? process.cwd();
 
-	let clients: McpClientId[] | undefined;
-	let scope: McpScope;
-	try {
-		clients = parseClientList(options.client);
-		scope = parseScope(options.scope);
-	} catch (e) {
-		return {
-			command: options.command,
-			error: e instanceof Error ? e.message : String(e),
-		};
+	const clientsResult = parseClientList(options.client);
+	if (!clientsResult.ok) {
+		return { command: options.command, error: clientsResult.error };
 	}
+	const scopeResult = parseScope(options.scope);
+	if (!scopeResult.ok) {
+		return { command: options.command, error: scopeResult.error };
+	}
+	const clients = clientsResult.value;
+	const scope = scopeResult.value;
 
 	const runOpts: RunOptions = {
 		scope,


### PR DESCRIPTION
## Summary

Follow-up to #212. With the wiki-lint accuracy fixes landed, two real `decision_violation` findings remained against ADR 0012 (Result<> pattern): `parsePrNumbers` in `feedback.ts` and `parseClientList` + `parseScope` in `mcp.ts`. This PR converts them.

Both callers were already translating the throw back into a Result-style error envelope via `try/catch`, so this just lifts the Result to the right boundary — the parsers are the ones who know about the failure, so they should return it.

## What changed

- **`packages/cli/src/commands/feedback.ts`**: `parsePrNumbers` now returns `Result<number[], InvalidPrNumberError>`. `feedbackIngestAction` drops the `try/catch` and handles the Result with a single `if (!parsed.ok)` guard.
- **`packages/cli/src/commands/mcp.ts`**: `parseClientList` → `Result<McpClientId[] | undefined, string>`; `parseScope` → `Result<McpScope, string>`. `mcpAction` drops the two-call `try/catch` in favor of sequential `if (!r.ok)` guards.
- Tests rewritten from `.toThrow(...)` to `r.ok === false` / `r.error` assertions, using the standard `if (r.ok)` narrow-and-unwrap pattern.

No behavioral change at the CLI boundary — both commands still exit non-zero with the same human-readable error messages.

## Test plan

- [x] `bun test packages/cli/src/commands/__tests__/feedback.test.ts` — 15/15 pass.
- [x] `bun test packages/cli/src/commands/__tests__/mcp.test.ts` — 18/18 pass.
- [x] `bun run typecheck` — clean.
- [x] `bun run check` (biome) — clean on touched files.
- [x] `maina commit` verify gate passed (13 tools).
- [x] `maina wiki lint` on this repo: **0 decision_violation findings** (was 2 after #212 merged).

## Follow-up from #212

PR #212 left these parsers as "pre-existing tech debt, out of scope." This PR closes that loop — after merge, the wiki-lint decision_violation count on master goes to zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in CLI feedback and MCP commands. Users now receive clearer, more consistent error messages when providing invalid inputs such as malformed PR numbers or unknown client configurations, improving overall command reliability.

* **Tests**
  * Updated comprehensive test suites for CLI feedback and MCP commands to verify proper input validation, error detection, and accurate error message reporting across various edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->