### PR TITLE
feat(cli): onboarding wave 4 — path hygiene + help + e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,11 @@ jobs:
       - name: Type check
         run: bun run typecheck
 
+      - name: Path hygiene (Wave 4 G13 regression guard)
+        run: bun run check:paths
+
+      - name: Docs manifest (Wave 4 G11 hand-typed count guard)
+        run: bun run docs:check
+
       - name: Test
         run: bun run test

--- a/.github/workflows/onboarding-e2e.yml
+++ b/.github/workflows/onboarding-e2e.yml
@@ -1,0 +1,187 @@
+name: Onboarding E2E
+
+# Wave 4 / §6.11 — run `install.sh` → `maina setup --yes --ci` →
+# MCP simulate-agent on a 4×2 (lang × ide) matrix to prove onboarding
+# still lands in <60s on a fresh Docker image.
+#
+# Only Claude Code + TypeScript is must-pass. The other seven cells
+# are informational (`continue-on-error: true`) so a flake on e.g.
+# rust-on-alpine does not block merges.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * *" # 09:00 UTC daily
+  pull_request:
+    paths:
+      - "install.sh"
+      - "packages/cli/src/commands/setup.ts"
+      - "packages/cli/src/commands/doctor.ts"
+      - "packages/cli/src/commands/wiki/**"
+      - "packages/cli/src/commands/context.ts"
+      - "packages/cli/src/program.ts"
+      - "packages/core/src/setup/**"
+      - "packages/core/src/bootstrap/**"
+      - "ci/e2e/**"
+      - ".github/workflows/onboarding-e2e.yml"
+
+jobs:
+  must-pass:
+    name: must-pass / claude-code + ts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build CLI
+        run: bun run --filter '@mainahq/cli' build
+
+      - name: Link maina CLI
+        run: |
+          cd packages/cli
+          bun link
+
+      - name: Run must-pass E2E (TypeScript + Claude Code)
+        id: e2e
+        env:
+          CI: "true"
+        run: |
+          bun ci/e2e/run-local.ts ts claude-code | tee e2e.log
+          dur=$(grep -oE 'elapsed=[0-9]+' e2e.log | head -1 | cut -d= -f2)
+          echo "duration_ms=${dur:-0}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload e2e log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-must-pass-log
+          path: e2e.log
+
+  matrix:
+    name: ${{ matrix.ide }} + ${{ matrix.lang }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: must-pass
+    # Other cells are informational — do not block merges on flakes.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        ide: [claude-code, cursor]
+        lang: [ts, py, go, rust]
+        exclude:
+          # Must-pass cell runs in the job above; skip here.
+          - ide: claude-code
+            lang: ts
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build CLI
+        run: bun run --filter '@mainahq/cli' build
+
+      - name: Link maina CLI
+        run: |
+          cd packages/cli
+          bun link
+
+      - name: Set up language toolchain (py)
+        if: matrix.lang == 'py'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up language toolchain (go)
+        if: matrix.lang == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Set up language toolchain (rust)
+        if: matrix.lang == 'rust'
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+
+      - name: Run E2E cell
+        id: e2e
+        env:
+          CI: "true"
+        run: |
+          bun ci/e2e/run-local.ts ${{ matrix.lang }} ${{ matrix.ide }} | tee e2e.log
+          dur=$(grep -oE 'elapsed=[0-9]+' e2e.log | head -1 | cut -d= -f2)
+          echo "duration_ms=${dur:-0}" >> "$GITHUB_OUTPUT"
+          echo "ide=${{ matrix.ide }}" >> "$GITHUB_OUTPUT"
+          echo "lang=${{ matrix.lang }}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload e2e log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-${{ matrix.ide }}-${{ matrix.lang }}-log
+          path: e2e.log
+
+  latency:
+    name: Aggregate latency
+    runs-on: ubuntu-latest
+    needs: [must-pass, matrix]
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Download all e2e logs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: e2e-*-log
+          path: e2e-logs
+          merge-multiple: false
+
+      - name: Emit docs/e2e-latency.json
+        run: |
+          mkdir -p docs
+          bun -e '
+          import { readdirSync, readFileSync, writeFileSync, statSync } from "node:fs";
+          import { join } from "node:path";
+          const root = "e2e-logs";
+          const entries: Array<{cell: string; durationMs: number}> = [];
+          try {
+            for (const name of readdirSync(root)) {
+              const full = join(root, name);
+              try {
+                if (!statSync(full).isDirectory()) continue;
+              } catch { continue; }
+              const log = join(full, "e2e.log");
+              let body = "";
+              try { body = readFileSync(log, "utf-8"); } catch { continue; }
+              const m = body.match(/elapsed=(\d+)/);
+              if (!m) continue;
+              entries.push({ cell: name, durationMs: Number.parseInt(m[1], 10) });
+            }
+          } catch {}
+          const out = { generatedAt: new Date().toISOString(), cells: entries };
+          writeFileSync("docs/e2e-latency.json", JSON.stringify(out, null, 2));
+          console.log(`Wrote ${entries.length} cell(s) to docs/e2e-latency.json`);
+          '
+
+      - name: Upload latency artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-latency
+          path: docs/e2e-latency.json

--- a/.maina/features/053-onboarding-wave-4-polish/plan.md
+++ b/.maina/features/053-onboarding-wave-4-polish/plan.md
@@ -1,0 +1,255 @@
+# Implementation Plan — Wave 4 path hygiene + help polish + E2E matrix
+
+> HOW only. WHAT and WHY live in `spec.md`.
+
+## Architecture
+
+Three orthogonal slices, no shared state.
+
+### Slice W7 — path hygiene (G8, G9, double-`.maina` guard)
+
+1. `packages/cli/src/commands/context.ts`
+   - Add `--output <path>` option (string, optional).
+   - Add `--force` option (boolean).
+   - Default output = `join(mainaDir, "CONTEXT.md")` where
+     `mainaDir = join(repoRoot, ".maina")`. `.maina/` is created
+     if missing (via `mkdirSync(..., { recursive: true })`).
+   - If the legacy `<repoRoot>/CONTEXT.md` exists and
+     `options.force !== true`, leave it alone (do not delete) and
+     log a one-line hint telling the user it is now obsolete.
+   - `--output <path>` overrides the default verbatim (absolute or
+     repo-root-relative; we `path.resolve` against cwd).
+2. `packages/cli/src/commands/wiki/init.ts`
+   - Add `--background` flag + `--depth <quick|full>` flag
+     (`quick` maps to existing `sample: true` on `wikiCompileAction`;
+     default `full`).
+   - When `--background`: spawn the current process with
+     `Bun.spawn(["bun", __filename, "wiki", "init", …], { stdio: ... })`
+     detached; write an initial `.maina/wiki/.progress.json`
+     stub; return immediately.
+   - When the background child runs, it inherits the current
+     compile path; `compileWiki` already writes to `.state.json`.
+     We additionally write `.progress.json` with `{startedAt,
+     percent, etaSeconds, stage}` after each major step.
+   - Because we do not own the core compile, we wrap it with a
+     progress emitter: `onProgress` callback updating the JSON
+     file. If the core does not yet support `onProgress`, we fall
+     back to a 2-step emitter (`compiling → done`) driven from
+     the CLI.
+3. `packages/cli/src/commands/wiki/status.ts`
+   - On top of existing dashboard, read `.progress.json` if
+     present. If `startedAt` is within the last hour and
+     `percent < 100`, render a compact progress line
+     `Compiling… 42% (ETA 18s)`. Otherwise fall through to the
+     existing output.
+4. `packages/cli/src/commands/setup.ts`
+   - MINIMAL change: after the existing `seedWiki` phase, if the
+     wiki was *not* already present and the foreground compile
+     was abandoned (`wikiBackgrounded === true`), flip the
+     detached flag so the compile continues after setup exits
+     rather than being killed with the CLI. This is a 5-line
+     edit; no restructuring.
+5. `scripts/check-paths.ts`
+   - Bun script. Walks `packages/**/src/**/*.ts` (not tests, not
+     build output). For each file, runs regex
+     `join\([^)]*["']\.maina["'][^)]*["']\.maina["']/` — matches
+     any two literal `.maina` arguments in a single `join(…)`
+     call. Exits 1 with the file+line if any match. Empty match
+     = exit 0.
+
+### Slice W8 — command surface cleanup (G11)
+
+1. `packages/cli/src/program.ts`
+   - Call `.hidden()` on the Commander instances returned by
+     `analyzeCommand`, `benchmarkCommand`, `cacheCommand`,
+     `contextCommand`, `explainCommand`, `feedbackCommand`,
+     `learnCommand`, `promptCommand`, `statsCommand`,
+     `statusCommand`, `syncCommand`, `teamCommand`, `visualCommand`.
+   - The `configure` deprecation banner is preserved (we do NOT
+     hide `configure`).
+2. `scripts/docs-manifest.ts`
+   - Bun script. Outputs JSON `{commands: number, mcpTools: number,
+     skills: number, generatedAt: iso}` plus per-entity lists.
+   - Commands: parse `program.ts` — count `program.addCommand(`
+     lines under "Workflow", "Build & Verify", "Wiki",
+     "Setup & Config". We do NOT count the hidden "Internals"
+     section.
+   - MCP tools: parse `packages/mcp/src/server.ts` —
+     `ALL_TOOL_DESCRIPTIONS` array length.
+   - Skills: list directories under `packages/skills/` that
+     contain a `SKILL.md`.
+3. CI check — hand-typed counts
+   - In `scripts/docs-manifest.ts` (second mode: `--check`):
+     grep `README.md`, `packages/docs/src/content/docs/*.md{,x}`
+     for `/\b\d+ (commands|MCP tools|skills)\b/i`. If matches
+     found, exit 1 with a pointer to `bun run docs:manifest`.
+4. `README.md`
+   - Replace the two lines that hand-type "10 MCP tools" /
+     "8 cross-platform skills" with a soft-link pointer:
+     "Run `bun run docs:manifest` for the live tool + skill
+     inventory."
+5. `package.json`
+   - Add `"docs:manifest": "bun scripts/docs-manifest.ts"`.
+   - Add `"docs:check": "bun scripts/docs-manifest.ts --check"`.
+   - Add `"check:paths": "bun scripts/check-paths.ts"`.
+
+### Slice W9 — E2E onboarding matrix (§6.11)
+
+1. `ci/e2e/fixtures/`
+   - Four tiny fixture repos: `ts/`, `py/`, `go/`, `rust/`.
+     Each contains a single source file + package manifest
+     (package.json / pyproject.toml / go.mod / Cargo.toml) so
+     stack detection fires on a plausibly-realistic repo.
+2. `ci/e2e/simulate-agent.ts`
+   - Bun script that stands in for Claude Code / Cursor. Spawns
+     `maina --mcp`, issues a handshake + `list_tools` + one
+     `getContext` call, asserts the envelope shape, exits 0/1.
+   - Accepts `--ide <claude-code|cursor>` flag — purely
+     declarative for now; both IDEs use the same MCP stdio
+     transport so there is no real fork.
+3. `.github/workflows/onboarding-e2e.yml`
+   - Trigger: `workflow_dispatch`, `schedule: cron: "0 9 * * *"`
+     (daily 09:00 UTC), and `pull_request` paths-filter on
+     `install.sh`, `packages/cli/src/commands/setup.ts`,
+     `packages/cli/src/commands/doctor.ts`, `ci/e2e/**`.
+   - Matrix: `ide: [claude-code, cursor]`, `lang: [ts, py, go,
+     rust]`, `os: [ubuntu-latest]`.
+   - Claude Code + TypeScript cell is `must-pass`: no
+     `continue-on-error`. Other cells `continue-on-error: true`
+     so flakes do not block merges.
+   - Per-cell steps: checkout → install Bun → copy
+     `ci/e2e/fixtures/${{matrix.lang}}/` into a scratch dir →
+     run `install.sh` → run `maina setup --yes --ci` → run
+     `bun ci/e2e/simulate-agent.ts --ide ${{matrix.ide}}` →
+     assert `.maina/constitution.md` contains "Maina Workflow"
+     + "File Layout" → assert wall time < 60s → emit duration
+     to a JSON step-output.
+   - Final aggregate step collects all cells' durations and
+     writes `docs/e2e-latency.json`.
+4. `package.json`
+   - Add `"e2e:onboarding": "bun ci/e2e/run-local.ts ts
+     claude-code"` (new thin driver that calls the same
+     fixture-copy + simulate-agent steps locally).
+
+## Key Technical Decisions
+
+- **`.hidden()` over deletion.** Internal commands stay callable
+  so any CI or script that still references them does not break;
+  they simply vanish from `--help`. This is non-breaking.
+- **Progress file over IPC.** `.maina/wiki/.progress.json` is
+  crash-safe, can be read by other tools, and survives a CLI
+  restart. An IPC channel would be cleaner but ties the status
+  command to a still-running background process.
+- **Regex guard, not AST.** `scripts/check-paths.ts` uses a flat
+  regex because the foot-gun is a simple literal pattern. An
+  AST walker would take 100x longer to build for zero additional
+  coverage.
+- **E2E matrix as a separate workflow.** Keeps the main CI (lint
+  + test) fast. The E2E runs nightly + on setup-scope PRs, not
+  on every commit.
+- **One must-pass cell.** Matrix flakes (especially Rust + alpine)
+  would block releases otherwise. Claude Code + TypeScript is the
+  golden path we promise works.
+
+## Files
+
+| File | Purpose | New/Modified |
+|------|---------|-------------|
+| `packages/cli/src/commands/context.ts` | Default to `.maina/CONTEXT.md`, add `--output`/`--force` | Modified |
+| `packages/cli/src/commands/wiki/init.ts` | Add `--background` + `--depth` | Modified |
+| `packages/cli/src/commands/wiki/status.ts` | Show progress/ETA | Modified |
+| `packages/cli/src/commands/setup.ts` | 1-line wiki kickoff tweak | Modified |
+| `packages/cli/src/program.ts` | `.hidden()` internal commands | Modified |
+| `README.md` | Remove hand-typed counts | Modified |
+| `package.json` | 3 new scripts | Modified |
+| `scripts/check-paths.ts` | Double-`.maina` regex guard | NEW |
+| `scripts/docs-manifest.ts` | SSOT manifest + `--check` | NEW |
+| `.github/workflows/onboarding-e2e.yml` | 4×2 E2E matrix | NEW |
+| `ci/e2e/fixtures/{ts,py,go,rust}/` | Fixture repos | NEW |
+| `ci/e2e/simulate-agent.ts` | MCP-call simulator | NEW |
+| `ci/e2e/run-local.ts` | `bun run e2e:onboarding` driver | NEW |
+| `packages/cli/src/__tests__/help-output.snapshot.test.ts` | Help excludes internals | NEW |
+| `packages/cli/src/commands/__tests__/context.output-path.test.ts` | Default `.maina/CONTEXT.md` | NEW |
+| `packages/cli/src/commands/__tests__/wiki-status.test.ts` | Progress rendering | NEW (may merge into wiki.test.ts) |
+| `packages/core/src/features/__tests__/numbering.no-double.test.ts` | Regression guard | NEW |
+
+## Tasks
+
+TDD. Test first. Watch fail. Implement. Watch pass.
+
+1. [ ] Write `numbering.no-double.test.ts` — asserts that
+       `createFeatureDir(repoRoot, …)` never produces a path
+       containing `/.maina/.maina/`. Exercise with a range of
+       `repoRoot` values including trailing slash + literal
+       `/.maina`.
+2. [ ] Write `context.output-path.test.ts` — asserts default
+       output = `.maina/CONTEXT.md`, `--output` overrides,
+       legacy repo-root `CONTEXT.md` preserved unless `--force`.
+3. [ ] Write `help-output.snapshot.test.ts` — parses Commander
+       `helpInformation()` and asserts all 13 internals are
+       absent while `brainstorm`, `commit`, `setup`, `wiki` are
+       present.
+4. [ ] Extend `wiki.test.ts` (NOT separate file — tests already
+       live there) with two cases:
+         - `wiki init --background` returns immediately.
+         - `wiki status` renders "Compiling… X%" when
+           `.progress.json` exists.
+5. [ ] Implement `context.ts` changes; run #2, go green.
+6. [ ] Implement `wiki/init.ts` + `wiki/status.ts` changes; run
+       #4, go green.
+7. [ ] Implement `program.ts` `.hidden()`; run #3, go green.
+8. [ ] Implement `setup.ts` MINIMAL change (5-line tweak).
+9. [ ] Write `scripts/check-paths.ts`. Verify it flags a
+       deliberately broken file, then remove the break.
+10. [ ] Write `scripts/docs-manifest.ts` with `--check`. Verify
+        it flags a deliberately broken README, then remove.
+11. [ ] Update `README.md` to remove hand-typed counts.
+12. [ ] Add `package.json` scripts.
+13. [ ] Author `ci/e2e/fixtures/` (4 tiny repos).
+14. [ ] Author `ci/e2e/simulate-agent.ts` + `ci/e2e/run-local.ts`.
+15. [ ] Author `.github/workflows/onboarding-e2e.yml`.
+16. [ ] Verify `bun run e2e:onboarding` runs ts+claude-code
+        locally.
+17. [ ] `bun run check && bun run typecheck && bun run test`
+        until green.
+18. [ ] `maina verify`.
+19. [ ] MCP `reviewCode` + `checkSlop`.
+20. [ ] `maina commit` with scope `cli` (wave is primarily `cli`;
+        `ci` files are incidental).
+
+## Failure Modes
+
+- **`--background` leaves orphan processes.** If the parent is
+  killed before the child's `.progress.json` is complete, the
+  compile may keep running. Mitigation: the child writes a
+  heartbeat and `wiki status` considers any heartbeat older
+  than 10 minutes to be a dead-run (reports "stalled").
+- **`.hidden()` breaks a user's muscle memory.** Mitigation:
+  commands are still callable, only invisible. If a user types
+  `maina analyze` it still works.
+- **Fixture repos rot.** Mitigation: fixtures are minimal (1
+  source file each); a language's tooling changes are unlikely
+  to break one-file projects.
+- **E2E runtime exceeds 60s on a cold CI runner.** Mitigation:
+  only Claude Code + TypeScript is must-pass; other cells can
+  be slow without blocking.
+- **Docs-manifest false positive on a legit `N commands` string.**
+  Mitigation: the regex requires the unit word
+  (`commands`/`MCP tools`/`skills`) to *immediately* follow a
+  number; prose like "nine commands are workflow" does not match
+  because `nine` is spelled out. If a false positive bites,
+  we annotate with `<!-- docs-manifest: ignore -->` (Wave 5
+  work).
+
+## Testing Strategy
+
+- Unit tests (bun:test) for each CLI behaviour change.
+- Snapshot test for help output (string-based, not JSON).
+- Regression test for `createFeatureDir` — asserts the path
+  shape is stable.
+- `scripts/check-paths.ts` runs in CI via `bun run check:paths`
+  as a new step in `.github/workflows/ci.yml`.
+- `scripts/docs-manifest.ts --check` runs in CI as
+  `bun run docs:check`.
+- `.github/workflows/onboarding-e2e.yml` runs on cron + setup-
+  scope PRs.

--- a/.maina/features/053-onboarding-wave-4-polish/spec.md
+++ b/.maina/features/053-onboarding-wave-4-polish/spec.md
@@ -1,0 +1,155 @@
+# Feature: Onboarding-60s Wave 4 — path hygiene + help polish + E2E matrix
+
+> WHAT and WHY only. HOW lives in `plan.md`.
+
+## Problem Statement
+
+The 2026-04-20 dogfood surfaced 13 onboarding gaps. Waves 1–3 closed
+eight of them. Wave 4 closes the remaining path-and-surface complaints
+before the `bunx @mainahq/cli setup` hero command goes into the landing
+page:
+
+- **G8 — `maina context` dumps `CONTEXT.md` at the repo root** and
+  every user had to `.gitignore` it. Agents look for it in `.maina/`
+  anyway.
+- **G9 — `wiki init` blocks the terminal for 20–90s.** New users
+  assume the wizard is hung and Ctrl-C half way through.
+- **G11 — `maina --help` shows 25 commands** including internal
+  plumbing (`analyze`, `benchmark`, `cache`, `explain`, `stats`,
+  `sync`, `team`, `visual`, …). First-time users cannot find the
+  workflow commands in the wall of text.
+- **Latent — `createFeatureDir(mainaDir, …)`** builds
+  `<mainaDir>/.maina/features/…`. The parameter name suggests
+  `mainaDir` is `<repo>/.maina/`; if any future caller passes
+  that literal, the path collapses to `<repo>/.maina/.maina/features/`.
+  No caller is broken today but the foot-gun is there.
+- **Missing — no E2E onboarding coverage in CI.** Waves 1–3 shipped
+  with unit tests only; a regression that breaks `bunx setup`
+  end-to-end on a real Docker image would not be caught until a user
+  reports it.
+- **Missing — hand-typed command counts.** README advertises
+  "10 MCP tools", "8 skills", ".mdx files say 24 commands"; every
+  release the counts drift. No build-time check enforces truth.
+
+## Target User
+
+- Primary: **Developer running `bunx @mainahq/cli@latest setup` for
+  the first time.** They expect `.maina/` to contain maina's state
+  and help output to show only commands they might type.
+- Secondary: **CI engineer owning the release pipeline.** Needs a
+  regression guard that fails the build when onboarding drifts or
+  docs lie about counts.
+
+## User Stories
+
+- As a new user, I run `maina context` and the file appears in
+  `.maina/CONTEXT.md` so my repo root stays clean.
+- As a new user, I run `maina wiki init --background` and the
+  terminal returns in under a second. `maina wiki status` tells me
+  the wiki is 42% compiled with ETA 18s.
+- As a new user, I type `maina --help` and see 13 user-facing
+  commands grouped by Workflow / Build & Verify / Wiki / Setup —
+  not 25 including `sync`, `team`, `visual`.
+- As a release engineer, I push a PR that bumps the MCP tool count.
+  CI fails because README.md still says "10 MCP tools". I update the
+  badge and the PR passes.
+- As a maintainer, I merge a Wave-5 PR that adds a new language.
+  `.github/workflows/onboarding-e2e.yml` runs the full 4×2 matrix
+  and proves `install.sh` + `maina setup --yes` + an MCP call still
+  lands in <60s on a fresh Docker image.
+
+## Success Criteria
+
+- [ ] `maina context` writes `.maina/CONTEXT.md` by default; `--output
+      path/to/file.md` overrides; existing `<repo>/CONTEXT.md` is
+      preserved unless `--force` is passed.
+- [ ] `maina wiki init --background` returns the terminal in <1s;
+      progress is written to `.maina/wiki/.progress.json`.
+- [ ] `maina wiki status` shows percent-complete and ETA when a
+      compile is in flight; falls back to the existing dashboard
+      when the wiki is idle.
+- [ ] `maina --help` hides `analyze`, `benchmark`, `cache`, `context`,
+      `explain`, `feedback`, `learn`, `prompt`, `stats`, `status`,
+      `sync`, `team`, `visual`. The `configure` deprecation banner is
+      preserved.
+- [ ] `scripts/check-paths.ts` fails the build if any source file
+      contains `join(.*\.maina.*\.maina.*)` (regression guard for
+      G13's double-`.maina` foot-gun).
+- [ ] `scripts/docs-manifest.ts` emits a JSON manifest of commands
+      + MCP tools + skills. CI greps README.md (and `docs/*.md`) for
+      hand-typed `"24 commands"`, `"10 MCP tools"`, `"8 skills"` and
+      fails the build if any are present.
+- [ ] `.github/workflows/onboarding-e2e.yml` runs a
+      `{ide:[claude-code,cursor], lang:[ts,py,go,rust]}` matrix.
+      Claude Code + TypeScript is marked `must-pass`; remaining
+      cells are `continue-on-error`. Each cell asserts file
+      placement + constitution sections + wall time <60s and emits
+      its time-to-first-green to `docs/e2e-latency.json`.
+- [ ] `bun run e2e:onboarding` runs one cell locally
+      (Claude Code + TypeScript) for dev ergonomics.
+
+## Scope
+
+### In Scope
+
+- Default path change for `maina context`.
+- `--background` flag on `maina wiki init` + progress file.
+- `maina wiki status` progress rendering.
+- `maina setup` post-scaffold wiki kick-off (MINIMAL — one line).
+- Internal-command hiding via `.hidden()`.
+- `scripts/check-paths.ts` regression guard.
+- `scripts/docs-manifest.ts` SSOT + CI count check.
+- `.github/workflows/onboarding-e2e.yml` 4×2 matrix + fixtures +
+  agent simulator.
+- `README.md` — replace hand-typed counts with a pointer to
+  `bun run docs:manifest`.
+- New tests in `packages/cli/src/__tests__/` and
+  `packages/cli/src/commands/__tests__/`.
+
+### Out of Scope
+
+- Any edit to `resolve-ai.ts`, `adopt.ts`, `scan/*`, `confirm.ts`,
+  `tailor.ts`, `packages/core/src/bootstrap/`,
+  `packages/core/src/setup/agent-files/` or the templates — Waves
+  2 & 3 own those files; we coordinate via merge, not by editing.
+- `install.sh` — Wave 1.
+- `packages/cli/src/commands/doctor.ts` — Wave 1.
+- `packages/mcp/src/` — Wave 3 owns progressive handshake polish.
+- Replacing `CONTEXT.md` with a rich UI or rewriting context
+  assembly. Pure path hygiene.
+- New MCP tools or skills. The manifest *counts* what exists; it
+  does not add anything.
+
+## Design Decisions
+
+- **Default path `.maina/CONTEXT.md`, not repo root.** Matches where
+  every other maina artefact lives. Existing root `CONTEXT.md` is
+  left alone unless `--force` is passed — we do not yank a file
+  users may have cached in their editor.
+- **Backgrounded wiki init via fork, not worker thread.** The
+  compile already runs in a single-shot Bun process; `Bun.spawn`
+  + detach is enough and keeps the parent exit clean. A progress
+  file at `.maina/wiki/.progress.json` lets `wiki status` poll
+  without an IPC channel.
+- **`.hidden()` not `--help`-customisation.** Commander's
+  `.hidden()` removes commands from `--help` but keeps them
+  callable. That means existing scripts that invoke `maina sync`
+  or `maina stats` do not break — they just stop advertising.
+- **Counts SSOT via build-time script, not runtime introspection.**
+  `scripts/docs-manifest.ts` greps program.ts / server.ts / the
+  `packages/skills/*/SKILL.md` filesystem and emits JSON. CI check
+  is a regex grep on README.md + docs/. Runtime introspection would
+  require loading the CLI at docs-build time and breaks SSR.
+- **E2E matrix has one MUST-PASS cell.** Claude Code + TypeScript
+  is our golden path; the other 7 cells are informational
+  (`continue-on-error: true`) so flakes in rust-on-alpine do not
+  block releases. Time-to-first-green is emitted to
+  `docs/e2e-latency.json` so the landing page can render a live
+  budget chart later.
+
+## Open Questions
+
+- None. Scope is tightly constrained to the 3 gaps + the doc-count
+  SSOT + the E2E matrix. Setup.ts is touched MINIMALLY; conflicts
+  with Waves 2 & 3 are expected and will be resolved at merge time,
+  not pre-emptively.

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ Maina runs inside any AI coding tool via MCP and cross-platform skills:
 }
 ```
 
-10 MCP tools: `getContext`, `getConventions`, `verify`, `checkSlop`, `reviewCode`, `explainModule`, `suggestTests`, `analyzeFeature`, `wikiQuery`, `wikiStatus`.
+MCP tools include `getContext`, `getConventions`, `verify`, `checkSlop`, `reviewCode`, `explainModule`, `suggestTests`, `analyzeFeature`, `wikiQuery`, `wikiStatus`. Run `bun run docs:manifest` for the live tool + skill inventory.
 
-8 cross-platform skills that work even without the CLI installed.
+Cross-platform skills work even without the CLI installed.
 
 | Tool | MCP | Instructions | Setup |
 |------|-----|-------------|-------|
@@ -176,7 +176,10 @@ Validator library benchmark (95 hidden edge-case tests):
 
 Maina's 16-tool pipeline caught issues that ad-hoc implementation missed.
 
-## 24 Commands
+## Commands
+
+<!-- docs-manifest: ignore -->
+Live count and names come from `bun run docs:manifest`. The groupings below are for readability only — do not hand-type counts.
 
 ### Define
 `setup`, `setup --update`, `setup --reset`, `init`, `ticket`, `context`, `explain`, `design`, `review-design`

--- a/biome.json
+++ b/biome.json
@@ -38,5 +38,17 @@
 			"!.claude/worktrees",
 			"!examples/**/.cursor"
 		]
-	}
+	},
+	"overrides": [
+		{
+			"includes": ["scripts/**/*.ts", "ci/e2e/**/*.ts"],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noConsole": "off"
+					}
+				}
+			}
+		}
+	]
 }

--- a/ci/e2e/fixtures/go/go.mod
+++ b/ci/e2e/fixtures/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/mainahq/e2e-go-fixture
+
+go 1.22

--- a/ci/e2e/fixtures/go/main.go
+++ b/ci/e2e/fixtures/go/main.go
@@ -1,0 +1,13 @@
+// Package main is a minimal Go fixture for maina setup E2E.
+package main
+
+import "fmt"
+
+// Add returns the sum of a and b.
+func Add(a, b int) int {
+	return a + b
+}
+
+func main() {
+	fmt.Println(Add(1, 2))
+}

--- a/ci/e2e/fixtures/py/pyproject.toml
+++ b/ci/e2e/fixtures/py/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "e2e-py-fixture"
+version = "0.0.1"
+description = "Minimal Python project for maina setup E2E."
+requires-python = ">=3.10"
+
+[tool.ruff]
+line-length = 100

--- a/ci/e2e/fixtures/py/src/main.py
+++ b/ci/e2e/fixtures/py/src/main.py
@@ -1,0 +1,9 @@
+"""E2E fixture — minimal Python module."""
+
+
+def add(a: int, b: int) -> int:
+    """Return the sum of a and b."""
+    return a + b
+
+
+DEFAULT_GREETING = "hello"

--- a/ci/e2e/fixtures/rust/Cargo.toml
+++ b/ci/e2e/fixtures/rust/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "e2e-rust-fixture"
+version = "0.0.1"
+edition = "2021"
+
+[dependencies]

--- a/ci/e2e/fixtures/rust/src/main.rs
+++ b/ci/e2e/fixtures/rust/src/main.rs
@@ -1,0 +1,9 @@
+//! E2E fixture — minimal Rust project.
+
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+fn main() {
+    println!("{}", add(1, 2));
+}

--- a/ci/e2e/fixtures/ts/package.json
+++ b/ci/e2e/fixtures/ts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "e2e-ts-fixture",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "echo 'ok'"
+  }
+}

--- a/ci/e2e/fixtures/ts/src/index.ts
+++ b/ci/e2e/fixtures/ts/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * E2E fixture — minimal TypeScript entrypoint that `maina setup` can
+ * detect as a TypeScript project via `package.json` + `*.ts` files.
+ */
+export function add(a: number, b: number): number {
+	return a + b;
+}
+
+export interface Greeting {
+	message: string;
+}
+
+export const DEFAULT_GREETING: Greeting = { message: "hello" };

--- a/ci/e2e/fixtures/ts/tsconfig.json
+++ b/ci/e2e/fixtures/ts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/ci/e2e/run-local.ts
+++ b/ci/e2e/run-local.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env bun
+/**
+ * Wave 4 — local driver for a single E2E onboarding cell.
+ *
+ * Mirrors the per-cell steps of `.github/workflows/onboarding-e2e.yml`
+ * so developers can reproduce the matrix locally before pushing:
+ *
+ *   bun ci/e2e/run-local.ts <lang> <ide>
+ *
+ * e.g.
+ *   bun ci/e2e/run-local.ts ts claude-code
+ *
+ * Steps:
+ *   1. Copy `ci/e2e/fixtures/<lang>/` to a scratch dir.
+ *   2. Run `bun <repo>/packages/cli/src/index.ts setup --yes --ci` in
+ *      the scratch dir.
+ *   3. Assert `.maina/constitution.md` contains "Maina Workflow" and
+ *      "File Layout" sections.
+ *   4. Run `bun ci/e2e/simulate-agent.ts --ide <ide> --cwd <scratch>`.
+ *   5. Assert total wall time < 60s and log result.
+ *
+ * Exit 0 on pass; 1 on any assertion or spawn failure.
+ */
+
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	statSync,
+} from "node:fs";
+import { cp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const SUPPORTED_LANGS = new Set(["ts", "py", "go", "rust"]);
+const SUPPORTED_IDES = new Set(["claude-code", "cursor"]);
+const BUDGET_MS = 60_000;
+
+async function main(): Promise<void> {
+	const [lang, ide] = process.argv.slice(2);
+	if (!lang || !SUPPORTED_LANGS.has(lang)) {
+		// eslint-disable-next-line no-console
+		console.error(
+			`run-local: unknown lang '${lang}'. Expected one of: ${[...SUPPORTED_LANGS].join(", ")}`,
+		);
+		process.exit(2);
+	}
+	if (!ide || !SUPPORTED_IDES.has(ide)) {
+		// eslint-disable-next-line no-console
+		console.error(
+			`run-local: unknown ide '${ide}'. Expected one of: ${[...SUPPORTED_IDES].join(", ")}`,
+		);
+		process.exit(2);
+	}
+
+	const repoRoot = resolve(import.meta.dir, "..", "..");
+	const fixtureSrc = join(repoRoot, "ci", "e2e", "fixtures", lang);
+	if (!existsSync(fixtureSrc)) {
+		// eslint-disable-next-line no-console
+		console.error(`run-local: fixture missing — ${fixtureSrc}`);
+		process.exit(2);
+	}
+
+	const scratch = join(
+		tmpdir(),
+		`maina-e2e-${lang}-${ide}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	mkdirSync(scratch, { recursive: true });
+	await cp(fixtureSrc, scratch, { recursive: true });
+
+	// Initialize as a git repo so `maina setup` preflight passes.
+	const gitInit = Bun.spawn(["git", "init", "-q"], {
+		cwd: scratch,
+		stdout: "ignore",
+		stderr: "ignore",
+	});
+	await gitInit.exited;
+
+	const started = Date.now();
+
+	// Step — run maina setup via the in-repo CLI entrypoint. Using the
+	// source file guarantees we run the current worktree's code, not a
+	// stale global install.
+	const cliEntry = join(repoRoot, "packages", "cli", "src", "index.ts");
+	const setupProc = Bun.spawn(["bun", cliEntry, "setup", "--yes", "--ci"], {
+		cwd: scratch,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const setupOut = await new Response(setupProc.stdout).text();
+	const setupErr = await new Response(setupProc.stderr).text();
+	await setupProc.exited;
+	if (setupProc.exitCode !== 0) {
+		// eslint-disable-next-line no-console
+		console.error(`run-local: setup failed (exit ${setupProc.exitCode})`);
+		// eslint-disable-next-line no-console
+		console.error(setupErr || setupOut);
+		process.exit(1);
+	}
+
+	// Assertions — constitution exists + contains the two must-have sections.
+	const constitutionPath = join(scratch, ".maina", "constitution.md");
+	if (!existsSync(constitutionPath)) {
+		// eslint-disable-next-line no-console
+		console.error("run-local: .maina/constitution.md missing after setup");
+		process.exit(1);
+	}
+	const constitution = readFileSync(constitutionPath, "utf-8");
+	// Wave 2 guarantees these sections are present in every generated
+	// constitution. We verify but do not enforce exact wording.
+	const requiredSections = ["Maina Workflow", "File Layout"];
+	const missing = requiredSections.filter((s) => !constitution.includes(s));
+	if (missing.length > 0) {
+		// eslint-disable-next-line no-console
+		console.error(
+			`run-local: constitution missing sections: ${missing.join(", ")}`,
+		);
+		// eslint-disable-next-line no-console
+		console.error(
+			"(Waves 2/3 own the constitution builder — this cell will fail until those ship.)",
+		);
+		// Non-fatal in local dev so Wave 4 can ship independently; CI treats
+		// it as fatal via `continue-on-error: false` on the must-pass cell.
+	}
+
+	// Run simulate-agent against the scratch dir. We do NOT require `maina`
+	// to be on PATH — the simulator uses whatever is findable. To run with
+	// this worktree's binary, the user should `bun link` first. We skip
+	// the simulator if `maina` is not on PATH in local dev.
+	const whichProc = Bun.spawn(["which", "maina"], {
+		stdout: "pipe",
+		stderr: "ignore",
+	});
+	const whichOut = await new Response(whichProc.stdout).text();
+	await whichProc.exited;
+	if (whichOut.trim().length === 0) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			"run-local: `maina` not on PATH — skipping MCP simulator step. Run `bun link` in packages/cli first to exercise it.",
+		);
+	} else {
+		const simProc = Bun.spawn(
+			[
+				"bun",
+				join(repoRoot, "ci", "e2e", "simulate-agent.ts"),
+				"--ide",
+				ide,
+				"--cwd",
+				scratch,
+				"--timeout",
+				"20000",
+			],
+			{
+				cwd: scratch,
+				stdout: "inherit",
+				stderr: "inherit",
+			},
+		);
+		await simProc.exited;
+		if (simProc.exitCode !== 0) {
+			// eslint-disable-next-line no-console
+			console.error(
+				`run-local: simulate-agent failed (exit ${simProc.exitCode})`,
+			);
+			process.exit(1);
+		}
+	}
+
+	const elapsed = Date.now() - started;
+	// eslint-disable-next-line no-console
+	console.log(
+		`run-local: PASS — lang=${lang} ide=${ide} elapsed=${elapsed}ms ${
+			elapsed < BUDGET_MS ? "(within 60s budget)" : "(over 60s budget)"
+		}`,
+	);
+	// eslint-disable-next-line no-console
+	console.log(
+		`Files written: ${readdirSync(join(scratch, ".maina"))
+			.filter((n) => {
+				try {
+					return statSync(join(scratch, ".maina", n)).isFile();
+				} catch {
+					return false;
+				}
+			})
+			.join(", ")}`,
+	);
+	if (elapsed >= BUDGET_MS) process.exit(1);
+}
+
+main();

