### PR TITLE
feat(docs): homepage receipts gallery (#257)

### DIFF
--- a/packages/docs/src/components/ReceiptGallery.astro
+++ b/packages/docs/src/components/ReceiptGallery.astro
@@ -1,0 +1,236 @@
+---
+/**
+ * ReceiptGallery — Wave 3.2 #257.
+ *
+ * Reads every `.maina/receipts/<hash>/receipt.json` at build time via
+ * Vite's `import.meta.glob`, hands the raw shapes to `buildGallery`, and
+ * renders cards. Pure SSG — zero client JS. Empty state covers fresh
+ * checkouts where no receipts have been produced yet (so the homepage
+ * doesn't visibly break).
+ */
+import { RECEIPTS_GALLERY } from '../data/landing';
+import {
+  buildGallery,
+  type RawReceipt,
+  type GalleryCard,
+} from '../data/receipts-gallery';
+
+const rawBase = import.meta.env.BASE_URL;
+const base = rawBase.endsWith('/') ? rawBase.slice(0, -1) : rawBase;
+
+const receiptModules = import.meta.glob<RawReceipt>(
+  '../../../../.maina/receipts/*/receipt.json',
+  { eager: true, import: 'default' },
+);
+
+const cards: GalleryCard[] = buildGallery(Object.values(receiptModules));
+
+// Resolve hrefs against the site base so this works under a non-root
+// `BASE_URL` (e.g. preview deploys).
+const resolvedCards = cards.map((c) => ({
+  ...c,
+  href: c.href.startsWith('/') ? `${base}${c.href}` : c.href,
+}));
+
+const allReceiptsHref = `${base}${RECEIPTS_GALLERY.allReceiptsHref}`;
+---
+
+<section class="receipts-gallery">
+  <div class="receipts-gallery__head">
+    <h2 class="receipts-gallery__title">{RECEIPTS_GALLERY.heading}</h2>
+    <p class="receipts-gallery__sub">{RECEIPTS_GALLERY.subheading}</p>
+  </div>
+
+  {resolvedCards.length === 0 ? (
+    <p class="receipts-gallery__empty">{RECEIPTS_GALLERY.emptyState}</p>
+  ) : (
+    <ul class="receipts-gallery__list">
+      {resolvedCards.map((c) => (
+        <li class="receipts-gallery__item">
+          <a class="receipts-gallery__card" href={c.href}>
+            <div class="receipts-gallery__card-head">
+              <span class={`receipts-gallery__status receipts-gallery__status--${c.status}`}>
+                {c.statusLabel}
+              </span>
+              <span class="receipts-gallery__hash">{c.hashShort}…</span>
+            </div>
+            <h3 class="receipts-gallery__pr">{c.prTitle}</h3>
+            <p class="receipts-gallery__walkthrough">{c.walkthrough}</p>
+            <div class="receipts-gallery__foot">
+              <span class="receipts-gallery__diff">{c.diffSummary}</span>
+              <span class="receipts-gallery__repo">{c.repo}</span>
+            </div>
+          </a>
+        </li>
+      ))}
+    </ul>
+  )}
+
+  {resolvedCards.length > 0 && (
+    <p class="receipts-gallery__cta">
+      <a href={allReceiptsHref}>{RECEIPTS_GALLERY.allReceiptsLabel} →</a>
+    </p>
+  )}
+</section>
+
+<style is:global>
+  .receipts-gallery {
+    max-width: 1100px;
+    margin: 96px auto;
+    padding: 0 24px;
+  }
+
+  .receipts-gallery__head {
+    text-align: center;
+    margin-bottom: 36px;
+  }
+
+  .receipts-gallery__title {
+    font-family: var(--font-display);
+    font-size: 32px;
+    font-weight: 600;
+    margin: 0 0 12px 0;
+    color: var(--color-ink);
+  }
+
+  .receipts-gallery__sub {
+    font-size: 15px;
+    color: var(--color-ink-muted);
+    max-width: 640px;
+    margin: 0 auto;
+    line-height: 1.55;
+  }
+
+  .receipts-gallery__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 16px;
+    grid-template-columns: 1fr;
+  }
+
+  @media (min-width: 720px) {
+    .receipts-gallery__list {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+
+  @media (min-width: 1000px) {
+    .receipts-gallery__list {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  .receipts-gallery__item { margin: 0; }
+
+  .receipts-gallery__card {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 18px 18px 16px;
+    background: var(--color-bg-elev);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: var(--radius);
+    text-decoration: none;
+    color: var(--color-ink);
+    transition: border-color 140ms ease, transform 140ms ease;
+    height: 100%;
+  }
+
+  .receipts-gallery__card:hover,
+  .receipts-gallery__card:focus-visible {
+    border-color: var(--color-accent);
+    transform: translateY(-1px);
+  }
+
+  .receipts-gallery__card-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .receipts-gallery__status {
+    display: inline-block;
+    padding: 3px 9px;
+    border-radius: 999px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+
+  .receipts-gallery__status--passed {
+    background: oklch(0.92 0.1 145);
+    color: oklch(0.25 0.15 145);
+  }
+
+  .receipts-gallery__status--partial {
+    background: oklch(0.92 0.08 90);
+    color: oklch(0.3 0.15 90);
+  }
+
+  .receipts-gallery__status--failed {
+    background: oklch(0.92 0.1 25);
+    color: oklch(0.3 0.15 25);
+  }
+
+  .receipts-gallery__hash {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-ink-muted);
+    word-break: break-all;
+  }
+
+  .receipts-gallery__pr {
+    font-family: var(--font-display);
+    font-size: 16px;
+    font-weight: 600;
+    margin: 0;
+    line-height: 1.35;
+  }
+
+  .receipts-gallery__walkthrough {
+    font-size: 13px;
+    color: var(--color-ink-muted);
+    line-height: 1.5;
+    margin: 0;
+    flex-grow: 1;
+  }
+
+  .receipts-gallery__foot {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-ink-muted);
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    padding-top: 10px;
+  }
+
+  .receipts-gallery__empty {
+    text-align: center;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    color: var(--color-ink-muted);
+    padding: 36px 0;
+  }
+
+  .receipts-gallery__cta {
+    text-align: center;
+    margin: 28px 0 0 0;
+    font-family: var(--font-mono);
+    font-size: 13px;
+  }
+
+  .receipts-gallery__cta a {
+    color: var(--color-accent);
+    text-decoration: none;
+  }
+
+  .receipts-gallery__cta a:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/packages/docs/src/data/__tests__/receipts-gallery.test.ts
+++ b/packages/docs/src/data/__tests__/receipts-gallery.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "bun:test";
+import {
+	buildGallery,
+	type RawReceipt,
+	receiptHref,
+	toGalleryCard,
+} from "../receipts-gallery";
+
+const sampleHash = "a".repeat(64);
+
+function rawReceipt(overrides: Partial<RawReceipt> = {}): RawReceipt {
+	return {
+		prTitle: "feat(x): a sample PR",
+		repo: "mainahq/maina",
+		timestamp: "2026-04-25T20:00:00.000Z",
+		status: "passed",
+		hash: sampleHash,
+		walkthrough:
+			"feat(x): a sample PR: +10 / −0 across 2 files. Maina ran 2 check(s) — 2 passed. Verified — passed 2 of 2 policy checks.",
+		diff: { files: 2, additions: 10, deletions: 0 },
+		checks: [{ status: "passed" }, { status: "passed" }],
+		...overrides,
+	};
+}
+
+describe("receipts-gallery", () => {
+	it("returns empty array when no receipts are supplied", () => {
+		expect(buildGallery([])).toEqual([]);
+	});
+
+	it("renders a status label that respects copy discipline (C2)", () => {
+		const card = toGalleryCard(rawReceipt());
+		expect(card?.statusLabel).toBe("passed 2 of 2 checks");
+		// C2: never "0 findings" / "no issues found".
+		expect(card?.statusLabel).not.toMatch(/\b(0 findings?|no issues? found)\b/);
+	});
+
+	it("only emits one of three known status badges", () => {
+		const passed = toGalleryCard(rawReceipt({ status: "passed" }));
+		const partial = toGalleryCard(rawReceipt({ status: "partial" }));
+		const failed = toGalleryCard(rawReceipt({ status: "failed" }));
+		expect(passed?.status).toBe("passed");
+		expect(partial?.status).toBe("partial");
+		expect(failed?.status).toBe("failed");
+		// Bogus statuses → card dropped (not coerced to a wrong badge).
+		expect(toGalleryCard(rawReceipt({ status: "totally-fine" }))).toBeNull();
+	});
+
+	it("links to /receipts/<hash>/ by default and to the chosen base when overridden", () => {
+		const card = toGalleryCard(rawReceipt());
+		expect(card?.href).toBe(`/receipts/${sampleHash}/`);
+		const onR = toGalleryCard(rawReceipt(), { linkBase: "/r/" });
+		expect(onR?.href).toBe(`/r/${sampleHash}/`);
+		// Trailing-slash insensitivity.
+		expect(receiptHref(sampleHash, "/receipts")).toBe(
+			`/receipts/${sampleHash}/`,
+		);
+	});
+
+	it("sorts newest-first and respects the limit", () => {
+		const cards = buildGallery(
+			[
+				rawReceipt({
+					hash: "1".repeat(64),
+					timestamp: "2026-04-23T00:00:00.000Z",
+				}),
+				rawReceipt({
+					hash: "2".repeat(64),
+					timestamp: "2026-04-25T00:00:00.000Z",
+				}),
+				rawReceipt({
+					hash: "3".repeat(64),
+					timestamp: "2026-04-24T00:00:00.000Z",
+				}),
+			],
+			{ limit: 2 },
+		);
+		expect(cards.map((c) => c.hash)).toEqual(["2".repeat(64), "3".repeat(64)]);
+	});
+
+	it("drops malformed receipts instead of throwing", () => {
+		// Missing required fields, bogus hash, wrong types — every one
+		// should silently drop, leaving the surviving valid card alone.
+		const cards = buildGallery([
+			rawReceipt(),
+			{ ...rawReceipt(), hash: "not-hex" },
+			{ ...rawReceipt(), hash: undefined },
+			{ ...rawReceipt(), prTitle: undefined },
+			{ ...rawReceipt(), timestamp: 12345 as unknown as string },
+		]);
+		expect(cards).toHaveLength(1);
+	});
+});

--- a/packages/docs/src/data/__tests__/receipts-gallery.test.ts
+++ b/packages/docs/src/data/__tests__/receipts-gallery.test.ts
@@ -78,6 +78,34 @@ describe("receipts-gallery", () => {
 		expect(cards.map((c) => c.hash)).toEqual(["2".repeat(64), "3".repeat(64)]);
 	});
 
+	it("rejects non-ISO-8601 timestamps", () => {
+		expect(toGalleryCard(rawReceipt({ timestamp: "yesterday" }))).toBeNull();
+		expect(toGalleryCard(rawReceipt({ timestamp: "2026/04/25" }))).toBeNull();
+		// Sanity: the canonical ISO form still parses.
+		expect(
+			toGalleryCard(rawReceipt({ timestamp: "2026-04-25T20:00:00.000Z" })),
+		).not.toBeNull();
+		// And the offset form is also valid ISO-8601.
+		expect(
+			toGalleryCard(rawReceipt({ timestamp: "2026-04-25T20:00:00+00:00" })),
+		).not.toBeNull();
+	});
+
+	it("breaks ties on equal timestamps deterministically by hash", () => {
+		const sameTime = "2026-04-25T20:00:00.000Z";
+		const cards = buildGallery([
+			rawReceipt({ hash: "b".repeat(64), timestamp: sameTime }),
+			rawReceipt({ hash: "a".repeat(64), timestamp: sameTime }),
+			rawReceipt({ hash: "c".repeat(64), timestamp: sameTime }),
+		]);
+		// All three timestamps tie; tie-break by hash ascending.
+		expect(cards.map((c) => c.hash)).toEqual([
+			"a".repeat(64),
+			"b".repeat(64),
+			"c".repeat(64),
+		]);
+	});
+
 	it("drops malformed receipts instead of throwing", () => {
 		// Missing required fields, bogus hash, wrong types — every one
 		// should silently drop, leaving the surviving valid card alone.

--- a/packages/docs/src/data/landing.ts
+++ b/packages/docs/src/data/landing.ts
@@ -164,6 +164,21 @@ export const ENGINES = {
 	],
 } as const;
 
+/** Receipts gallery — Wave 3.2 #257. Cards render between Engines and
+ * ProofStrip; data comes from `.maina/receipts/<hash>/receipt.json` at
+ * build time. Heading is locked copy; per-card text is generated from
+ * the receipts themselves and adheres to C2 ("passed N of M", never
+ * "0 findings"). */
+export const RECEIPTS_GALLERY = {
+	heading: "Recent verifications",
+	subheading:
+		"Real receipts from this repo. Each card is a cryptographic record of a merge — diff stats, status, and the checks that ran. Click through for the signed JSON and walkthrough.",
+	emptyState:
+		"receipts ship with each merge — none recorded yet for this build",
+	allReceiptsLabel: "all receipts",
+	allReceiptsHref: "/receipts/",
+} as const;
+
 /** ProofStrip receipts. */
 export const PROOF_STRIP = {
 	stats: [

--- a/packages/docs/src/data/receipts-gallery.ts
+++ b/packages/docs/src/data/receipts-gallery.ts
@@ -1,0 +1,156 @@
+/**
+ * Build-time helpers for the homepage receipts gallery (Wave 3.2 #257).
+ *
+ * The Astro component reads the JSON files via `import.meta.glob`; this
+ * module turns the raw shapes into the trimmed cards the UI renders.
+ *
+ * Pure functions only — kept out of the component so unit tests can
+ * exercise the empty state, sort order, copy discipline (C2), and the
+ * status-badge allow-list without spinning up a Vite/Astro environment.
+ */
+
+export interface RawReceipt {
+	prTitle?: unknown;
+	repo?: unknown;
+	timestamp?: unknown;
+	status?: unknown;
+	hash?: unknown;
+	walkthrough?: unknown;
+	diff?: {
+		files?: unknown;
+		additions?: unknown;
+		deletions?: unknown;
+	};
+	checks?: unknown[];
+}
+
+export type StatusBadge = "passed" | "failed" | "partial";
+
+export interface GalleryCard {
+	prTitle: string;
+	repo: string;
+	timestamp: string;
+	status: StatusBadge;
+	statusLabel: string;
+	hash: string;
+	hashShort: string;
+	href: string;
+	walkthrough: string;
+	diffSummary: string;
+	passed: number;
+	total: number;
+}
+
+const HEX64 = /^[0-9a-f]{64}$/;
+
+/**
+ * Build the receipt URL for a card. The Pages workflow stages
+ * `.maina/receipts/<hash>/` under `/receipts/` on the docs site, so this
+ * is the URL the gallery actually lands on. `linkBase` defaults to
+ * `/receipts/` — pass `/r/` to point at the polymorphic resolver once it
+ * ships (Wave 1.8).
+ */
+export function receiptHref(hash: string, linkBase = "/receipts/"): string {
+	const trimmed = linkBase.endsWith("/") ? linkBase : `${linkBase}/`;
+	return `${trimmed}${hash}/`;
+}
+
+/**
+ * Coerce + validate a single raw receipt into a card. Returns null if any
+ * required field is missing or shaped wrong — the gallery silently skips
+ * these so a single malformed receipt doesn't take the whole homepage out.
+ */
+export function toGalleryCard(
+	raw: RawReceipt,
+	options: { linkBase?: string } = {},
+): GalleryCard | null {
+	const hash = typeof raw.hash === "string" ? raw.hash : null;
+	if (!hash || !HEX64.test(hash)) return null;
+	const prTitle = typeof raw.prTitle === "string" ? raw.prTitle : null;
+	if (!prTitle) return null;
+	const repo = typeof raw.repo === "string" ? raw.repo : null;
+	if (!repo) return null;
+	const timestamp = typeof raw.timestamp === "string" ? raw.timestamp : null;
+	if (!timestamp) return null;
+	const status = normalizeStatus(raw.status);
+	if (!status) return null;
+	const walkthroughRaw =
+		typeof raw.walkthrough === "string" ? raw.walkthrough : "";
+	const walkthrough = trimWalkthrough(walkthroughRaw);
+
+	const checks = Array.isArray(raw.checks) ? raw.checks : [];
+	const passed = checks.filter(
+		(c): c is { status?: unknown } =>
+			typeof c === "object" &&
+			c !== null &&
+			(c as { status?: unknown }).status === "passed",
+	).length;
+	const total = checks.length;
+
+	const files = numOrZero(raw.diff?.files);
+	const additions = numOrZero(raw.diff?.additions);
+	const deletions = numOrZero(raw.diff?.deletions);
+	const diffSummary = `+${additions} / −${deletions} across ${files} file${files === 1 ? "" : "s"}`;
+
+	return {
+		prTitle,
+		repo,
+		timestamp,
+		status,
+		statusLabel: statusLabel(status, passed, total),
+		hash,
+		hashShort: hash.slice(0, 12),
+		href: receiptHref(hash, options.linkBase),
+		walkthrough,
+		diffSummary,
+		passed,
+		total,
+	};
+}
+
+/**
+ * Build the gallery from raw receipts: parse, drop malformed entries,
+ * sort newest first, slice to limit. `limit` defaults to 6 (the
+ * homepage shows a strip, not a backlog).
+ */
+export function buildGallery(
+	rawReceipts: RawReceipt[],
+	options: { limit?: number; linkBase?: string } = {},
+): GalleryCard[] {
+	const limit = options.limit ?? 6;
+	const cards = rawReceipts
+		.map((r) => toGalleryCard(r, { linkBase: options.linkBase }))
+		.filter((c): c is GalleryCard => c !== null);
+	cards.sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1));
+	return cards.slice(0, limit);
+}
+
+function normalizeStatus(raw: unknown): StatusBadge | null {
+	return raw === "passed" || raw === "failed" || raw === "partial" ? raw : null;
+}
+
+function statusLabel(
+	status: StatusBadge,
+	passed: number,
+	total: number,
+): string {
+	// C2 copy discipline: never "0 findings" / "no issues found".
+	if (total === 0) {
+		if (status === "passed") return "verified";
+		if (status === "partial") return "partial — see logs";
+		return "failed — see logs";
+	}
+	if (status === "passed") return `passed ${passed} of ${total} checks`;
+	if (status === "partial") return `partial — ${passed} of ${total} held`;
+	return `failed — ${passed} of ${total} held`;
+}
+
+function trimWalkthrough(raw: string): string {
+	const collapsed = raw.replace(/\s+/g, " ").trim();
+	if (collapsed.length <= 220) return collapsed;
+	return `${collapsed.slice(0, 217).replace(/\s+\S*$/, "")}…`;
+}
+
+function numOrZero(raw: unknown): number {
+	return typeof raw === "number" && Number.isFinite(raw) ? Math.trunc(raw) : 0;
+}

--- a/packages/docs/src/data/receipts-gallery.ts
+++ b/packages/docs/src/data/receipts-gallery.ts
@@ -71,7 +71,7 @@ export function toGalleryCard(
 	const repo = typeof raw.repo === "string" ? raw.repo : null;
 	if (!repo) return null;
 	const timestamp = typeof raw.timestamp === "string" ? raw.timestamp : null;
-	if (!timestamp) return null;
+	if (!timestamp || !isIsoTimestamp(timestamp)) return null;
 	const status = normalizeStatus(raw.status);
 	if (!status) return null;
 	const walkthroughRaw =
@@ -121,12 +121,27 @@ export function buildGallery(
 	const cards = rawReceipts
 		.map((r) => toGalleryCard(r, { linkBase: options.linkBase }))
 		.filter((c): c is GalleryCard => c !== null);
-	cards.sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1));
+	// Newest-first; equal timestamps fall back to hash for a deterministic
+	// total order. Returning 0 on full equality keeps the JS sort contract.
+	cards.sort((a, b) => {
+		if (a.timestamp !== b.timestamp) return a.timestamp < b.timestamp ? 1 : -1;
+		if (a.hash !== b.hash) return a.hash < b.hash ? -1 : 1;
+		return 0;
+	});
 	return cards.slice(0, limit);
 }
 
 function normalizeStatus(raw: unknown): StatusBadge | null {
 	return raw === "passed" || raw === "failed" || raw === "partial" ? raw : null;
+}
+
+const ISO_8601 =
+	/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function isIsoTimestamp(raw: string): boolean {
+	if (!ISO_8601.test(raw)) return false;
+	const t = Date.parse(raw);
+	return Number.isFinite(t);
 }
 
 function statusLabel(

--- a/packages/docs/src/pages/index.astro
+++ b/packages/docs/src/pages/index.astro
@@ -6,6 +6,7 @@ import HeroV2 from '../components/Hero.v2.astro';
 import PainStrip from '../components/PainStrip.astro';
 import Terminal from '../components/Terminal.astro';
 import Engines from '../components/Engines.astro';
+import ReceiptGallery from '../components/ReceiptGallery.astro';
 import ProofStrip from '../components/ProofStrip.astro';
 import StackFit from '../components/StackFit.astro';
 import Comparison from '../components/Comparison.astro';
@@ -109,6 +110,7 @@ const jsonLd = {
     <div class="band-bleed"><PainStrip /></div>
     <Terminal />
     <div class="band-bleed band-hairline"><Engines /></div>
+    <ReceiptGallery />
     <ProofStrip />
     <div class="band-bleed"><StackFit /></div>
     <Comparison />


### PR DESCRIPTION
Closes #257. Wave 3.2 brand surface.

## Summary

- New \`packages/docs/src/components/ReceiptGallery.astro\` reads \`.maina/receipts/*/receipt.json\` at build time via Vite's \`import.meta.glob\` and renders the 6 newest receipts as cards. Pure SSG — zero runtime JS.
- Each card: status badge (\`passed | partial | failed\` allow-list), short hash, PR title, walkthrough excerpt, diff summary, repo. Card is one big \`<a>\` to \`/receipts/<hash>/\` (the URL the Pages workflow now serves).
- \`packages/docs/src/data/receipts-gallery.ts\` holds the parsing/sort/copy-discipline logic as pure functions so unit tests don't need an Astro build. 6 tests cover: empty state, C2 copy discipline, status badge allow-list, link target, newest-first sort + limit, malformed-receipt resilience.
- Section sits between Engines and ProofStrip on the homepage. Empty state covers fresh checkouts where no receipts have been produced yet (gallery doesn't visibly break).
- \`linkBase\` option is plumbed through so we can swap \`/receipts/\` → \`/r/\` once the polymorphic resolver (Wave 1.8) ships.

## Why this matters

Direction doc 2026-04-25 calls out: a reader who lands on the homepage should see N actual receipts within 3 seconds. After this lands, they will. Wave 3.3 (\`#258\` distribution test) can then post the gallery URL with confidence.

## Test plan

- [x] \`bun test packages/docs/src/data/__tests__/receipts-gallery.test.ts\` — 6/6 pass
- [x] \`bun run typecheck\` — 0 errors
- [x] \`bun run build\` (Astro) succeeds; gallery rendered with 6 real receipts in \`dist/index.html\`
- [x] \`maina commit\` passes verify (13 tools)
- [ ] After merge: \`mainahq.com\` shows the gallery between Engines and ProofStrip with working per-receipt links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a receipts gallery section to the homepage displaying recent build verification records. Each gallery card shows verification status, shortened commit hash, PR title, walkthrough link, and a summary of changes for easy reference.

* **Tests**
  * Added comprehensive test suite for receipts gallery functionality, validating data transformation, status handling, sorting, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->