### PR TITLE
ci(docs): receipts index link-integrity guard (#269)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,13 @@ jobs:
       - name: Build docs
         run: cd packages/docs && bun run build
 
+      # Validate that every link in .maina/receipts/index.html resolves to
+      # an actual hash directory with both index.html and receipt.json on
+      # disk. Catches drift between hand-edits and the generator before
+      # we ship 404s to mainahq.com (#269).
+      - name: Receipt index link integrity
+        run: bun scripts/check-receipts-index.ts
+
       # Copy backfilled + future receipts into the published site so each
       # receipt is reachable at /receipts/<hash>/ on Pages. Receipts are
       # static HTML+JSON; Starlight is fine with sibling directories under

--- a/scripts/__tests__/check-receipts-index.test.ts
+++ b/scripts/__tests__/check-receipts-index.test.ts
@@ -58,6 +58,8 @@ describe("checkReceiptsIndex", () => {
 
 		const result = checkReceiptsIndex(indexPath, tmp);
 		expect(isClean(result)).toBe(true);
+		// total comes from the parse, not a re-read; covers the dedup-IO fix.
+		expect(result.total).toBe(2);
 	});
 
 	test("flags missing directories", () => {

--- a/scripts/__tests__/check-receipts-index.test.ts
+++ b/scripts/__tests__/check-receipts-index.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for the receipts index integrity check (#269).
+ *
+ * Each test sets up a temp directory with hand-crafted receipts +
+ * index.html, runs the checker, and asserts on the structured result
+ * (so the same logic can be reused from CI without parsing stderr).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { checkReceiptsIndex, isClean } from "../check-receipts-index";
+
+const HASH_A = "a".repeat(64);
+const HASH_B = "b".repeat(64);
+const HASH_C = "c".repeat(64);
+
+function buildIndex(hashes: string[]): string {
+	const links = hashes
+		.map(
+			(h) =>
+				`<tr><td><a href="./${h}/index.html">PR ${h.slice(0, 6)}</a></td></tr>`,
+		)
+		.join("\n");
+	return `<!DOCTYPE html><html><body><table>${links}</table></body></html>`;
+}
+
+let tmp: string;
+
+beforeEach(() => {
+	tmp = join(
+		"/tmp",
+		`maina-receipts-check-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	mkdirSync(tmp, { recursive: true });
+});
+
+afterEach(() => {
+	rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeReceipt(hash: string, files: { html?: boolean; json?: boolean }) {
+	mkdirSync(join(tmp, hash), { recursive: true });
+	if (files.html !== false) {
+		writeFileSync(join(tmp, hash, "index.html"), "<html></html>", "utf-8");
+	}
+	if (files.json !== false) {
+		writeFileSync(join(tmp, hash, "receipt.json"), "{}", "utf-8");
+	}
+}
+
+describe("checkReceiptsIndex", () => {
+	test("clean run when every link resolves", () => {
+		writeReceipt(HASH_A, {});
+		writeReceipt(HASH_B, {});
+		const indexPath = join(tmp, "index.html");
+		writeFileSync(indexPath, buildIndex([HASH_A, HASH_B]), "utf-8");
+
+		const result = checkReceiptsIndex(indexPath, tmp);
+		expect(isClean(result)).toBe(true);
+	});
+
+	test("flags missing directories", () => {
+		writeReceipt(HASH_A, {});
+		// HASH_B is in the index but never written to disk.
+		const indexPath = join(tmp, "index.html");
+		writeFileSync(indexPath, buildIndex([HASH_A, HASH_B]), "utf-8");
+
+		const result = checkReceiptsIndex(indexPath, tmp);
+		expect(isClean(result)).toBe(false);
+		expect(result.missingDirs).toEqual([HASH_B]);
+	});
+
+	test("flags directories missing index.html or receipt.json", () => {
+		writeReceipt(HASH_A, { html: false });
+		writeReceipt(HASH_B, { json: false });
+		const indexPath = join(tmp, "index.html");
+		writeFileSync(indexPath, buildIndex([HASH_A, HASH_B]), "utf-8");
+
+		const result = checkReceiptsIndex(indexPath, tmp);
+		expect(result.missingHtml).toEqual([HASH_A]);
+		expect(result.missingJson).toEqual([HASH_B]);
+		expect(isClean(result)).toBe(false);
+	});
+
+	test("flags duplicate links", () => {
+		writeReceipt(HASH_A, {});
+		const indexPath = join(tmp, "index.html");
+		// Same hash linked twice — the on-disk dir is fine, but the index
+		// is malformed.
+		writeFileSync(indexPath, buildIndex([HASH_A, HASH_A]), "utf-8");
+
+		const result = checkReceiptsIndex(indexPath, tmp);
+		expect(result.duplicateHashes).toEqual([HASH_A]);
+		expect(isClean(result)).toBe(false);
+	});
+
+	test("ignores hashes that don't match the 64-hex pattern", () => {
+		writeReceipt(HASH_A, {});
+		const indexPath = join(tmp, "index.html");
+		// Add a stray short link that the regex shouldn't match — the
+		// checker should ignore it cleanly rather than blow up.
+		const html = `${buildIndex([HASH_A])}<a href="./not-hex/index.html">x</a>`;
+		writeFileSync(indexPath, html, "utf-8");
+
+		const result = checkReceiptsIndex(indexPath, tmp);
+		expect(isClean(result)).toBe(true);
+	});
+
+	test("handles an empty index (no receipt links yet)", () => {
+		const indexPath = join(tmp, "index.html");
+		writeFileSync(indexPath, "<!DOCTYPE html><html></html>", "utf-8");
+
+		const result = checkReceiptsIndex(indexPath, tmp);
+		expect(isClean(result)).toBe(true);
+	});
+
+	test("aggregates several failure modes in one run", () => {
+		writeReceipt(HASH_A, {}); // ok
+		writeReceipt(HASH_B, { html: false }); // missing html
+		// HASH_C: not written at all
+		const indexPath = join(tmp, "index.html");
+		writeFileSync(indexPath, buildIndex([HASH_A, HASH_B, HASH_C]), "utf-8");
+
+		const result = checkReceiptsIndex(indexPath, tmp);
+		expect(result.missingHtml).toEqual([HASH_B]);
+		expect(result.missingDirs).toEqual([HASH_C]);
+		expect(result.missingJson).toEqual([]);
+		expect(isClean(result)).toBe(false);
+	});
+});

--- a/scripts/check-receipts-index.ts
+++ b/scripts/check-receipts-index.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env bun
+/**
+ * Receipts index link-integrity guard (#269).
+ *
+ * Parses `.maina/receipts/index.html`, extracts every per-receipt link
+ * (`href="./<64-hex>/index.html"`), and asserts:
+ *   1. every linked hash directory exists on disk under `.maina/receipts/`
+ *   2. each directory contains both `index.html` and `receipt.json`
+ *   3. no link is duplicated
+ *   4. the index file itself exists when the receipts directory does
+ *
+ * Exits 0 on clean, 1 on any failure (prints the offending hashes for
+ * grep-to-IDE navigation). The Pages workflow runs this before staging
+ * receipts under `dist/` so we never publish a 404 to mainahq.com.
+ *
+ * Run manually:
+ *     bun scripts/check-receipts-index.ts
+ *
+ * CI wires this in via the docs.yml "Stage receipts" step.
+ */
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const RECEIPTS_DIR = ".maina/receipts";
+const INDEX_PATH = join(RECEIPTS_DIR, "index.html");
+const HASH_HREF = /href="\.\/([0-9a-f]{64})\/index\.html"/g;
+
+interface CheckResult {
+	missingDirs: string[];
+	missingHtml: string[];
+	missingJson: string[];
+	duplicateHashes: string[];
+}
+
+export function checkReceiptsIndex(
+	indexPath: string,
+	receiptsDir: string,
+): CheckResult {
+	const result: CheckResult = {
+		missingDirs: [],
+		missingHtml: [],
+		missingJson: [],
+		duplicateHashes: [],
+	};
+
+	const html = readFileSync(indexPath, "utf-8");
+	const matches = [...html.matchAll(HASH_HREF)];
+	const hashes = matches.map((m) => m[1]).filter((h): h is string => !!h);
+
+	const seen = new Set<string>();
+	for (const hash of hashes) {
+		if (seen.has(hash)) {
+			result.duplicateHashes.push(hash);
+			continue;
+		}
+		seen.add(hash);
+
+		const dir = join(receiptsDir, hash);
+		if (!existsSync(dir) || !statSync(dir).isDirectory()) {
+			result.missingDirs.push(hash);
+			continue;
+		}
+		if (!existsSync(join(dir, "index.html"))) result.missingHtml.push(hash);
+		if (!existsSync(join(dir, "receipt.json"))) result.missingJson.push(hash);
+	}
+	return result;
+}
+
+export function isClean(r: CheckResult): boolean {
+	return (
+		r.missingDirs.length === 0 &&
+		r.missingHtml.length === 0 &&
+		r.missingJson.length === 0 &&
+		r.duplicateHashes.length === 0
+	);
+}
+
+function reportAndExit(r: CheckResult, total: number): never {
+	if (isClean(r)) {
+		process.stdout.write(
+			`Receipt index integrity: ${total} link(s) checked, all resolve.\n`,
+		);
+		process.exit(0);
+	}
+	process.stderr.write("Receipt index integrity FAILED:\n");
+	for (const h of r.missingDirs) {
+		process.stderr.write(`  missing directory: ${h.slice(0, 12)}…\n`);
+	}
+	for (const h of r.missingHtml) {
+		process.stderr.write(`  missing index.html: ${h.slice(0, 12)}…\n`);
+	}
+	for (const h of r.missingJson) {
+		process.stderr.write(`  missing receipt.json: ${h.slice(0, 12)}…\n`);
+	}
+	for (const h of r.duplicateHashes) {
+		process.stderr.write(`  duplicate link: ${h.slice(0, 12)}…\n`);
+	}
+	process.exit(1);
+}
+
+if (import.meta.main) {
+	if (!existsSync(RECEIPTS_DIR)) {
+		// No receipts directory at all → nothing to check (e.g. fresh
+		// checkout). The docs workflow has its own "fail if missing"
+		// guard for the publish path; this script stays advisory here.
+		process.stdout.write("Receipts directory absent — nothing to check.\n");
+		process.exit(0);
+	}
+	if (!existsSync(INDEX_PATH)) {
+		process.stderr.write(
+			`Receipts directory exists but ${INDEX_PATH} is missing.\n`,
+		);
+		process.exit(1);
+	}
+	const result = checkReceiptsIndex(INDEX_PATH, RECEIPTS_DIR);
+	const html = readFileSync(INDEX_PATH, "utf-8");
+	const total = [...html.matchAll(HASH_HREF)].length;
+	reportAndExit(result, total);
+}

--- a/scripts/check-receipts-index.ts
+++ b/scripts/check-receipts-index.ts
@@ -26,11 +26,26 @@ const RECEIPTS_DIR = ".maina/receipts";
 const INDEX_PATH = join(RECEIPTS_DIR, "index.html");
 const HASH_HREF = /href="\.\/([0-9a-f]{64})\/index\.html"/g;
 
-interface CheckResult {
+export interface CheckResult {
 	missingDirs: string[];
 	missingHtml: string[];
 	missingJson: string[];
 	duplicateHashes: string[];
+	/** Total link count seen in the index (including duplicates). Computed
+	 * once during parse so the CLI doesn't have to re-read + re-regex the
+	 * index file just to print the count. */
+	total: number;
+}
+
+/** True when `statSync` reports a directory. Wrapped in try/catch because
+ * a TOCTOU race or a permission flip between `existsSync` and `statSync`
+ * would otherwise crash the guard with an unstructured throw. */
+function isDirectorySafe(dir: string): boolean {
+	try {
+		return statSync(dir).isDirectory();
+	} catch {
+		return false;
+	}
 }
 
 export function checkReceiptsIndex(
@@ -42,11 +57,13 @@ export function checkReceiptsIndex(
 		missingHtml: [],
 		missingJson: [],
 		duplicateHashes: [],
+		total: 0,
 	};
 
 	const html = readFileSync(indexPath, "utf-8");
 	const matches = [...html.matchAll(HASH_HREF)];
 	const hashes = matches.map((m) => m[1]).filter((h): h is string => !!h);
+	result.total = hashes.length;
 
 	const seen = new Set<string>();
 	for (const hash of hashes) {
@@ -57,7 +74,7 @@ export function checkReceiptsIndex(
 		seen.add(hash);
 
 		const dir = join(receiptsDir, hash);
-		if (!existsSync(dir) || !statSync(dir).isDirectory()) {
+		if (!isDirectorySafe(dir)) {
 			result.missingDirs.push(hash);
 			continue;
 		}
@@ -76,25 +93,27 @@ export function isClean(r: CheckResult): boolean {
 	);
 }
 
-function reportAndExit(r: CheckResult, total: number): never {
+function reportAndExit(r: CheckResult): never {
 	if (isClean(r)) {
 		process.stdout.write(
-			`Receipt index integrity: ${total} link(s) checked, all resolve.\n`,
+			`Receipt index integrity: ${r.total} link(s) checked, all resolve.\n`,
 		);
 		process.exit(0);
 	}
 	process.stderr.write("Receipt index integrity FAILED:\n");
+	// Print full hashes so the offending directory is grep-uniquely
+	// identifiable — short prefixes can collide.
 	for (const h of r.missingDirs) {
-		process.stderr.write(`  missing directory: ${h.slice(0, 12)}…\n`);
+		process.stderr.write(`  missing directory: ${h}\n`);
 	}
 	for (const h of r.missingHtml) {
-		process.stderr.write(`  missing index.html: ${h.slice(0, 12)}…\n`);
+		process.stderr.write(`  missing index.html: ${h}\n`);
 	}
 	for (const h of r.missingJson) {
-		process.stderr.write(`  missing receipt.json: ${h.slice(0, 12)}…\n`);
+		process.stderr.write(`  missing receipt.json: ${h}\n`);
 	}
 	for (const h of r.duplicateHashes) {
-		process.stderr.write(`  duplicate link: ${h.slice(0, 12)}…\n`);
+		process.stderr.write(`  duplicate link: ${h}\n`);
 	}
 	process.exit(1);
 }
@@ -113,8 +132,5 @@ if (import.meta.main) {
 		);
 		process.exit(1);
 	}
-	const result = checkReceiptsIndex(INDEX_PATH, RECEIPTS_DIR);
-	const html = readFileSync(INDEX_PATH, "utf-8");
-	const total = [...html.matchAll(HASH_HREF)].length;
-	reportAndExit(result, total);
+	reportAndExit(checkReceiptsIndex(INDEX_PATH, RECEIPTS_DIR));
 }


### PR DESCRIPTION
Closes #269.

## Summary

- New \`scripts/check-receipts-index.ts\` parses \`.maina/receipts/index.html\` and asserts: every per-receipt link resolves to an on-disk hash directory containing both \`index.html\` and \`receipt.json\`, and no link is duplicated.
- Wired into \`.github/workflows/docs.yml\` between \"Build docs\" and \"Stage receipts under docs dist\" so a malformed index fails CI before the artefact uploads to Pages — i.e. we never publish a 404.
- 7 tests in \`scripts/__tests__/check-receipts-index.test.ts\` cover the clean path, missing dir, missing per-receipt files, duplicate links, malformed (non-hex) hrefs, empty index, and an aggregated multi-failure case.
- The script ignores anything that doesn't match the 64-hex pattern, so it won't trip on stray markup or future link styles.

## Why this matters

Wave 3.2 just shipped the gallery + Pages publish pipeline. The published receipts are the brand surface — a 404 there is loud and embarrassing. This guard catches the drift class CodeRabbit flagged on #266: typo in the index, missing folder copy, or a hand-edit that never got the matching directory committed.

## Test plan

- [x] \`bun test scripts/__tests__/check-receipts-index.test.ts\` — 7/7 pass
- [x] \`bun scripts/check-receipts-index.ts\` against current repo prints \"10 link(s) checked, all resolve\"
- [x] \`maina commit\` passes verify
- [ ] After merge: docs.yml runs the guard before staging; any future drift fails the workflow loudly

🤖 Generated with [Claude Code](https://claude.com/claude-code)