### PR TITLE
feat(core): per-receipt footer backlink to receipts index (#268)

### DIFF
--- a/packages/core/src/receipt/__tests__/build.test.ts
+++ b/packages/core/src/receipt/__tests__/build.test.ts
@@ -171,6 +171,21 @@ describe("renderReceiptHtml", () => {
 		expect(html).toContain("&lt;script&gt;");
 	});
 
+	test("includes a footer backlink to the receipts index", async () => {
+		const result = await buildReceipt({
+			prTitle: "linked PR",
+			pipeline: stubPipeline(),
+			constitutionHash: "a".repeat(64),
+			promptsHash: "b".repeat(64),
+		});
+		if (!result.ok) throw new Error("build failed");
+		const html = renderReceiptHtml(result.data);
+		// Per-receipt URLs are at /receipts/<hash>/, so "../" lands on the
+		// listing page. Avoids dead-end navigation when users land on a
+		// receipt link directly.
+		expect(html).toMatch(/<a href="\.\.\/"[^>]*>[^<]*receipts[^<]*<\/a>/i);
+	});
+
 	test("shows a retry badge when retries > 0", async () => {
 		const result = await buildReceipt({
 			prTitle: "retried PR",

--- a/packages/core/src/receipt/render.ts
+++ b/packages/core/src/receipt/render.ts
@@ -89,6 +89,8 @@ ${receipt.checks.map(renderCheck).join("\n")}
 <footer>
 Verified with Maina. Receipt format: v1 (<a href="https://schemas.mainahq.com/v1.json">schemas.mainahq.com/v1.json</a>).
 Verify this receipt offline with <code>maina verify-receipt ./receipt.json</code>.
+<br>
+<a href="../">Back to receipts index</a>
 </footer>
 </body>
 </html>`;


### PR DESCRIPTION
Closes #268. Picked up from CodeRabbit nit on #266.

## Summary

- \`renderReceiptHtml\` footer now includes \`<a href=\"../\">Back to receipts index</a>\` so users landing on a per-receipt URL (\`/receipts/<hash>/\`) can navigate to the listing.
- Receipt hash is computed from JSON canonicalization, not the rendered HTML — existing receipt hashes stay valid; only the per-receipt index.html changes when receipts are regenerated.
- Test asserts the link is present in the rendered HTML.

## Test plan

- [x] \`bun test packages/core/src/receipt/__tests__/build.test.ts\` — 9/9 pass
- [x] \`maina commit\` passes verify
- [ ] After merge: re-running the backfill (\`#265\`) regenerates per-receipt HTML with the backlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)