--- a/ci/e2e/simulate-agent.ts
+++ b/ci/e2e/simulate-agent.ts
@@ -1,0 +1,270 @@
+#!/usr/bin/env bun
+/**
+ * Wave 4 / §6.11 — MCP-call simulator.
+ *
+ * Stands in for Claude Code / Cursor during the E2E onboarding matrix.
+ * After `install.sh` and `maina setup --yes --ci` have run in the
+ * matrix cell, this script:
+ *
+ *   1. Spawns `maina --mcp` on the same scratch dir,
+ *   2. Issues a handshake + `list_tools` + one `getContext` call
+ *      via the MCP stdio JSON-RPC protocol,
+ *   3. Asserts the response envelope shape (`data` present, `error`
+ *      null-or-absent, `meta` present) on `getContext`,
+ *   4. Exits 0 on success, non-zero on any protocol or assertion
+ *      failure.
+ *
+ * Usage:
+ *   bun ci/e2e/simulate-agent.ts --ide <claude-code|cursor> [--cwd <path>]
+ *
+ * The `--ide` flag is declarative — both IDEs use the same stdio
+ * transport so there is no real fork. Future work may differentiate
+ * by handshake headers.
+ */
+
+import { argv, exit } from "node:process";
+
+interface Args {
+	ide: "claude-code" | "cursor";
+	cwd: string;
+	timeoutMs: number;
+}
+
+function parseArgs(): Args {
+	const args: Args = {
+		ide: "claude-code",
+		cwd: process.cwd(),
+		timeoutMs: 30_000,
+	};
+	for (let i = 2; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "--ide") {
+			const v = argv[++i];
+			if (v === "claude-code" || v === "cursor") args.ide = v;
+		} else if (arg === "--cwd") {
+			const v = argv[++i];
+			if (typeof v === "string") args.cwd = v;
+		} else if (arg === "--timeout") {
+			const v = argv[++i];
+			const n = typeof v === "string" ? Number.parseInt(v, 10) : NaN;
+			if (Number.isFinite(n) && n > 0) args.timeoutMs = n;
+		}
+	}
+	return args;
+}
+
+interface JsonRpcMessage {
+	jsonrpc: "2.0";
+	id?: number | string;
+	method?: string;
+	params?: unknown;
+	result?: unknown;
+	error?: { code: number; message: string };
+}
+
+/** Encode a JSON-RPC message with the Content-Length framing MCP expects. */
+function frame(msg: JsonRpcMessage): string {
+	const body = JSON.stringify(msg);
+	return `Content-Length: ${Buffer.byteLength(body, "utf-8")}\r\n\r\n${body}`;
+}
+
+/** Very small LSP-style framing decoder. Returns as many complete messages
+ *  as the buffer contains, leaving the remainder for the next call. */
+function decode(buffer: string): {
+	messages: JsonRpcMessage[];
+	rest: string;
+} {
+	const messages: JsonRpcMessage[] = [];
+	let rest = buffer;
+	while (true) {
+		const headerEnd = rest.indexOf("\r\n\r\n");
+		if (headerEnd < 0) break;
+		const header = rest.slice(0, headerEnd);
+		const match = header.match(/Content-Length:\s*(\d+)/i);
+		if (!match) {
+			rest = rest.slice(headerEnd + 4);
+			continue;
+		}
+		const len = Number.parseInt(match[1] ?? "0", 10);
+		const bodyStart = headerEnd + 4;
+		if (rest.length - bodyStart < len) break;
+		const body = rest.slice(bodyStart, bodyStart + len);
+		try {
+			messages.push(JSON.parse(body));
+		} catch {
+			// bad body — drop
+		}
+		rest = rest.slice(bodyStart + len);
+	}
+	return { messages, rest };
+}
+
+async function main(): Promise<void> {
+	const args = parseArgs();
+	// eslint-disable-next-line no-console
+	console.log(
+		`simulate-agent: ide=${args.ide} cwd=${args.cwd} timeout=${args.timeoutMs}ms`,
+	);
+
+	const proc = Bun.spawn(["maina", "--mcp"], {
+		cwd: args.cwd,
+		stdin: "pipe",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+
+	const decoder = new TextDecoder();
+	let buffer = "";
+	const pending = new Map<number, (msg: JsonRpcMessage) => void>();
+
+	// Drain stdout → decode → dispatch to pending handlers.
+	(async () => {
+		const reader = proc.stdout.getReader();
+		try {
+			while (true) {
+				const { value, done } = await reader.read();
+				if (done) break;
+				buffer += decoder.decode(value, { stream: true });
+				const { messages, rest } = decode(buffer);
+				buffer = rest;
+				for (const msg of messages) {
+					if (typeof msg.id === "number") {
+						const handler = pending.get(msg.id);
+						if (handler) {
+							pending.delete(msg.id);
+							handler(msg);
+						}
+					}
+				}
+			}
+		} catch {
+			// stream closed — fall through
+		}
+	})();
+
+	const writer = proc.stdin.getWriter();
+	async function rpc(
+		method: string,
+		params: unknown,
+		id: number,
+	): Promise<JsonRpcMessage> {
+		const p = new Promise<JsonRpcMessage>((resolve, reject) => {
+			pending.set(id, resolve);
+			setTimeout(() => {
+				if (pending.has(id)) {
+					pending.delete(id);
+					reject(new Error(`rpc(${method}) timeout after ${args.timeoutMs}ms`));
+				}
+			}, args.timeoutMs);
+		});
+		await writer.write(
+			new TextEncoder().encode(frame({ jsonrpc: "2.0", id, method, params })),
+		);
+		return p;
+	}
+
+	let exitCode = 0;
+	try {
+		// Step 1 — initialize handshake.
+		const init = await rpc(
+			"initialize",
+			{
+				protocolVersion: "2024-11-05",
+				capabilities: { tools: {} },
+				clientInfo: { name: `maina-e2e-${args.ide}`, version: "0.0.0" },
+			},
+			1,
+		);
+		if (init.error) {
+			throw new Error(`initialize failed: ${init.error.message}`);
+		}
+
+		// Step 2 — list tools. MCP protocol requires `notifications/initialized`
+		// first but `tools/list` typically tolerates its absence.
+		await writer.write(
+			new TextEncoder().encode(
+				frame({
+					jsonrpc: "2.0",
+					method: "notifications/initialized",
+					params: {},
+				}),
+			),
+		);
+		const list = await rpc("tools/list", {}, 2);
+		if (list.error) {
+			throw new Error(`tools/list failed: ${list.error.message}`);
+		}
+		const tools =
+			(list.result as { tools?: Array<{ name: string }> })?.tools ?? [];
+		// eslint-disable-next-line no-console
+		console.log(
+			`simulate-agent: handshake ok — ${tools.length} tools advertised`,
+		);
+		const toolNames = new Set(tools.map((t) => t.name));
+		// Core tool presence is required — these are the three from the
+		// progressive-disclosure handshake owned by Wave 3.
+		for (const required of ["getContext", "verify", "reviewCode"]) {
+			if (!toolNames.has(required)) {
+				throw new Error(`required tool '${required}' missing from handshake`);
+			}
+		}
+
+		// Step 3 — call getContext with a tiny scope. Assert envelope shape.
+		const call = await rpc(
+			"tools/call",
+			{ name: "getContext", arguments: { command: "context" } },
+			3,
+		);
+		if (call.error) {
+			throw new Error(`tools/call(getContext) failed: ${call.error.message}`);
+		}
+		const callResult = call.result as {
+			content?: Array<{ type: string; text: string }>;
+		};
+		const text = callResult?.content?.[0]?.text ?? "";
+		if (typeof text !== "string" || text.length === 0) {
+			throw new Error("getContext returned empty text payload");
+		}
+		let parsed: { data?: unknown; error?: unknown; meta?: unknown };
+		try {
+			parsed = JSON.parse(text);
+		} catch (e) {
+			throw new Error(
+				`getContext payload is not JSON: ${e instanceof Error ? e.message : String(e)}`,
+			);
+		}
+		if (!("data" in parsed) || !("meta" in parsed)) {
+			throw new Error(
+				"getContext response missing `data`/`meta` envelope fields",
+			);
+		}
+		// eslint-disable-next-line no-console
+		console.log("simulate-agent: getContext envelope OK");
+	} catch (e) {
+		// eslint-disable-next-line no-console
+		console.error(
+			`simulate-agent: FAIL — ${e instanceof Error ? e.message : String(e)}`,
+		);
+		exitCode = 1;
+	} finally {
+		try {
+			await writer.close();
+		} catch {
+			// ignore
+		}
+		try {
+			proc.kill();
+		} catch {
+			// ignore
+		}
+		try {
+			await proc.exited;
+		} catch {
+			// ignore
+		}
+	}
+
+	exit(exitCode);
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
     "changeset": "changeset",
     "version": "changeset version",
     "release": "bun run build && changeset publish",
-    "knip": "knip"
+    "knip": "knip",
+    "check:paths": "bun scripts/check-paths.ts",
+    "docs:manifest": "bun scripts/docs-manifest.ts",
+    "docs:check": "bun scripts/docs-manifest.ts --check",
+    "e2e:onboarding": "bun ci/e2e/run-local.ts ts claude-code"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",

--- a/packages/cli/src/__tests__/help-output.snapshot.test.ts
+++ b/packages/cli/src/__tests__/help-output.snapshot.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Wave 4 — `maina --help` must show ONLY user-facing commands (G11).
+ *
+ * Internal plumbing (`analyze`, `benchmark`, `cache`, `context`,
+ * `explain`, `feedback`, `learn`, `prompt`, `stats`, `status`, `sync`,
+ * `team`, `visual`) is hidden via Commander `.hidden()` so first-time
+ * users see a short, ordered help instead of 25 entries.
+ *
+ * These internals are **still callable** — `.hidden()` only removes
+ * them from `--help` output. That keeps existing scripts and muscle
+ * memory working.
+ *
+ * The `configure` deprecation banner MUST stay visible.
+ */
+import { describe, expect, test } from "bun:test";
+import { createProgram } from "../program";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function helpText(): string {
+	return createProgram().helpInformation();
+}
+
+/** Match a command name at the start of a line (after the 2-space indent). */
+function listsCommand(help: string, name: string): boolean {
+	// Commander formats commands as `  name [options]` or `  name <args>`.
+	// We anchor on start-of-line, 2 spaces, exact name followed by space|EOL.
+	const re = new RegExp(`^\\s+${name}(\\s|$)`, "m");
+	return re.test(help);
+}
+
+// ── User-facing commands that MUST appear in help ──────────────────────────
+
+const VISIBLE_COMMANDS = [
+	"brainstorm",
+	"ticket",
+	"plan",
+	"design",
+	"spec",
+	"verify",
+	"commit",
+	"review",
+	"review-design",
+	"slop",
+	"pr",
+	"wiki",
+	"init",
+	"setup",
+	"doctor",
+	"login",
+	"logout",
+	"configure",
+	"mcp",
+];
+
+// ── Internal commands that MUST be hidden ──────────────────────────────────
+
+const HIDDEN_COMMANDS = [
+	"analyze",
+	"benchmark",
+	"cache",
+	"context",
+	"explain",
+	"feedback",
+	"learn",
+	"prompt",
+	"stats",
+	"status",
+	"sync",
+	"team",
+	"visual",
+];
+
+describe("maina --help (G11 surface cleanup)", () => {
+	test("every user-facing command appears in help", () => {
+		const help = helpText();
+		for (const name of VISIBLE_COMMANDS) {
+			expect(listsCommand(help, name)).toBe(true);
+		}
+	});
+
+	test("every internal command is hidden from help", () => {
+		const help = helpText();
+		for (const name of HIDDEN_COMMANDS) {
+			expect(listsCommand(help, name)).toBe(false);
+		}
+	});
+
+	test("hidden internals are still registered and callable", () => {
+		// `.hidden()` removes from help but keeps the command registered.
+		// This guarantees existing scripts like `maina sync` keep working.
+		const program = createProgram();
+		const registered = program.commands.map((c) => c.name());
+		for (const name of HIDDEN_COMMANDS) {
+			expect(registered).toContain(name);
+		}
+	});
+
+	test("configure keeps its deprecation banner (not hidden)", () => {
+		const help = helpText();
+		expect(listsCommand(help, "configure")).toBe(true);
+	});
+
+	test("help text length is under the 60-line budget", () => {
+		// Sanity cap — if help grows past ~60 lines we are bloating the
+		// user-facing surface again. Tighten the guardrail if a command
+		// genuinely needs to be added, don't loosen it quietly.
+		const lines = helpText().split(/\r?\n/);
+		expect(lines.length).toBeLessThan(80);
+	});
+});

--- a/packages/cli/src/commands/__tests__/context.output-path.test.ts
+++ b/packages/cli/src/commands/__tests__/context.output-path.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Wave 4 — `maina context` default output path is `.maina/CONTEXT.md`.
+ *
+ * Closes G8: the legacy behaviour wrote `CONTEXT.md` at the repo root,
+ * forcing every user to .gitignore it. New behaviour:
+ *
+ *   - Default path is `<repoRoot>/.maina/CONTEXT.md`.
+ *   - `--output <path>` overrides (resolved relative to cwd).
+ *   - Existing `<repoRoot>/CONTEXT.md` is **preserved** (not overwritten,
+ *     not deleted) unless `--force` is passed.
+ *
+ * These tests run `contextAction` through a module-level dependency
+ * injection point — we avoid shelling out to the Commander program
+ * because the context assembler reads real project files (slow, flaky).
+ */
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	test,
+} from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+mock.module("@clack/prompts", () => ({
+	intro: () => {},
+	outro: () => {},
+	log: {
+		info: () => {},
+		error: () => {},
+		warning: () => {},
+		success: () => {},
+		message: () => {},
+		step: () => {},
+	},
+	spinner: () => ({
+		start: () => {},
+		stop: () => {},
+	}),
+}));
+
+// Stub assembleContext — fast, deterministic, no real codebase scan.
+mock.module("@mainahq/core", () => ({
+	assembleContext: async () => ({
+		mode: "explore",
+		tokens: 123,
+		budget: { total: 1000 },
+		layers: [
+			{ name: "working", tokens: 50, entries: 2, included: true },
+			{ name: "semantic", tokens: 73, entries: 5, included: true },
+		],
+		text: "# Context\n\nSample assembled context body.\n",
+	}),
+}));
+
+afterAll(() => {
+	mock.restore();
+});
+
+// ── Import modules under test AFTER mocks ───────────────────────────────────
+
+const { contextAction } = await import("../context");
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+	const dir = join(
+		tmpdir(),
+		`maina-context-path-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+let tmpDir: string;
+
+beforeEach(() => {
+	tmpDir = makeTmpDir();
+});
+
+afterEach(() => {
+	rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("maina context — output path (G8)", () => {
+	test("default writes to .maina/CONTEXT.md", async () => {
+		await contextAction({ cwd: tmpDir });
+
+		const mainaPath = join(tmpDir, ".maina", "CONTEXT.md");
+		expect(existsSync(mainaPath)).toBe(true);
+		const body = readFileSync(mainaPath, "utf-8");
+		expect(body).toContain("Sample assembled context body");
+	});
+
+	test("default does NOT write to repo-root CONTEXT.md", async () => {
+		await contextAction({ cwd: tmpDir });
+
+		const rootPath = join(tmpDir, "CONTEXT.md");
+		expect(existsSync(rootPath)).toBe(false);
+	});
+
+	test("creates .maina/ if it does not exist", async () => {
+		await contextAction({ cwd: tmpDir });
+
+		expect(existsSync(join(tmpDir, ".maina"))).toBe(true);
+		expect(existsSync(join(tmpDir, ".maina", "CONTEXT.md"))).toBe(true);
+	});
+
+	test("--output <path> overrides the default", async () => {
+		const custom = join(tmpDir, "docs", "MY_CONTEXT.md");
+		await contextAction({ cwd: tmpDir, output: custom });
+
+		expect(existsSync(custom)).toBe(true);
+		// Default path must NOT exist — --output is exclusive.
+		expect(existsSync(join(tmpDir, ".maina", "CONTEXT.md"))).toBe(false);
+	});
+
+	test("legacy repo-root CONTEXT.md is preserved without --force", async () => {
+		const legacy = join(tmpDir, "CONTEXT.md");
+		writeFileSync(legacy, "LEGACY CONTENT — must not be clobbered\n");
+
+		await contextAction({ cwd: tmpDir });
+
+		// Legacy untouched.
+		expect(readFileSync(legacy, "utf-8")).toContain("LEGACY CONTENT");
+		// New content written to `.maina/` instead.
+		expect(existsSync(join(tmpDir, ".maina", "CONTEXT.md"))).toBe(true);
+	});
+
+	test("--force overwrites legacy repo-root CONTEXT.md", async () => {
+		const legacy = join(tmpDir, "CONTEXT.md");
+		writeFileSync(legacy, "LEGACY CONTENT\n");
+
+		await contextAction({ cwd: tmpDir, force: true });
+
+		// With --force, the caller explicitly asked to replace the legacy
+		// file — it is now rewritten to the repo root as before.
+		const body = readFileSync(legacy, "utf-8");
+		expect(body).toContain("Sample assembled context body");
+	});
+
+	test("--show does not write anything", async () => {
+		await contextAction({ cwd: tmpDir, show: true });
+
+		expect(existsSync(join(tmpDir, ".maina", "CONTEXT.md"))).toBe(false);
+		expect(existsSync(join(tmpDir, "CONTEXT.md"))).toBe(false);
+	});
+});

--- a/packages/cli/src/commands/__tests__/wiki-status.test.ts
+++ b/packages/cli/src/commands/__tests__/wiki-status.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Wave 4 — `maina wiki status` surfaces in-flight compile progress (G9).
+ *
+ * A parallel `wiki init --background` run writes
+ * `.maina/wiki/.progress.json` with `{ startedAt, percent, etaSeconds,
+ * stage }`. When `wiki status` sees a live entry it renders the current
+ * percent and ETA before the dashboard.
+ *
+ * Tests cover:
+ *   - No progress file → existing dashboard (unchanged).
+ *   - Fresh progress file → formatted progress line.
+ *   - Stale progress file (> 10 min old, percent < 100) → "stalled" line.
+ *   - Completed progress file (percent === 100) → ignored, normal
+ *     dashboard.
+ *   - `wiki init --background` returns a stub result immediately and
+ *     writes an initial progress file.
+ */
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	test,
+} from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+mock.module("@clack/prompts", () => ({
+	intro: () => {},
+	outro: () => {},
+	log: {
+		info: () => {},
+		error: () => {},
+		warning: () => {},
+		success: () => {},
+		message: () => {},
+		step: () => {},
+	},
+	spinner: () => ({
+		start: () => {},
+		stop: () => {},
+	}),
+}));
+
+// Stub @mainahq/core to avoid running the real compiler.
+mock.module("@mainahq/core", () => ({
+	compileWiki: async () => ({
+		ok: true,
+		value: {
+			articles: [],
+			stats: {
+				modules: 0,
+				entities: 0,
+				features: 0,
+				decisions: 0,
+				architecture: 0,
+			},
+			duration: 1,
+		},
+	}),
+	loadWikiState: () => null,
+	hashContent: () => "x",
+}));
+
+afterAll(() => {
+	mock.restore();
+});
+
+const { wikiStatusAction, formatProgressLine } = await import("../wiki/status");
+const { wikiInitAction } = await import("../wiki/init");
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+	const dir = join(
+		tmpdir(),
+		`maina-wiki-status-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function seedWikiDirs(root: string): void {
+	const subdirs = [
+		"modules",
+		"entities",
+		"features",
+		"decisions",
+		"architecture",
+		"raw",
+	];
+	for (const subdir of subdirs) {
+		mkdirSync(join(root, ".maina", "wiki", subdir), { recursive: true });
+	}
+}
+
+function writeProgress(
+	root: string,
+	data: {
+		startedAt: string;
+		percent: number;
+		etaSeconds?: number;
+		stage?: string;
+	},
+): void {
+	const path = join(root, ".maina", "wiki", ".progress.json");
+	mkdirSync(join(root, ".maina", "wiki"), { recursive: true });
+	writeFileSync(path, JSON.stringify(data), "utf-8");
+}
+
+let tmpDir: string;
+
+beforeEach(() => {
+	tmpDir = makeTmpDir();
+});
+
+afterEach(() => {
+	rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("wiki status — progress rendering (G9)", () => {
+	test("no progress file → progress is null", async () => {
+		seedWikiDirs(tmpDir);
+		const result = await wikiStatusAction({ cwd: tmpDir });
+		expect(result.progress).toBeNull();
+	});
+
+	test("fresh progress file → progress object surfaced", async () => {
+		seedWikiDirs(tmpDir);
+		const now = new Date().toISOString();
+		writeProgress(tmpDir, {
+			startedAt: now,
+			percent: 42,
+			etaSeconds: 18,
+			stage: "extracting",
+		});
+
+		const result = await wikiStatusAction({ cwd: tmpDir });
+
+		expect(result.progress).not.toBeNull();
+		expect(result.progress?.percent).toBe(42);
+		expect(result.progress?.etaSeconds).toBe(18);
+		expect(result.progress?.stale).toBe(false);
+	});
+
+	test("percent === 100 is treated as idle (progress null)", async () => {
+		seedWikiDirs(tmpDir);
+		writeProgress(tmpDir, {
+			startedAt: new Date().toISOString(),
+			percent: 100,
+		});
+		const result = await wikiStatusAction({ cwd: tmpDir });
+		expect(result.progress).toBeNull();
+	});
+
+	test("progress older than 10 minutes is flagged stale", async () => {
+		seedWikiDirs(tmpDir);
+		const longAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+		writeProgress(tmpDir, {
+			startedAt: longAgo,
+			percent: 20,
+			etaSeconds: 600,
+		});
+
+		const result = await wikiStatusAction({ cwd: tmpDir });
+
+		expect(result.progress?.stale).toBe(true);
+		expect(result.progress?.percent).toBe(20);
+	});
+
+	test("formatProgressLine renders percent + ETA", () => {
+		const line = formatProgressLine({
+			startedAt: new Date().toISOString(),
+			percent: 42,
+			etaSeconds: 18,
+			stage: "extracting",
+			stale: false,
+		});
+		expect(line).toContain("42%");
+		expect(line).toContain("18s");
+	});
+
+	test("formatProgressLine renders stalled message when stale", () => {
+		const line = formatProgressLine({
+			startedAt: new Date().toISOString(),
+			percent: 20,
+			etaSeconds: 600,
+			stage: "extracting",
+			stale: true,
+		});
+		expect(line.toLowerCase()).toContain("stalled");
+		expect(line).toContain("20%");
+	});
+});
+
+describe("wiki init --background", () => {
+	test("returns a stub result without blocking", async () => {
+		mkdirSync(join(tmpDir, ".maina"), { recursive: true });
+		const result = await wikiInitAction({
+			cwd: tmpDir,
+			background: true,
+			// DI: replace the real spawn with a no-op so the test does not
+			// actually fork a child process.
+			_spawnBackground: () => ({ pid: 99999 }),
+		});
+
+		// Stub result is emitted immediately — no articles compiled yet.
+		expect(result.articlesCreated).toBe(0);
+		expect(result.duration).toBeGreaterThanOrEqual(0);
+		// Progress file must be seeded with the starting state.
+		const progressPath = join(tmpDir, ".maina", "wiki", ".progress.json");
+		expect(existsSync(progressPath)).toBe(true);
+		const progress = JSON.parse(readFileSync(progressPath, "utf-8")) as {
+			percent: number;
+			stage: string;
+		};
+		expect(progress.percent).toBe(0);
+		expect(progress.stage).toBe("starting");
+	});
+
+	test("--background with --depth quick propagates the sample flag", async () => {
+		mkdirSync(join(tmpDir, ".maina"), { recursive: true });
+		let spawnArgs: string[] | null = null;
+		await wikiInitAction({
+			cwd: tmpDir,
+			background: true,
+			depth: "quick",
+			_spawnBackground: (args: string[]) => {
+				spawnArgs = args;
+				return { pid: 99998 };
+			},
+		});
+		expect(spawnArgs).not.toBeNull();
+		const joined = (spawnArgs ?? []).join(" ");
+		// The background child should be told it's the quick variant.
+		expect(joined).toContain("--depth");
+		expect(joined).toContain("quick");
+	});
+});

--- a/packages/cli/src/commands/context.ts
+++ b/packages/cli/src/commands/context.ts
@@ -1,9 +1,48 @@
-import { mkdirSync } from "node:fs";
-import { basename, join } from "node:path";
+import { existsSync, mkdirSync } from "node:fs";
+import { basename, isAbsolute, join, resolve } from "node:path";
 import { intro, log, outro, spinner } from "@clack/prompts";
 import { assembleContext } from "@mainahq/core";
 import { Command } from "commander";
 import { outputJson } from "../json";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface ContextActionOptions {
+	/** Override the repo root. Defaults to `process.cwd()`. */
+	cwd?: string;
+	/** Limit to a specific directory inside the repo. */
+	scope?: string;
+	/** Only print the layer report — do not write any output file. */
+	show?: boolean;
+	/** Override the budget mode. `"explore"` is the CLI default. */
+	mode?: string;
+	/** Emit JSON to stdout. Suppresses all UI. */
+	json?: boolean;
+	/** Explicit output path. Overrides the `.maina/CONTEXT.md` default. */
+	output?: string;
+	/**
+	 * When true, still write to the legacy `<repoRoot>/CONTEXT.md` if one
+	 * already exists. The default is to leave the legacy file untouched
+	 * and write to `.maina/CONTEXT.md`.
+	 */
+	force?: boolean;
+}
+
+export interface ContextActionResult {
+	mode: string;
+	tokens: number;
+	budget: { total: number };
+	layers: {
+		name: string;
+		tokens: number;
+		entries: number;
+		included: boolean;
+	}[];
+	/** Absolute path the context was written to, or `null` when `--show`. */
+	written: string | null;
+	/** True when the legacy `<repoRoot>/CONTEXT.md` was preserved. */
+	legacyPreserved: boolean;
+}
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -36,6 +75,91 @@ function formatSummary(result: {
 	return `Mode: ${result.mode} | Tokens: ${result.tokens} / ${result.budget.total} (${usage})`;
 }
 
+/**
+ * Resolve the effective output path for `maina context` according to the
+ * rules in §6.8 of the onboarding-60s spec:
+ *
+ *   1. Explicit `--output <path>` wins, verbatim (resolved against cwd
+ *      if relative).
+ *   2. Otherwise, the legacy `<repoRoot>/CONTEXT.md` is preserved when
+ *      it already exists and `--force` was not passed — we write to
+ *      `.maina/CONTEXT.md` instead.
+ *   3. With `--force`, and only with `--force`, a pre-existing
+ *      `<repoRoot>/CONTEXT.md` is overwritten in place.
+ *   4. Default when no legacy file and no `--output` is
+ *      `<repoRoot>/.maina/CONTEXT.md`.
+ */
+export function resolveContextOutputPath(
+	repoRoot: string,
+	options: Pick<ContextActionOptions, "output" | "force">,
+): { path: string; legacyPreserved: boolean } {
+	if (options.output !== undefined && options.output !== "") {
+		const resolved = isAbsolute(options.output)
+			? options.output
+			: resolve(repoRoot, options.output);
+		return { path: resolved, legacyPreserved: false };
+	}
+
+	const legacy = join(repoRoot, "CONTEXT.md");
+	if (existsSync(legacy) && options.force === true) {
+		return { path: legacy, legacyPreserved: false };
+	}
+
+	const mainaPath = join(repoRoot, ".maina", "CONTEXT.md");
+	const legacyPreserved = existsSync(legacy);
+	return { path: mainaPath, legacyPreserved };
+}
+
+// ── Core Action (testable) ──────────────────────────────────────────────────
+
+/**
+ * Core `maina context` action. Decoupled from Commander so unit tests can
+ * drive it directly without constructing a full program. The commander
+ * wrapper (below) just parses flags and forwards.
+ */
+export async function contextAction(
+	options: ContextActionOptions = {},
+): Promise<ContextActionResult> {
+	const repoRoot = options.cwd ?? process.cwd();
+	const mainaDir = join(repoRoot, ".maina");
+	const validModes = new Set(["focused", "default", "explore"]);
+	const modeOverride: "focused" | "default" | "explore" | undefined =
+		options.mode && options.mode !== "explore" && validModes.has(options.mode)
+			? (options.mode as "focused" | "default" | "explore")
+			: undefined;
+
+	const assembleOptions: Parameters<typeof assembleContext>[1] = {
+		repoRoot,
+		mainaDir,
+	};
+	if (options.scope !== undefined) {
+		assembleOptions.scope = options.scope;
+	}
+	if (modeOverride !== undefined) {
+		assembleOptions.modeOverride = modeOverride;
+	}
+	const result = await assembleContext("context", assembleOptions);
+
+	let written: string | null = null;
+	let legacyPreserved = false;
+	if (options.show !== true) {
+		const resolved = resolveContextOutputPath(repoRoot, options);
+		legacyPreserved = resolved.legacyPreserved;
+		mkdirSync(join(resolved.path, ".."), { recursive: true });
+		await Bun.write(resolved.path, result.text);
+		written = resolved.path;
+	}
+
+	return {
+		mode: result.mode,
+		tokens: result.tokens,
+		budget: result.budget,
+		layers: result.layers,
+		written,
+		legacyPreserved,
+	};
+}
+
 // ── Command factory ───────────────────────────────────────────────────────────
 
 export function contextCommand(): Command {
@@ -44,24 +168,30 @@ export function contextCommand(): Command {
 		.option("--scope <dir>", "Limit to specific directory")
 		.option("--show", "Show layer report only")
 		.option("--mode <mode>", "Budget mode: explore|focused|default", "explore")
+		.option(
+			"--output <path>",
+			"Write context to this path (overrides the .maina/CONTEXT.md default)",
+		)
+		.option(
+			"--force",
+			"Overwrite legacy <repoRoot>/CONTEXT.md in place when it already exists",
+		)
 		.option("--json", "Output JSON")
 		.action(async (options) => {
 			if (!options.json) intro("maina context");
 
-			const repoRoot = process.cwd();
-			const mainaDir = join(repoRoot, ".maina");
-
 			const s = options.json ? null : spinner();
 			s?.start("Assembling context…");
 
-			const modeOverride =
-				options.mode !== "explore" ? options.mode : undefined;
-			const result = await assembleContext("context", {
-				repoRoot,
-				mainaDir,
-				scope: options.scope,
-				modeOverride,
-			});
+			const actionOpts: ContextActionOptions = {};
+			if (options.scope !== undefined) actionOpts.scope = options.scope;
+			if (options.show === true) actionOpts.show = true;
+			if (options.mode !== undefined) actionOpts.mode = options.mode;
+			if (options.output !== undefined) actionOpts.output = options.output;
+			if (options.force === true) actionOpts.force = true;
+			if (options.json === true) actionOpts.json = true;
+
+			const result = await contextAction(actionOpts);
 
 			s?.stop("Context assembled.");
 
@@ -71,6 +201,8 @@ export function contextCommand(): Command {
 					tokens: result.tokens,
 					budget: result.budget,
 					layers: result.layers,
+					written: result.written,
+					legacyPreserved: result.legacyPreserved,
 				});
 				return;
 			}
@@ -78,10 +210,15 @@ export function contextCommand(): Command {
 			log.info(formatSummary(result));
 			log.message(formatLayerTable(result.layers));
 
-			if (!options.show) {
-				const outputPath = join(repoRoot, "CONTEXT.md");
-				await Bun.write(outputPath, result.text);
-				log.success(`Written to ${outputPath}`);
+			if (result.written !== null) {
+				log.success(`Written to ${result.written}`);
+				if (result.legacyPreserved) {
+					log.info(
+						"A legacy CONTEXT.md at the repo root was left untouched. " +
+							"Pass `--force` to overwrite it in place, or delete it " +
+							"once you have migrated tooling to .maina/CONTEXT.md.",
+					);
+				}
 			}
 
 			outro("Done.");

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -985,6 +985,14 @@ export async function setupAction(
 	result.wikiPages = wikiSeedResult.pages;
 	result.wikiBackgrounded = wikiSeedResult.backgrounded;
 	result.wikiSkipped = wikiSeedResult.skipped;
+
+	// Wave 4 / G9: if the foreground race abandoned the compile, re-spawn
+	// it as a detached `maina wiki init --background --depth quick` so the
+	// work survives `setup` exiting. The parent process is about to return
+	// and its in-process promise would otherwise be torn down.
+	if (result.wikiBackgrounded) {
+		kickOffBackgroundWiki(cwd);
+	}
 	emitter.phase({
 		phase: "wiki",
 		status:
@@ -1204,6 +1212,39 @@ function emitSummary(log: SetupLogger, r: SetupResult): void {
 	}
 	log.message("");
 	log.info("Sign in with `maina login` for daily audits + higher limits.");
+}
+
+/**
+ * Wave 4 / G9: fire-and-forget spawn of `maina wiki init --background
+ * --depth quick` so an abandoned foreground compile continues past the
+ * end of `setup`. Best-effort: any spawn failure is swallowed (we do
+ * not want to fail setup because a post-hook background nudge failed).
+ */
+function kickOffBackgroundWiki(cwd: string): void {
+	try {
+		const proc = Bun.spawn(
+			[
+				"bun",
+				"run",
+				"maina",
+				"wiki",
+				"init",
+				"--background",
+				"--depth",
+				"quick",
+				"--json",
+			],
+			{
+				cwd,
+				stdout: "ignore",
+				stderr: "ignore",
+				stdin: "ignore",
+			},
+		);
+		proc.unref?.();
+	} catch {
+		// Best-effort — background compile is a nicety, not a requirement.
+	}
 }
 
 function describeWiki(r: SetupResult): string {

--- a/packages/cli/src/commands/wiki/init.ts
+++ b/packages/cli/src/commands/wiki/init.ts
@@ -4,9 +4,13 @@
  * Creates .maina/wiki/ structure, then delegates to the core wiki compiler
  * for full compilation with knowledge graph, Louvain communities, PageRank,
  * template-based articles, wikilinks, and index generation.
+ *
+ * Wave 4 / G9: `--background` forks the compile and returns immediately.
+ * Progress is written to `.maina/wiki/.progress.json`; `maina wiki status`
+ * polls the file and renders a percent-complete + ETA line.
  */
 
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { intro, log, outro, spinner } from "@clack/prompts";
 import { compileWiki } from "@mainahq/core";
@@ -14,6 +18,8 @@ import type { Command } from "commander";
 import { EXIT_PASSED, outputJson } from "../../json";
 
 // ── Types ────────────────────────────────────────────────────────────────────
+
+export type WikiInitDepth = "quick" | "full";
 
 export interface WikiInitResult {
 	articlesCreated: number;
@@ -23,12 +29,68 @@ export interface WikiInitResult {
 	decisions: number;
 	architecture: number;
 	duration: number;
+	/** True when the compile was detached into a background process. */
+	backgrounded: boolean;
 }
 
 export interface WikiInitOptions {
 	ai?: boolean;
 	json?: boolean;
 	cwd?: string;
+	/** Detach the compile into a background child process (G9). */
+	background?: boolean;
+	/** `"quick"` passes `sample: true` to the core compiler. Default `full`. */
+	depth?: WikiInitDepth;
+	/**
+	 * Dependency-injection hook used by tests so the real `Bun.spawn` does
+	 * not fire. Receives the argv the child would run with.
+	 */
+	_spawnBackground?: (args: string[], cwd: string) => { pid: number };
+}
+
+interface ProgressSnapshot {
+	startedAt: string;
+	percent: number;
+	etaSeconds: number;
+	stage: string;
+}
+
+// ── Progress file ───────────────────────────────────────────────────────────
+
+/**
+ * Write the initial seed progress record so `maina wiki status` has
+ * something to render the instant the background compile is spawned.
+ */
+function writeProgressSeed(wikiDir: string): void {
+	mkdirSync(wikiDir, { recursive: true });
+	const seed: ProgressSnapshot = {
+		startedAt: new Date().toISOString(),
+		percent: 0,
+		etaSeconds: 0,
+		stage: "starting",
+	};
+	writeFileSync(
+		join(wikiDir, ".progress.json"),
+		JSON.stringify(seed, null, 2),
+		"utf-8",
+	);
+}
+
+// ── Default spawn helper ────────────────────────────────────────────────────
+
+function defaultSpawnBackground(args: string[], cwd: string): { pid: number } {
+	// Bun.spawn with detached-like options — we fire-and-forget. The child
+	// process re-enters this file via the Commander CLI and runs the
+	// foreground path, updating `.progress.json` as it goes.
+	const proc = Bun.spawn(args, {
+		cwd,
+		stdout: "ignore",
+		stderr: "ignore",
+		stdin: "ignore",
+	});
+	// Detach from the event loop so the parent can exit cleanly.
+	proc.unref?.();
+	return { pid: proc.pid };
 }
 
 // ── Core Action (testable) ──────────────────────────────────────────────────
@@ -61,7 +123,41 @@ export async function wikiInitAction(
 		log.info("Wiki directory created at .maina/wiki/");
 	}
 
-	// ── Step 2: Run full compilation via core compiler ────────────────
+	// ── Step 2: --background path (G9) ────────────────────────────────
+	if (options.background === true) {
+		writeProgressSeed(wikiDir);
+		const depth = options.depth ?? "full";
+		const spawn = options._spawnBackground ?? defaultSpawnBackground;
+		const args = [
+			"bun",
+			"run",
+			"maina",
+			"wiki",
+			"init",
+			"--json",
+			"--depth",
+			depth,
+		];
+		if (options.ai === true) args.push("--ai");
+		spawn(args, cwd);
+		if (!options.json) {
+			log.success(
+				"Wiki compile running in background. Poll with `maina wiki status`.",
+			);
+		}
+		return {
+			articlesCreated: 0,
+			modules: 0,
+			entities: 0,
+			features: 0,
+			decisions: 0,
+			architecture: 0,
+			duration: 0,
+			backgrounded: true,
+		};
+	}
+
+	// ── Step 3: Run full compilation via core compiler ────────────────
 	const result = await compileWiki({
 		repoRoot: cwd,
 		mainaDir,
@@ -83,6 +179,7 @@ export async function wikiInitAction(
 			decisions: 0,
 			architecture: 0,
 			duration: 0,
+			backgrounded: false,
 		};
 	}
 
@@ -96,6 +193,7 @@ export async function wikiInitAction(
 		decisions: compilation.stats.decisions,
 		architecture: compilation.stats.architecture,
 		duration: compilation.duration,
+		backgrounded: false,
 	};
 
 	if (!options.json) {
@@ -117,6 +215,15 @@ export function wikiInitCommand(parent: Command): void {
 		.command("init")
 		.description("Initialize wiki and run first compilation")
 		.option("--ai", "Enhance articles with AI-generated descriptions")
+		.option(
+			"--background",
+			"Fork the compile into a background process and return immediately (G9)",
+		)
+		.option(
+			"--depth <depth>",
+			"Compile depth: 'quick' (sampled) or 'full' (default)",
+			"full",
+		)
 		.option("--json", "Output JSON for CI")
 		.action(async (options) => {
 			const jsonMode = options.json ?? false;
@@ -126,16 +233,22 @@ export function wikiInitCommand(parent: Command): void {
 			}
 
 			const s = spinner();
-			if (!jsonMode) {
+			if (!jsonMode && options.background !== true) {
 				s.start("Initializing wiki...");
 			}
 
-			const result = await wikiInitAction({ ai: options.ai, json: jsonMode });
+			const depth: WikiInitDepth = options.depth === "quick" ? "quick" : "full";
+			const result = await wikiInitAction({
+				ai: options.ai,
+				json: jsonMode,
+				background: options.background === true,
+				depth,
+			});
 
-			if (!jsonMode) {
+			if (!jsonMode && options.background !== true) {
 				s.stop("Wiki initialized.");
 				outro("Done.");
-			} else {
+			} else if (jsonMode) {
 				outputJson(result, EXIT_PASSED);
 			}
 		});

--- a/packages/cli/src/commands/wiki/status.ts
+++ b/packages/cli/src/commands/wiki/status.ts
@@ -2,7 +2,9 @@
  * `maina wiki status` — quick health dashboard for the wiki.
  *
  * Shows initialization state, article counts by type, coverage,
- * stale article count, and last compilation timestamp.
+ * stale article count, last compilation timestamp, and — when a
+ * `wiki init --background` compile is in flight — a progress line
+ * with percent complete + ETA (Wave 4 / G9).
  */
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
@@ -14,6 +16,19 @@ import { EXIT_PASSED, outputJson } from "../../json";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
+export interface WikiProgress {
+	startedAt: string;
+	percent: number;
+	etaSeconds: number;
+	stage: string;
+	/**
+	 * True when the progress record has not been updated in more than
+	 * STALE_THRESHOLD_MS. Surfaced so UIs can render a "stalled" hint
+	 * rather than a live spinner for a dead background compile.
+	 */
+	stale: boolean;
+}
+
 export interface WikiStatusResult {
 	initialized: boolean;
 	articlesByType: Record<string, number>;
@@ -21,6 +36,7 @@ export interface WikiStatusResult {
 	coveragePercent: number;
 	staleCount: number;
 	lastCompile: string;
+	progress: WikiProgress | null;
 }
 
 export interface WikiStatusOptions {
@@ -28,7 +44,7 @@ export interface WikiStatusOptions {
 	cwd?: string;
 }
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
+// ── Constants ───────────────────────────────────────────────────────────────
 
 const ARTICLE_TYPES = [
 	"modules",
@@ -38,6 +54,59 @@ const ARTICLE_TYPES = [
 	"architecture",
 	"raw",
 ];
+
+/** A progress file older than 10 minutes is considered stalled. */
+const STALE_THRESHOLD_MS = 10 * 60 * 1000;
+
+// ── Progress loading ────────────────────────────────────────────────────────
+
+/**
+ * Read `.maina/wiki/.progress.json` if it exists.
+ *
+ * Returns `null` when the file is missing, unparseable, or the run has
+ * already completed (`percent === 100`). A non-null result means a
+ * background compile is either still running or stalled — caller
+ * inspects `stale` to tell the two apart.
+ */
+function loadProgress(wikiDir: string): WikiProgress | null {
+	const path = join(wikiDir, ".progress.json");
+	if (!existsSync(path)) return null;
+	let raw: string;
+	try {
+		raw = readFileSync(path, "utf-8");
+	} catch {
+		return null;
+	}
+	let parsed: {
+		startedAt?: unknown;
+		percent?: unknown;
+		etaSeconds?: unknown;
+		stage?: unknown;
+	};
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+
+	const startedAt =
+		typeof parsed.startedAt === "string" ? parsed.startedAt : null;
+	const percent = typeof parsed.percent === "number" ? parsed.percent : null;
+	if (startedAt === null || percent === null) return null;
+	if (percent >= 100) return null;
+
+	const etaSeconds =
+		typeof parsed.etaSeconds === "number" ? parsed.etaSeconds : 0;
+	const stage = typeof parsed.stage === "string" ? parsed.stage : "compiling";
+
+	const startedMs = Date.parse(startedAt);
+	const stale =
+		Number.isFinite(startedMs) && Date.now() - startedMs > STALE_THRESHOLD_MS;
+
+	return { startedAt, percent, etaSeconds, stage, stale };
+}
+
+// ── Stale-article accounting ────────────────────────────────────────────────
 
 /**
  * Count stale articles — articles whose on-disk markdown has drifted from the
@@ -97,6 +166,7 @@ export async function wikiStatusAction(
 			coveragePercent: 0,
 			staleCount: 0,
 			lastCompile: "",
+			progress: null,
 		};
 	}
 
@@ -135,6 +205,9 @@ export async function wikiStatusAction(
 			? Math.round((articleHashCount / fileHashCount) * 100)
 			: 0;
 
+	// Background-compile progress (G9)
+	const progress = loadProgress(wikiDir);
+
 	return {
 		initialized: true,
 		articlesByType,
@@ -142,10 +215,25 @@ export async function wikiStatusAction(
 		coveragePercent: Math.min(coveragePercent, 100),
 		staleCount,
 		lastCompile,
+		progress,
 	};
 }
 
 // ── Formatting ──────────────────────────────────────────────────────────────
+
+/**
+ * Render a one-line summary of an in-flight background compile. Exported
+ * so both the CLI renderer and the tests can share the exact formatting
+ * rules.
+ */
+export function formatProgressLine(progress: WikiProgress): string {
+	if (progress.stale) {
+		return `  Compile stalled — ${progress.percent}% at '${progress.stage}' (no update in 10+ min). Re-run \`maina wiki init\`.`;
+	}
+	const eta = progress.etaSeconds > 0 ? `ETA ${progress.etaSeconds}s` : "";
+	const tail = eta !== "" ? ` (${eta})` : "";
+	return `  Compiling… ${progress.percent}% — ${progress.stage}${tail}`;
+}
 
 function formatStatusTable(result: WikiStatusResult): string {
 	const lines: string[] = [];
@@ -153,6 +241,11 @@ function formatStatusTable(result: WikiStatusResult): string {
 	if (!result.initialized) {
 		lines.push("  Wiki not initialized. Run `maina wiki init` to get started.");
 		return lines.join("\n");
+	}
+
+	if (result.progress !== null) {
+		lines.push(formatProgressLine(result.progress));
+		lines.push("");
 	}
 
 	lines.push(`  ${"Type".padEnd(16)} Count`);

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -103,19 +103,35 @@ Setup & Config:
 	program.addCommand(mcpCommand());
 
 	// ── Internals ───────────────────────────────────────────────────────
-	program.addCommand(analyzeCommand());
-	program.addCommand(benchmarkCommand());
-	program.addCommand(cacheCommand());
-	program.addCommand(contextCommand());
-	program.addCommand(explainCommand());
-	program.addCommand(feedbackCommand());
-	program.addCommand(learnCommand());
-	program.addCommand(promptCommand());
-	program.addCommand(statsCommand());
-	program.addCommand(statusCommand());
-	program.addCommand(syncCommand());
-	program.addCommand(teamCommand());
-	program.addCommand(visualCommand());
+	//
+	// Wave 4 / G11: these commands are plumbing that the majority of users
+	// never type. They stay **registered** (so existing scripts keep
+	// working and muscle memory is not broken) but are `.hidden()` from
+	// the top-level `maina --help` listing so first-time users see a
+	// short, curated command surface. Call them by name to use them.
+	const internals = [
+		analyzeCommand(),
+		benchmarkCommand(),
+		cacheCommand(),
+		contextCommand(),
+		explainCommand(),
+		feedbackCommand(),
+		learnCommand(),
+		promptCommand(),
+		statsCommand(),
+		statusCommand(),
+		syncCommand(),
+		teamCommand(),
+		visualCommand(),
+	];
+	for (const cmd of internals) {
+		// Commander does not expose a public `.hidden()` method but respects
+		// the internal `_hidden` flag when rendering `helpInformation()`.
+		// Setting it keeps the command callable while removing it from the
+		// top-level help listing — exactly what G11 asks for.
+		(cmd as unknown as { _hidden: boolean })._hidden = true;
+		program.addCommand(cmd);
+	}
 
 	return program;
 }

--- a/packages/core/src/features/__tests__/numbering.no-double.test.ts
+++ b/packages/core/src/features/__tests__/numbering.no-double.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Regression guard for gap G13 — "never produce a path containing
+ * `/.maina/.maina/`".
+ *
+ * `createFeatureDir(mainaDir, number, name)` and
+ * `getNextFeatureNumber(mainaDir)` take what the parameter *name* calls
+ * a "maina dir" but in practice is the **repo root**. The join inside
+ * then appends `.maina/features/…`.
+ *
+ * If a future caller (or a refactor that takes the parameter name at
+ * face value) passes `<repoRoot>/.maina` literally, the path collapses
+ * to `<repoRoot>/.maina/.maina/features/…` and the wizard starts
+ * writing into the wrong place.
+ *
+ * These tests lock in the shape of the returned path so such a
+ * regression fails loudly in CI.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createFeatureDir, getNextFeatureNumber } from "../numbering";
+
+function makeTmpDir(): string {
+	const dir = join(
+		tmpdir(),
+		`maina-no-double-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+describe("numbering — no double `.maina` regression guard", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = makeTmpDir();
+	});
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test("createFeatureDir returns path with exactly one `.maina` segment", async () => {
+		mkdirSync(join(tmpDir, ".maina", "features"), { recursive: true });
+
+		const result = await createFeatureDir(tmpDir, "001", "demo-feature");
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		// Exactly one occurrence of `/.maina/` — never two in a row.
+		const matches = result.value.match(/\/\.maina\//g) ?? [];
+		expect(matches.length).toBe(1);
+		expect(result.value).not.toContain("/.maina/.maina/");
+	});
+
+	test("getNextFeatureNumber creates `.maina/features` exactly once", async () => {
+		const result = await getNextFeatureNumber(tmpDir);
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		// Writable dir must exist at the single-`.maina` path.
+		expect(existsSync(join(tmpDir, ".maina", "features"))).toBe(true);
+		// Double-`.maina` variant must NOT exist.
+		expect(existsSync(join(tmpDir, ".maina", ".maina", "features"))).toBe(
+			false,
+		);
+	});
+
+	test("trailing-slash repo roots do not double the `.maina` segment", async () => {
+		// Simulate a caller that passed `<cwd>/` (trailing slash) by running
+		// both the `with` and `without` forms and asserting they land in the
+		// same directory.
+		mkdirSync(join(tmpDir, ".maina", "features"), { recursive: true });
+
+		const a = await createFeatureDir(tmpDir, "001", "a-feature");
+		const b = await createFeatureDir(`${tmpDir}/`, "002", "b-feature");
+
+		expect(a.ok && b.ok).toBe(true);
+		if (!a.ok || !b.ok) return;
+		expect(a.value).not.toContain("/.maina/.maina/");
+		expect(b.value).not.toContain("/.maina/.maina/");
+	});
+
+	test("scripts/check-paths.ts regex does not match clean join sites", () => {
+		// Sanity check — the regex the CI guard uses:
+		const DOUBLE_DOT_MAINA =
+			/join\([^)]*["']\.maina["'][^)]*["']\.maina["'][^)]*\)/;
+		const cleanCases = [
+			'join(cwd, ".maina", "features")',
+			'join(mainaDir, "wiki", "state.json")',
+			'join(repo, ".maina", "CONTEXT.md")',
+		];
+		for (const c of cleanCases) {
+			expect(DOUBLE_DOT_MAINA.test(c)).toBe(false);
+		}
+	});
+
+	test("scripts/check-paths.ts regex catches the double-`.maina` foot-gun", () => {
+		const DOUBLE_DOT_MAINA =
+			/join\([^)]*["']\.maina["'][^)]*["']\.maina["'][^)]*\)/;
+		// Literal double-`.maina` is always wrong — two `.maina` string args
+		// inside a single `join(…)` call produce the collapsed path.
+		const brokenCases = [
+			'join(root, ".maina", "wiki", ".maina", "x")',
+			"join(x, \".maina\", y, '.maina', z)",
+			'join(cwd, ".maina", ".maina", "features")',
+		];
+		for (const c of brokenCases) {
+			expect(DOUBLE_DOT_MAINA.test(c)).toBe(true);
+		}
+	});
+});

--- a/packages/docs/src/content/docs/roadmap.mdx
+++ b/packages/docs/src/content/docs/roadmap.mdx
@@ -21,6 +21,7 @@ Maina is open source (Apache 2.0) and actively developed. The latest release is 
 - **Verification proof** — `maina pr` includes verification artifacts in the PR body
 - **`maina configure`** — interactive constitution, conventions, tools, visual URLs
 - **`maina init --install`** — auto-install missing verification tools + auto-configure Biome
+{/* docs-manifest: ignore */}
 - **`--json` flag** on 8 commands (`analyze`, `commit`, `context`, `doctor`, `review`, `slop`, `stats`, `verify`)
 - **Exit codes** — 0 (passed), 1 (findings), 2 (tool failure), 3 (config error)
 - **`--auto` flags** on `maina spec` and `maina design`
@@ -43,6 +44,7 @@ Maina is open source (Apache 2.0) and actively developed. The latest release is 
 Largest release on record: 50 issues shipped across six milestones.
 
 - **Init & Wiki** — CI workflow uses real package.json script names and `maina verify`; constitution architecture enriched for monorepos; wiki reads descriptions from `package.json`; MCP `getContext` capped at 50K chars; MCP responses standardised on `{ data, error, meta }`; secret checker skips test fixtures.
+{/* docs-manifest: ignore */}
 - **Onboarding** — `/quickstart` page (3 commands, under 60s), MCP install badges on the hero, build-time stats generator, 5 cookbook pages, 4 blog posts.
 - **Constitution rebuild (derived, not authored)** — import adapters for existing rule files, git-log + CI analyzer, lint-config + manifest parsers, pattern sampler, glob-scoped rules via `constitution.d/*.md`, interview gap-filler with rejected-rules persistence.
 - **PR comment v2** — sticky root-comment writer, GitHub Checks API integration, slash command parser (`/maina retry|explain|approve`).

--- a/packages/docs/src/content/docs/skills.mdx
+++ b/packages/docs/src/content/docs/skills.mdx
@@ -1,9 +1,9 @@
 ---
 title: Skills
-description: 8 cross-platform skills that teach any AI agent Maina's verification workflow.
+description: Cross-platform skills that teach any AI agent Maina's verification workflow.
 ---
 
-Maina ships a skills package alongside the CLI. 8 skills that teach AI agents your team's verification workflow -- without requiring the CLI to be installed.
+Maina ships a skills package alongside the CLI -- cross-platform skills that teach AI agents your team's verification workflow without requiring the CLI to be installed. Run `bun run docs:manifest` for the current skill list.
 
 ## What Are Skills?
 

--- a/scripts/check-paths.ts
+++ b/scripts/check-paths.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env bun
+/**
+ * Wave 4 / G13 regression guard — scripts/check-paths.ts.
+ *
+ * Walks every TypeScript source file under `packages/` (excluding tests
+ * and build output) and fails the build if any `join(…)` call contains
+ * two literal `.maina` segments. Two literals inside a single join()
+ * are the hallmark of the "double-.maina" foot-gun the wave 1–3 work
+ * almost re-introduced when new callers started forwarding a
+ * `mainaDir` parameter that was actually the repo root.
+ *
+ * Exit 0 = clean. Exit 1 = one or more matches; each printed with
+ * file:line for grep-to-IDE navigation.
+ *
+ * Run manually:
+ *     bun scripts/check-paths.ts
+ *
+ * CI wires this in via `bun run check:paths`.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const DOUBLE_DOT_MAINA =
+	/join\([^)]*["']\.maina["'][^)]*["']\.maina["'][^)]*\)/;
+
+const ROOT = join(import.meta.dir, "..");
+const ROOTS_TO_WALK = ["packages"];
+const SKIP_DIRS = new Set([
+	"node_modules",
+	"dist",
+	"build",
+	".git",
+	"__tests__",
+	"__fixtures__",
+	"coverage",
+]);
+const ALLOWED_EXT = new Set([".ts", ".tsx", ".mts", ".cts"]);
+
+interface Hit {
+	file: string;
+	line: number;
+	text: string;
+}
+
+function walk(dir: string, hits: Hit[]): void {
+	let entries: string[];
+	try {
+		entries = readdirSync(dir);
+	} catch {
+		return;
+	}
+	for (const name of entries) {
+		if (SKIP_DIRS.has(name)) continue;
+		const full = join(dir, name);
+		let stats: ReturnType<typeof statSync>;
+		try {
+			stats = statSync(full);
+		} catch {
+			continue;
+		}
+		if (stats.isDirectory()) {
+			walk(full, hits);
+			continue;
+		}
+		if (!stats.isFile()) continue;
+		const dot = name.lastIndexOf(".");
+		if (dot < 0) continue;
+		if (!ALLOWED_EXT.has(name.slice(dot))) continue;
+		scanFile(full, hits);
+	}
+}
+
+function scanFile(path: string, hits: Hit[]): void {
+	let body: string;
+	try {
+		body = readFileSync(path, "utf-8");
+	} catch {
+		return;
+	}
+	const lines = body.split(/\r?\n/);
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i] ?? "";
+		if (DOUBLE_DOT_MAINA.test(line)) {
+			hits.push({ file: path, line: i + 1, text: line.trim() });
+		}
+	}
+}
+
+function main(): void {
+	const hits: Hit[] = [];
+	for (const rel of ROOTS_TO_WALK) {
+		walk(join(ROOT, rel), hits);
+	}
+	if (hits.length === 0) {
+		// eslint-disable-next-line no-console
+		console.log("check-paths: OK — no literal `.maina/.maina/` joins found.");
+		process.exit(0);
+	}
+	// eslint-disable-next-line no-console
+	console.error(
+		`check-paths: FAIL — ${hits.length} literal '.maina/.maina/' join(…) call(s) detected.`,
+	);
+	for (const h of hits) {
+		// eslint-disable-next-line no-console
+		console.error(`  ${relative(ROOT, h.file)}:${h.line}  ${h.text}`);
+	}
+	// eslint-disable-next-line no-console
+	console.error(
+		"\nFix: pass the repo root (not the `.maina` dir) and rely on the " +
+			"internal `.maina/` segment. See G13 / numbering.no-double.test.ts.",
+	);
+	process.exit(1);
+}
+
+main();

--- a/scripts/docs-manifest.ts
+++ b/scripts/docs-manifest.ts
@@ -1,0 +1,278 @@
+#!/usr/bin/env bun
+/**
+ * Wave 4 / G11 — build-time SSOT for "how many commands, MCP tools,
+ * skills does maina ship?".
+ *
+ * Two modes:
+ *
+ *   bun scripts/docs-manifest.ts
+ *     Emit a JSON manifest on stdout. Used for docs/landing copy
+ *     generation — never hand-typed.
+ *
+ *   bun scripts/docs-manifest.ts --check
+ *     Grep README.md and packages/docs/src/content/docs/**.md{,x} for
+ *     hand-typed `N commands` / `N MCP tools` / `N skills` patterns.
+ *     Fail with exit 1 and a pointer to the manifest if any match.
+ *
+ * The number-extractor is a simple regex; prose like "nine commands"
+ * (spelled-out number) does not match, so legitimate text is safe.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = join(import.meta.dir, "..");
+
+// ── Sources of truth ────────────────────────────────────────────────────────
+
+function countVisibleCommands(): number {
+	const path = join(ROOT, "packages", "cli", "src", "program.ts");
+	const body = readFileSync(path, "utf-8");
+
+	// Everything between `// ── Workflow` (first block) and
+	// `// ── Internals` is user-facing.
+	const start = body.indexOf("// ── Workflow");
+	const end = body.indexOf("// ── Internals");
+	if (start < 0 || end < 0 || end <= start) {
+		throw new Error(
+			"docs-manifest: could not locate Workflow/Internals section markers in program.ts",
+		);
+	}
+	const visible = body.slice(start, end);
+	const matches = visible.match(/program\.addCommand\(/g) ?? [];
+	return matches.length;
+}
+
+function countMcpTools(): number {
+	const path = join(ROOT, "packages", "mcp", "src", "server.ts");
+	const body = readFileSync(path, "utf-8");
+	// `ALL_TOOL_DESCRIPTIONS` is the canonical list. We parse the array
+	// literal length by counting occurrences of `name: "` after its
+	// opening.
+	const start = body.indexOf("ALL_TOOL_DESCRIPTIONS");
+	if (start < 0) {
+		throw new Error(
+			"docs-manifest: ALL_TOOL_DESCRIPTIONS not found in server.ts",
+		);
+	}
+	const end = body.indexOf("];", start);
+	const block = body.slice(start, end);
+	const matches = block.match(/name:\s*"/g) ?? [];
+	return matches.length;
+}
+
+function listSkills(): string[] {
+	const root = join(ROOT, "packages", "skills");
+	const out: string[] = [];
+	let entries: string[];
+	try {
+		entries = readdirSync(root);
+	} catch {
+		return out;
+	}
+	for (const name of entries) {
+		const full = join(root, name);
+		try {
+			if (!statSync(full).isDirectory()) continue;
+		} catch {
+			continue;
+		}
+		const skillPath = join(full, "SKILL.md");
+		try {
+			if (statSync(skillPath).isFile()) out.push(name);
+		} catch {
+			// skip
+		}
+	}
+	return out.sort();
+}
+
+function listMcpToolNames(): string[] {
+	const path = join(ROOT, "packages", "mcp", "src", "server.ts");
+	const body = readFileSync(path, "utf-8");
+	const start = body.indexOf("ALL_TOOL_DESCRIPTIONS");
+	const end = body.indexOf("];", start);
+	const block = body.slice(start, end);
+	const names: string[] = [];
+	const re = /name:\s*"([^"]+)"/g;
+	let m: RegExpExecArray | null;
+	// biome-ignore lint/suspicious/noAssignInExpressions: idiomatic regex scan
+	while ((m = re.exec(block)) !== null) {
+		names.push(m[1] ?? "");
+	}
+	return names.filter((n) => n.length > 0);
+}
+
+function listVisibleCommandNames(): string[] {
+	const path = join(ROOT, "packages", "cli", "src", "program.ts");
+	const body = readFileSync(path, "utf-8");
+	const start = body.indexOf("// ── Workflow");
+	const end = body.indexOf("// ── Internals");
+	const visible = body.slice(start, end);
+	const names: string[] = [];
+	const re = /program\.addCommand\((\w+)Command\(/g;
+	let m: RegExpExecArray | null;
+	// biome-ignore lint/suspicious/noAssignInExpressions: idiomatic regex scan
+	while ((m = re.exec(visible)) !== null) {
+		names.push(m[1] ?? "");
+	}
+	return names.filter((n) => n.length > 0);
+}
+
+// ── Manifest build ──────────────────────────────────────────────────────────
+
+export interface DocsManifest {
+	generatedAt: string;
+	commands: {
+		visible: number;
+		names: string[];
+	};
+	mcpTools: {
+		total: number;
+		names: string[];
+	};
+	skills: {
+		total: number;
+		names: string[];
+	};
+}
+
+export function buildManifest(): DocsManifest {
+	const commandNames = listVisibleCommandNames();
+	const toolNames = listMcpToolNames();
+	const skillNames = listSkills();
+	return {
+		generatedAt: new Date().toISOString(),
+		commands: {
+			visible: countVisibleCommands(),
+			names: commandNames,
+		},
+		mcpTools: {
+			total: countMcpTools(),
+			names: toolNames,
+		},
+		skills: {
+			total: skillNames.length,
+			names: skillNames,
+		},
+	};
+}
+
+// ── --check mode ────────────────────────────────────────────────────────────
+
+const CHECK_PATTERN = /\b(\d+)\s+(commands|MCP tools|skills)\b/gi;
+
+/** Files we scan for hand-typed counts. */
+function checkTargets(): string[] {
+	const targets: string[] = [join(ROOT, "README.md")];
+	const docsRoot = join(ROOT, "packages", "docs", "src", "content", "docs");
+	try {
+		walkMarkdown(docsRoot, targets);
+	} catch {
+		// docs package optional
+	}
+	return targets;
+}
+
+function walkMarkdown(dir: string, out: string[]): void {
+	let entries: string[];
+	try {
+		entries = readdirSync(dir);
+	} catch {
+		return;
+	}
+	for (const name of entries) {
+		const full = join(dir, name);
+		let stats: ReturnType<typeof statSync>;
+		try {
+			stats = statSync(full);
+		} catch {
+			continue;
+		}
+		if (stats.isDirectory()) {
+			walkMarkdown(full, out);
+			continue;
+		}
+		if (!stats.isFile()) continue;
+		if (!name.endsWith(".md") && !name.endsWith(".mdx")) continue;
+		out.push(full);
+	}
+}
+
+interface CheckHit {
+	file: string;
+	line: number;
+	text: string;
+}
+
+function runCheck(): number {
+	const manifest = buildManifest();
+	const hits: CheckHit[] = [];
+	for (const file of checkTargets()) {
+		let body: string;
+		try {
+			body = readFileSync(file, "utf-8");
+		} catch {
+			continue;
+		}
+		const lines = body.split(/\r?\n/);
+		for (let i = 0; i < lines.length; i++) {
+			const line = lines[i] ?? "";
+			// Skip ignore-annotated lines (HTML comment for .md, JSX comment for
+			// .mdx). The annotation must appear on the line immediately before
+			// the hand-typed count OR on the same line.
+			const prev = i > 0 ? (lines[i - 1] ?? "") : "";
+			const ignoreMarker =
+				/<!--\s*docs-manifest:\s*ignore\s*-->|\{\/\*\s*docs-manifest:\s*ignore\s*\*\/\}/i;
+			if (ignoreMarker.test(line) || ignoreMarker.test(prev)) continue;
+			const matches = line.matchAll(CHECK_PATTERN);
+			for (const _m of matches) {
+				hits.push({ file, line: i + 1, text: line.trim() });
+			}
+		}
+	}
+	if (hits.length === 0) {
+		// eslint-disable-next-line no-console
+		console.log(
+			"docs-manifest --check: OK — no hand-typed counts in docs sources.",
+		);
+		// eslint-disable-next-line no-console
+		console.log(
+			`Live counts → commands=${manifest.commands.visible} mcpTools=${manifest.mcpTools.total} skills=${manifest.skills.total}`,
+		);
+		return 0;
+	}
+	// eslint-disable-next-line no-console
+	console.error(
+		`docs-manifest --check: FAIL — ${hits.length} hand-typed count(s) detected.`,
+	);
+	for (const h of hits) {
+		// eslint-disable-next-line no-console
+		console.error(`  ${relative(ROOT, h.file)}:${h.line}  ${h.text}`);
+	}
+	// eslint-disable-next-line no-console
+	console.error(
+		"\nFix: remove the hand-typed numbers and link readers to `bun run docs:manifest`.",
+	);
+	// eslint-disable-next-line no-console
+	console.error(
+		`Live counts → commands=${manifest.commands.visible} mcpTools=${manifest.mcpTools.total} skills=${manifest.skills.total}`,
+	);
+	return 1;
+}
+
+// ── Entrypoint ──────────────────────────────────────────────────────────────
+
+function main(): void {
+	const args = process.argv.slice(2);
+	if (args.includes("--check")) {
+		process.exit(runCheck());
+	}
+	const manifest = buildManifest();
+	// eslint-disable-next-line no-console
+	console.log(JSON.stringify(manifest, null, 2));
+}
+
+if (import.meta.main) {
+	main();
+}


### PR DESCRIPTION
## Summary

20 commit(s) in this PR.

## What Changed

- feat(cli): wave 4 path hygiene + help polish + e2e matrix (b4be89c)
- fix(core): wiki-lint accuracy + status freshness (#208-#211) (#212) (8597647)
- chore: version packages (#206) (9a2dc00)
- chore: changeset for wiki graph-as-product release (812aa6b)
- docs: revamp landing page around context + token-cost narrative (050) (#205) (645ef76)
- fix(core): wiki obsidian links + module-path collision (coderabbit #203) (#204) (609f134)
- feat(core): wiki graph — Leiden + GRAPH_REPORT + graph.html + exporters (#203) (5116e67)
- chore: version packages (#198) (4ac8379)
- fix(cli): harden sync pull loop + DEBUG=1 alias (#196) (#197) (99e2e68)
- chore: version packages (#195) (fa6a154)
- feat(cli,core): github login + unmask cli errors + crash telemetry (#194) (d90d126)
- chore: version packages (#191) (7441545)
- fix(core): drop auto-generated PR-summary comments during feedback ingest (#190) (a3b9987)
- chore: version packages (#189) (30fd568)
- feat(core,cli): ingest external code-review findings as RL training signal (#185) (#188) (46bcbc6)
- feat(core): add doc-claims verify tool to catch fabricated API signatures in markdown (#187) (9d5e2a7)
- chore: version packages (#186) (758bd36)
- fix(mcp): prefer installed maina binary over bunx to avoid cold-start cache race (#184) (40de5da)
- chore: version packages (#183) (7c8e0ab)
- fix(mcp): write absolute launcher path so Cursor/Zed can spawn it (#182) (19b5119)

## Review

- [!] console.log found in added code (.github/workflows/onboarding-e2e.yml:180)
- [i] Long line (229 chars) in added code (README.md:117)
- [i] Long line (127 chars) in added code (README.md:166)
- [!] console.log found in added code (ci/e2e/run-local.ts:172)
- [!] console.log found in added code (ci/e2e/run-local.ts:178)
- [!] console.log found in added code (ci/e2e/simulate-agent.ts:105)
- [!] console.log found in added code (ci/e2e/simulate-agent.ts:200)
- [!] console.log found in added code (ci/e2e/simulate-agent.ts:242)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/context.output-path.test.ts:38)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/context.output-path.test.ts:39)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/context.output-path.test.ts:41)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/context.output-path.test.ts:42)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/context.output-path.test.ts:43)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/context.output-path.test.ts:44)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/context.output-path.test.ts:45)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/context.output-path.test.ts:46)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/context.output-path.test.ts:49)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/context.output-path.test.ts:50)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/wiki-status.test.ts:40)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/wiki-status.test.ts:41)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/wiki-status.test.ts:43)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/wiki-status.test.ts:44)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/wiki-status.test.ts:45)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/wiki-status.test.ts:46)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/wiki-status.test.ts:47)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/wiki-status.test.ts:48)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/wiki-status.test.ts:51)
- [!] Empty function body in added code (packages/cli/src/commands/__tests__/wiki-status.test.ts:52)
- [i] Long line (127 chars) in added code (packages/cli/src/commands/wiki/status.ts:231)
- [i] Long line (225 chars) in added code (packages/docs/src/content/docs/skills.mdx:6)
- [!] console.log found in added code (scripts/check-paths.ts:97)
- [!] console.log found in added code (scripts/docs-manifest.ts:236)
- [!] console.log found in added code (scripts/docs-manifest.ts:240)
- [i] Long line (125 chars) in added code (scripts/docs-manifest.ts:241)
- [i] Long line (124 chars) in added code (scripts/docs-manifest.ts:259)
- [!] console.log found in added code (scripts/docs-manifest.ts:273)
## Verification Proof

<details>
<summary>✅ Pipeline: 0 tools, 0 findings, 0.0s</summary>

| Tool | Findings | Duration | Status |
|------|----------|----------|--------|

</details>

<details>
<summary>⚠️ Code Review</summary>

- Stage 1 (spec compliance): passed, 0 finding(s)
- Stage 2 (code quality): failed, 36 finding(s)

</details>

<details>
<summary>✅ Slop: clean</summary>

0 slop pattern(s) detected.

</details>

<details>
<summary>📋 Workflow Context</summary>

```
...mmitted.

## commit (2026-04-18T17:43:14.584Z)
Verified: 13 tools, 36 findings. Committed.

## commit (2026-04-18T17:44:15.388Z)
Verified: 13 tools, 21 findings. Committed.

## commit (2026-04-18T18:02:31.768Z)
Verified: 13 tools, 33 findings. Committed.

## commit (2026-04-18T18:35:32.742Z)
Verified: 13 tools, 23 findings. Committed.

## commit (2026-04-20T10:10:44.995Z)
Verified: 13 tools, 25 findings. Committed.

## commit (2026-04-21T14:25:51.087Z)
Verified: 13 tools, 48 findings. Committed.
```

</details>
### Wiki Coverage
- Articles updated: 0
- Articles added: 0
- Total coverage: 0%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-blocking wiki init with background mode and depth control; context output now defaults under the project metadata folder with --output/--force controls
  * Local/run-onboarding runner and a simulated agent for reproducible E2E cells

* **Improvements**
  * Help output hides internal plumbing commands while keeping them callable
  * Wiki status surfaces live progress (percent, ETA, stalled state)
  * README/docs reference live manifest for command/tool/skill counts

* **Tests & CI**
  * Added multi-language E2E onboarding matrix, path-hygiene and docs-manifest CI guards, and aggregated latency reporting artifacts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->