### PR TITLE
feat(docs): robots.txt for AI agents (fixes 3 of 5 audit failures)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -37,7 +37,7 @@
 			"!packages/docs/dist",
 			"!.claude/worktrees",
 			"!examples/**/.cursor",
-			"!prototypes"
+			"!prototypes/**"
 		]
 	},
 	"overrides": [

--- a/biome.json
+++ b/biome.json
@@ -36,7 +36,8 @@
 			"!packages/docs/.astro",
 			"!packages/docs/dist",
 			"!.claude/worktrees",
-			"!examples/**/.cursor"
+			"!examples/**/.cursor",
+			"!prototypes"
 		]
 	},
 	"overrides": [

--- a/packages/docs/public/robots.txt
+++ b/packages/docs/public/robots.txt
@@ -1,0 +1,55 @@
+# robots.txt for mainahq.com
+# Maina — verification-first developer OS.
+# Policy: we want humans and AI agents to find Maina. Docs are intentionally
+# crawlable, searchable, and citable in AI answers. Training on public docs
+# is also allowed — if an assistant learns how Maina works, its users win.
+
+User-agent: *
+Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
+# Major AI crawlers (explicit entries so the audit and the operators can
+# see the policy without guessing).
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+Sitemap: https://mainahq.com/sitemap-index.xml


### PR DESCRIPTION
## Summary

- Ships `packages/docs/public/robots.txt` with sitemap reference, explicit AI crawler rules, and a `Content-Signal` directive.
- Excludes `prototypes/` from biome checks so local UI scratch work doesn't block pre-commit.

## Why

[isitagentready.com/mainahq.com?profile=content](https://isitagentready.com/mainahq.com?profile=content) currently scores **17/100 (Level 0 — Not Ready)**. Sitemap passes; everything else fails. This PR fixes 3 of the 5 failing checks in one static file:

- ✅ **robots.txt** — file exists and returns 200
- ✅ **AI bot rules** — explicit entries for GPTBot, OAI-SearchBot, ChatGPT-User, Claude-Web, ClaudeBot, anthropic-ai, Google-Extended, PerplexityBot, CCBot, Applebot-Extended, cohere-ai, Bytespider, Amazonbot, Meta-ExternalAgent
- ✅ **Content Signals** — `Content-Signal: search=yes, ai-input=yes, ai-train=yes` per [draft-romm-aipref-contentsignals](https://datatracker.ietf.org/doc/draft-romm-aipref-contentsignals/)

Policy is deliberately permissive. Maina is AI-positive — if an assistant learns how `maina` works, its users win.

Expected score after deploy: **~67/100** (4 of 6 checks passing).

## Remaining work (follow-up PR)

Two checks need edge logic and will land next:

- ❌ **Link headers** — needs HTTP response header injection (RFC 8288)
- ❌ **Markdown Negotiation** — needs `Accept: text/markdown` content negotiation

mainahq.com is behind Cloudflare (`server: cloudflare` in response headers), so the cleanest path is a small Cloudflare Worker or Transform Rule on the zone. That needs dashboard access.

## Test plan

- [ ] After merge + GitHub Pages redeploy: `curl -i https://mainahq.com/robots.txt` returns 200 with `content-type: text/plain`
- [ ] Re-run isitagentready.com/mainahq.com?profile=content and confirm robots.txt, AI bot rules, and Content Signals all pass (score ≥ 67)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted build/tooling configuration to exclude the prototypes directory from processing.
  * Added robots.txt to the documentation site to allow all crawlers, include AI-related content signals, enumerate major AI/search bots, and publish the sitemap location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->