### PR TITLE
feat(core,cli): thread diff stats into receipt builds (#264)

### DIFF
--- a/packages/cli/src/commands/receipt.ts
+++ b/packages/cli/src/commands/receipt.ts
@@ -143,8 +143,9 @@ async function resolveDiffStats(
 	// `--all` walks every tracked file; line-level add/del don't apply.
 	if (options.all) return { additions: 0, deletions: 0, files: 0 };
 	// Default path: staged diff (what `maina receipt` runs against pre-merge).
-	// Backfill always provides options.diff or options.files+base, so this
-	// branch only fires for the live `maina receipt` invocation.
+	// Backfill provides `options.diff` directly because it knows the
+	// synthetic commit range to diff against; without that hint, we fall
+	// back to staged.
 	return getDiffStats({ cwd, staged: true });
 }
 

--- a/packages/cli/src/commands/receipt.ts
+++ b/packages/cli/src/commands/receipt.ts
@@ -11,8 +11,10 @@ import { join, relative } from "node:path";
 import {
 	type BuildReceiptInput,
 	buildReceipt,
+	type DiffStats,
 	deriveChecksAndStatus,
 	generateWalkthrough,
+	getDiffStats,
 	getStagedFiles,
 	getTrackedFiles,
 	type PipelineResult,
@@ -36,6 +38,10 @@ export interface ReceiptActionOptions {
 	 * detection — useful for backfill scripts that compute a PR's
 	 * diff scope directly. */
 	files?: string[];
+	/** Pre-computed diff stats. Backfill computes its own range
+	 * (`<commit>^..<commit>`) and passes the result through; otherwise
+	 * receiptAction shells out to `git diff --shortstat` itself. */
+	diff?: DiffStats;
 }
 
 export interface ReceiptActionResult {
@@ -61,7 +67,7 @@ export async function receiptAction(
 	const pipeline = await runVerifyPipeline(cwd, options);
 	const { constitutionHash, promptsHash } = loadPromptVersion(cwd);
 	const prTitle = options.title ?? "Untitled PR";
-	const diff = { additions: 0, deletions: 0, files: 0 };
+	const diff = options.diff ?? (await resolveDiffStats(cwd, options));
 	const retries = 0;
 
 	// Use the *same* check derivation that buildReceipt will use — guarantees
@@ -128,6 +134,18 @@ export async function receiptAction(
 		totalCount: built.data.checks.length,
 		status: built.data.status,
 	};
+}
+
+async function resolveDiffStats(
+	cwd: string,
+	options: ReceiptActionOptions,
+): Promise<DiffStats> {
+	// `--all` walks every tracked file; line-level add/del don't apply.
+	if (options.all) return { additions: 0, deletions: 0, files: 0 };
+	// Default path: staged diff (what `maina receipt` runs against pre-merge).
+	// Backfill always provides options.diff or options.files+base, so this
+	// branch only fires for the live `maina receipt` invocation.
+	return getDiffStats({ cwd, staged: true });
 }
 
 async function runVerifyPipeline(

--- a/packages/core/src/git/__tests__/git.test.ts
+++ b/packages/core/src/git/__tests__/git.test.ts
@@ -4,10 +4,12 @@ import {
 	getChangedFiles,
 	getCurrentBranch,
 	getDiff,
+	getDiffStats,
 	getRecentCommits,
 	getRepoRoot,
 	getRepoSlug,
 	getStagedFiles,
+	parseShortstat,
 } from "../index";
 
 describe("git operations", () => {
@@ -59,6 +61,54 @@ describe("git operations", () => {
 	test("getDiff() returns a string", async () => {
 		const diff = await getDiff();
 		expect(typeof diff).toBe("string");
+	});
+
+	test("parseShortstat() returns zeros for empty input", () => {
+		expect(parseShortstat("")).toEqual({
+			additions: 0,
+			deletions: 0,
+			files: 0,
+		});
+		expect(parseShortstat("   \n  ")).toEqual({
+			additions: 0,
+			deletions: 0,
+			files: 0,
+		});
+	});
+
+	test("parseShortstat() handles full add+del shortstat line", () => {
+		const line = " 3 files changed, 42 insertions(+), 5 deletions(-)";
+		expect(parseShortstat(line)).toEqual({
+			files: 3,
+			additions: 42,
+			deletions: 5,
+		});
+	});
+
+	test("parseShortstat() handles add-only shortstat", () => {
+		expect(parseShortstat(" 1 file changed, 1 insertion(+)")).toEqual({
+			files: 1,
+			additions: 1,
+			deletions: 0,
+		});
+	});
+
+	test("parseShortstat() handles del-only shortstat", () => {
+		expect(parseShortstat(" 2 files changed, 7 deletions(-)")).toEqual({
+			files: 2,
+			additions: 0,
+			deletions: 7,
+		});
+	});
+
+	test("getDiffStats() returns a stats object (may be zero)", async () => {
+		const stats = await getDiffStats();
+		expect(typeof stats.additions).toBe("number");
+		expect(typeof stats.deletions).toBe("number");
+		expect(typeof stats.files).toBe("number");
+		expect(stats.additions).toBeGreaterThanOrEqual(0);
+		expect(stats.deletions).toBeGreaterThanOrEqual(0);
+		expect(stats.files).toBeGreaterThanOrEqual(0);
 	});
 
 	test("getRepoSlug() returns owner/repo format", async () => {

--- a/packages/core/src/git/__tests__/git.test.ts
+++ b/packages/core/src/git/__tests__/git.test.ts
@@ -111,6 +111,19 @@ describe("git operations", () => {
 		expect(stats.files).toBeGreaterThanOrEqual(0);
 	});
 
+	test("getDiffStats() returns zeros when only `from` or `to` is set", async () => {
+		expect(await getDiffStats({ from: "HEAD" })).toEqual({
+			additions: 0,
+			deletions: 0,
+			files: 0,
+		});
+		expect(await getDiffStats({ to: "HEAD" })).toEqual({
+			additions: 0,
+			deletions: 0,
+			files: 0,
+		});
+	});
+
 	test("getRepoSlug() returns owner/repo format", async () => {
 		const slug = await getRepoSlug();
 		expect(typeof slug).toBe("string");

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -94,6 +94,63 @@ export async function getDiff(
 	return output;
 }
 
+export interface DiffStats {
+	additions: number;
+	deletions: number;
+	files: number;
+}
+
+/**
+ * Parse a `git diff --shortstat` line. Output forms:
+ *   ""                                              → all zero
+ *   " 1 file changed, 1 insertion(+)"               → add-only
+ *   " 2 files changed, 7 deletions(-)"              → del-only
+ *   " 3 files changed, 42 insertions(+), 5 deletions(-)"
+ */
+export function parseShortstat(output: string): DiffStats {
+	if (!output.trim()) return { additions: 0, deletions: 0, files: 0 };
+	const filesMatch = output.match(/(\d+) files? changed/);
+	const addMatch = output.match(/(\d+) insertions?\(\+\)/);
+	const delMatch = output.match(/(\d+) deletions?\(-\)/);
+	return {
+		files: filesMatch?.[1] ? Number.parseInt(filesMatch[1], 10) : 0,
+		additions: addMatch?.[1] ? Number.parseInt(addMatch[1], 10) : 0,
+		deletions: delMatch?.[1] ? Number.parseInt(delMatch[1], 10) : 0,
+	};
+}
+
+export interface GetDiffStatsOptions {
+	/** Range start (e.g. `<commit>^`). Use with `to` for an arbitrary range. */
+	from?: string;
+	/** Range end. */
+	to?: string;
+	/** Use `--cached` (staged diff). Ignored when `from`/`to` are set. */
+	staged?: boolean;
+	/** Optional pathspec to scope the stats to a specific file list. */
+	files?: string[];
+	cwd?: string;
+}
+
+/**
+ * Compute diff stats. Falls back to zero on git failure (matches the rest
+ * of this module's never-throw pattern).
+ */
+export async function getDiffStats(
+	options: GetDiffStatsOptions = {},
+): Promise<DiffStats> {
+	const args = ["diff", "--shortstat"];
+	if (options.from && options.to) {
+		args.push(`${options.from}..${options.to}`);
+	} else if (options.staged) {
+		args.push("--cached");
+	}
+	if (options.files && options.files.length > 0) {
+		args.push("--", ...options.files);
+	}
+	const output = await exec(args, options.cwd);
+	return parseShortstat(output);
+}
+
 export async function getStagedFiles(cwd?: string): Promise<string[]> {
 	const output = await exec(["diff", "--cached", "--name-only"], cwd);
 	if (!output) return [];

--- a/packages/core/src/git/index.ts
+++ b/packages/core/src/git/index.ts
@@ -14,6 +14,10 @@ async function exec(
 			cwd,
 			stdout: "pipe",
 			stderr: "pipe",
+			// Force English git output so locale-aware parsers (e.g.
+			// parseShortstat's "files changed / insertions / deletions"
+			// regexes) work on contributor machines that aren't en_US.
+			env: { ...process.env, LC_ALL: "C", LANG: "C" },
 		});
 		const output = await new Response(proc.stdout).text();
 		const exitCode = await proc.exited;
@@ -134,10 +138,19 @@ export interface GetDiffStatsOptions {
 /**
  * Compute diff stats. Falls back to zero on git failure (matches the rest
  * of this module's never-throw pattern).
+ *
+ * `from` and `to` must be supplied together — supplying only one is a
+ * caller bug (the other "default" git would pick is rarely the range the
+ * caller meant). Returns zero in that case rather than silently producing
+ * misleading stats.
  */
 export async function getDiffStats(
 	options: GetDiffStatsOptions = {},
 ): Promise<DiffStats> {
+	const partialRange =
+		(options.from && !options.to) || (!options.from && options.to);
+	if (partialRange) return { additions: 0, deletions: 0, files: 0 };
+
 	const args = ["diff", "--shortstat"];
 	if (options.from && options.to) {
 		args.push(`${options.from}..${options.to}`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -255,15 +255,19 @@ export {
 // Git
 export {
 	type Commit,
+	type DiffStats,
+	type GetDiffStatsOptions,
 	getBranchName,
 	getChangedFiles,
 	getCurrentBranch,
 	getDiff,
+	getDiffStats,
 	getRecentCommits,
 	getRepoRoot,
 	getRepoSlug,
 	getStagedFiles,
 	getTrackedFiles,
+	parseShortstat,
 } from "./git/index";
 export {
 	appendVerifiedByTrailer,

--- a/scripts/backfill-receipts.ts
+++ b/scripts/backfill-receipts.ts
@@ -26,6 +26,7 @@ import {
 	type ReceiptActionResult,
 	receiptAction,
 } from "../packages/cli/src/commands/receipt";
+import { getDiffStats } from "../packages/core/src/git";
 import { writeIndexPage as writeReceiptIndexPage } from "../packages/core/src/receipt/index-page";
 
 interface BackfillOptions {
@@ -252,12 +253,23 @@ async function backfillOne(
 		};
 	}
 
+	// Pre-compute diff stats for the same range so the receipt records the
+	// PR's actual line-level scope rather than 0/0/0. The default path in
+	// receiptAction can't infer this — it's a synthetic range across the
+	// merge commit's parent → merge commit.
+	const diff = await getDiffStats({
+		cwd: options.cwd,
+		from: `${pr.mergeCommit.oid}^`,
+		to: pr.mergeCommit.oid,
+	});
+
 	try {
 		const receipt = await receiptAction({
 			cwd: options.cwd,
 			base: pr.baseRefName,
 			title: pr.title,
 			files,
+			diff,
 			noIndex: true, // we'll refresh once at the end
 		});
 		return { ok: true, receipt };

--- a/scripts/backfill-receipts.ts
+++ b/scripts/backfill-receipts.ts
@@ -208,6 +208,30 @@ async function captureOriginalRef(cwd: string): Promise<string> {
 	return sha.stdout.trim();
 }
 
+/**
+ * Resolve the diff range that captures the PR's contribution. For true
+ * merge commits (2 parents) we diff first-parent..second-parent so the
+ * range covers only the feature-branch contents, not the linear advance
+ * of master. For squash/single-parent commits, fall back to `^..oid`.
+ *
+ * Returned SHAs are full 40-char hashes — slicing for display happens at
+ * the call site.
+ */
+async function diffRangeFor(
+	oid: string,
+	cwd: string,
+): Promise<{ from: string; to: string }> {
+	const result = await runGit(["rev-list", "--parents", "-n", "1", oid], cwd);
+	if (result.exitCode === 0) {
+		const parts = result.stdout.trim().split(/\s+/);
+		// Format: <oid> <parent1> [<parent2>...]
+		if (parts.length >= 3 && parts[1] && parts[2]) {
+			return { from: parts[1], to: parts[2] };
+		}
+	}
+	return { from: `${oid}^`, to: oid };
+}
+
 async function backfillOne(
 	pr: MergedPr,
 	options: BackfillOptions,
@@ -229,13 +253,20 @@ async function backfillOne(
 		};
 	}
 
-	// Compute the PR's diff scope. For squash-merged PRs the merge commit
-	// has a single parent (the previous tip of the target branch), so the
-	// PR's actual changes are simply `<commit>^ → <commit>`. Three-dot
-	// against `origin/<base>` returns empty because the squash commit IS
-	// already in the base after the merge.
+	// Compute the PR's diff scope based on the merge commit's parent count:
+	//   - squash-merge or rebase-merge tip (1 parent): `<commit>^ → <commit>`
+	//   - true merge commit       (2 parents):         `<commit>^1 → <commit>^2`
+	//                                                  (^1 = base before merge,
+	//                                                   ^2 = feature branch tip)
+	// Rebase-merged multi-commit PRs are undercounted: only the last commit
+	// of the PR's range is captured because the parent of the merged tip is
+	// the previous PR commit, not the PR's base. This repo uses squash-merge
+	// exclusively, so the caveat is documented but not handled.
+	// Three-dot against `origin/<base>` returns empty because the merge IS
+	// already in the base after merging.
+	const range = await diffRangeFor(pr.mergeCommit.oid, options.cwd);
 	const diffFiles = await runGit(
-		["diff", "--name-only", `${pr.mergeCommit.oid}^`, pr.mergeCommit.oid],
+		["diff", "--name-only", range.from, range.to],
 		options.cwd,
 	);
 	const files =
@@ -249,7 +280,7 @@ async function backfillOne(
 	if (files.length === 0) {
 		return {
 			ok: false,
-			reason: `no files in diff scope ${pr.mergeCommit.oid.slice(0, 12)}^..${pr.mergeCommit.oid.slice(0, 12)}`,
+			reason: `no files in diff scope ${range.from.slice(0, 12)}..${range.to.slice(0, 12)}`,
 		};
 	}
 
@@ -259,8 +290,8 @@ async function backfillOne(
 	// merge commit's parent → merge commit.
 	const diff = await getDiffStats({
 		cwd: options.cwd,
-		from: `${pr.mergeCommit.oid}^`,
-		to: pr.mergeCommit.oid,
+		from: range.from,
+		to: range.to,
 	});
 
 	try {


### PR DESCRIPTION
Closes #264. Required before #265 (rerun backfill) can produce truthful receipts.

## Summary

- Receipts no longer hardcode \`diff: { additions: 0, deletions: 0, files: 0 }\`. \`receiptAction\` now uses \`options.diff\` if provided, otherwise computes via \`git diff --shortstat\`.
- \`packages/core/src/git\` gains \`parseShortstat\` + \`getDiffStats\` (range, staged, working-tree, optional pathspec).
- \`scripts/backfill-receipts.ts\` pre-computes \`from: <oid>^, to: <oid>\` stats and threads them into \`receiptAction\` so backfilled receipts capture the PR's actual line-level scope.
- Default path (live \`maina receipt\` pre-merge) computes from staged diff. \`--all\` still records 0/0/0 because line-level add/del don't apply to a tracked-files snapshot.

## Why this matters

The 10 receipts merged in #258 every claim "0 files changed, 0 insertions(+), 0 deletions(-)". Walkthroughs and HTML cards therefore imply each PR was a no-op, weakening them as proof artefacts. With this change, re-running the backfill (#265) will produce receipts that report real diff scope.

## Test plan

- [x] \`parseShortstat\` unit-tested against 4 forms (empty / add+del / add-only / del-only)
- [x] \`getDiffStats\` returns a stats object end-to-end against the working repo
- [x] \`bun run typecheck\` passes
- [x] \`maina commit\` passes verify (13 tools, 0 errors)
- [ ] After merge: \`#265\` reruns backfill and the published receipts show real diff stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Receipts now accurately display actual diff statistics from your pull requests
  - Added support for computing diff metrics across various git merge scenarios

* **Bug Fixes**
  - Fixed receipt generation to use computed diff statistics instead of default values, improving accuracy

* **Tests**
  - Added comprehensive unit tests for diff statistics parsing and computation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->