### PR TITLE
feat(docs): landing analytics + UTM source attribution (MAI-4)

### DIFF
--- a/docs/launch/utm-link-pack.md
+++ b/docs/launch/utm-link-pack.md
@@ -1,0 +1,114 @@
+# UTM link pack — source-attribution playbook
+
+Every public post that points at `mainahq.com` should use one of the links below. The landing page captures `utm_*` + `ref` on first touch into `sessionStorage`, then forwards the same payload to `/api/waitlist` (and the mailto fallback today) so we can answer the only question that matters: **what channel sent us the people who joined the beta?**
+
+Companion: [WaitlistForm.astro](../../packages/docs/src/components/WaitlistForm.astro), [astro.config.mjs](../../packages/docs/astro.config.mjs) (UTM capture lives in the head injection).
+
+## Convention
+
+```
+?utm_source=<channel>&utm_medium=<format>&utm_campaign=<post-or-launch>&utm_content=<variant>
+```
+
+- `utm_source` — the platform (e.g. `hn`, `x`, `lobsters`, `reddit`, `devto`, `cto-newsletter`).
+- `utm_medium` — the format (e.g. `post`, `comment`, `reply`, `bio`, `dm`, `email`).
+- `utm_campaign` — slug for the specific post or launch (e.g. `show-hn-may`, `context-cost-thread`).
+- `utm_content` — A/B variant when we test multiple framings of the same post.
+
+Keep slugs lowercase, hyphenated, ≤32 chars. Reuse the same `utm_campaign` across all posts that promote the same artifact so we can roll them up.
+
+## Ready-to-paste links
+
+### Hacker News — Show HN (launch)
+
+```
+https://mainahq.com/?utm_source=hn&utm_medium=post&utm_campaign=show-hn-launch
+```
+
+### Hacker News — top-level comment in a related thread
+
+```
+https://mainahq.com/?utm_source=hn&utm_medium=comment&utm_campaign=hn-thread-ai-codegen
+```
+
+### Twitter / X — main launch tweet
+
+```
+https://mainahq.com/?utm_source=x&utm_medium=post&utm_campaign=show-hn-launch
+```
+
+### Twitter / X — reply in a thread
+
+```
+https://mainahq.com/?utm_source=x&utm_medium=reply&utm_campaign=show-hn-launch
+```
+
+### Twitter / X — bio link
+
+```
+https://mainahq.com/?utm_source=x&utm_medium=bio&utm_campaign=evergreen
+```
+
+### Lobsters
+
+```
+https://mainahq.com/?utm_source=lobsters&utm_medium=post&utm_campaign=show-hn-launch
+```
+
+### Reddit — `/r/programming`, `/r/MachineLearning`, etc.
+
+```
+https://mainahq.com/?utm_source=reddit&utm_medium=post&utm_campaign=show-hn-launch&utm_content=r-programming
+```
+
+Swap `utm_content` per subreddit (e.g. `r-machinelearning`, `r-typescript`) so we know which subs converted.
+
+### dev.to / Hashnode cross-posts
+
+```
+https://mainahq.com/?utm_source=devto&utm_medium=article&utm_campaign=context-cost-deep-dive
+```
+
+### Newsletter mentions (e.g. TLDR, Bytes, AI Engineer)
+
+```
+https://mainahq.com/?utm_source=tldr&utm_medium=email&utm_campaign=may-2026-feature
+```
+
+### Direct CTO outreach (1:1 DM/email)
+
+```
+https://mainahq.com/?utm_source=outreach&utm_medium=dm&utm_campaign=cto-may-batch-1
+```
+
+Substitute `utm_source=ceo-outreach` for CEO-sent links so we can separate the two pipelines in waitlist reporting.
+
+### Talks / podcasts / conference references
+
+```
+https://mainahq.com/?utm_source=podcast&utm_medium=show-notes&utm_campaign=<show-slug>
+```
+
+## How attribution flows
+
+```
+visitor lands → utm-capture script writes maina_attrib to sessionStorage (first touch wins)
+              → user navigates within the site (attribution persists across navigation)
+              → user submits /cloud waitlist
+                → fetch payload includes utm_* + referrer + landing_path
+                  → Cloudflare Worker (mainahq/maina-cloud, MAI-12) persists row
+                → mailto fallback body also embeds the attribution block
+              → Plausible "Waitlist Submit" custom event fires with utm_source/medium/campaign as props
+```
+
+Pageviews + outbound clicks land in Plausible (`PUBLIC_PLAUSIBLE_DOMAIN=mainahq.com` set in Cloudflare Pages env). Waitlist submissions land in the Worker store + Plausible custom events. Cross-reference by `utm_campaign` to compute view → waitlist conversion per channel.
+
+## Local dev / preview
+
+If `PUBLIC_PLAUSIBLE_DOMAIN` is unset (default), no analytics tag is emitted — UTM capture still works, attribution still rides on waitlist submissions, but pageview rollups are skipped. This is intentional so preview deploys don't pollute the prod Plausible site.
+
+## When NOT to use these
+
+- Do **not** put UTM params on links **inside** the site — `sessionStorage` is first-touch only, so internal nav with `?utm_source=...` would no-op anyway, but it pollutes the URL for users sharing the link onwards.
+- Do **not** use them on transactional email links (password resets, receipt emails). Reserve `utm_*` for acquisition surfaces.
+- Do **not** invent new `utm_source` values without adding them above — channel sprawl makes the rollup useless.

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -8,6 +8,9 @@ import starlightLlmsTxt from 'starlight-llms-txt';
 // emitted. Pageviews + outbound-link clicks + tagged events ("install
 // copy", "waitlist submit") are the only signals; no cookies, no PII.
 // See docs/launch/utm-link-pack.md for the source-attribution playbook.
+// AnalyticsHead.astro is the shared partial; it's imported into the
+// standalone pages (`index.astro`, `cloud.astro`) and the snippet below
+// is the same content for Starlight-rendered pages.
 const PLAUSIBLE_DOMAIN = process.env.PUBLIC_PLAUSIBLE_DOMAIN || '';
 const PLAUSIBLE_SRC =
   process.env.PUBLIC_PLAUSIBLE_SRC ||
@@ -31,10 +34,6 @@ const analyticsHead = PLAUSIBLE_DOMAIN
     ]
   : [];
 
-// UTM capture — runs on every page load, stashes any utm_* + referrer +
-// landing path in sessionStorage so WaitlistForm.astro can forward them
-// with the submission (works for both the fetch path and the mailto
-// fallback). Sized for inline injection; no external request.
 const utmCaptureHead = [
   {
     tag: 'script',
@@ -49,8 +48,6 @@ const utmCaptureHead = [
     fields.forEach(function(f){var v=params.get(f); if(v){found[f]=v.slice(0,128); hasAny=true;}});
     var prior={};
     try { prior=JSON.parse(sessionStorage.getItem(KEY)||'{}'); } catch(e) {}
-    // First-touch attribution: only overwrite if we have new utm params,
-    // otherwise keep the prior value so a deeper page-nav doesn't wipe it.
     if (hasAny) {
       found.referrer = document.referrer || prior.referrer || '';
       found.landing_path = window.location.pathname + window.location.search;

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -3,6 +3,71 @@ import starlight from '@astrojs/starlight';
 import tailwindcss from '@tailwindcss/vite';
 import starlightLlmsTxt from 'starlight-llms-txt';
 
+// Plausible domain is opt-in via env var. Unset (e.g. local dev, previews,
+// or a build before Cloudflare Pages is wired) → no analytics tag is
+// emitted. Pageviews + outbound-link clicks + tagged events ("install
+// copy", "waitlist submit") are the only signals; no cookies, no PII.
+// See docs/launch/utm-link-pack.md for the source-attribution playbook.
+const PLAUSIBLE_DOMAIN = process.env.PUBLIC_PLAUSIBLE_DOMAIN || '';
+const PLAUSIBLE_SRC =
+  process.env.PUBLIC_PLAUSIBLE_SRC ||
+  'https://plausible.io/js/script.tagged-events.outbound-links.js';
+
+const analyticsHead = PLAUSIBLE_DOMAIN
+  ? [
+      {
+        tag: 'script',
+        attrs: {
+          defer: true,
+          'data-domain': PLAUSIBLE_DOMAIN,
+          src: PLAUSIBLE_SRC,
+        },
+      },
+      {
+        tag: 'script',
+        content:
+          'window.plausible=window.plausible||function(){(window.plausible.q=window.plausible.q||[]).push(arguments)};',
+      },
+    ]
+  : [];
+
+// UTM capture — runs on every page load, stashes any utm_* + referrer +
+// landing path in sessionStorage so WaitlistForm.astro can forward them
+// with the submission (works for both the fetch path and the mailto
+// fallback). Sized for inline injection; no external request.
+const utmCaptureHead = [
+  {
+    tag: 'script',
+    content: `
+(function(){
+  try {
+    var KEY='maina_attrib';
+    var params=new URLSearchParams(window.location.search);
+    var fields=['utm_source','utm_medium','utm_campaign','utm_content','utm_term','ref','gclid'];
+    var found={};
+    var hasAny=false;
+    fields.forEach(function(f){var v=params.get(f); if(v){found[f]=v.slice(0,128); hasAny=true;}});
+    var prior={};
+    try { prior=JSON.parse(sessionStorage.getItem(KEY)||'{}'); } catch(e) {}
+    // First-touch attribution: only overwrite if we have new utm params,
+    // otherwise keep the prior value so a deeper page-nav doesn't wipe it.
+    if (hasAny) {
+      found.referrer = document.referrer || prior.referrer || '';
+      found.landing_path = window.location.pathname + window.location.search;
+      found.landing_at = new Date().toISOString();
+      sessionStorage.setItem(KEY, JSON.stringify(found));
+    } else if (!prior.landing_path) {
+      prior.referrer = document.referrer || '';
+      prior.landing_path = window.location.pathname + window.location.search;
+      prior.landing_at = new Date().toISOString();
+      sessionStorage.setItem(KEY, JSON.stringify(prior));
+    }
+  } catch(e) {}
+})();
+`.trim(),
+  },
+];
+
 export default defineConfig({
   site: 'https://mainahq.com',
   base: '/',
@@ -13,6 +78,7 @@ export default defineConfig({
   },
   integrations: [
     starlight({
+      head: [...analyticsHead, ...utmCaptureHead],
       plugins: [
         starlightLlmsTxt({
           projectName: 'Maina',

--- a/packages/docs/src/components/AnalyticsHead.astro
+++ b/packages/docs/src/components/AnalyticsHead.astro
@@ -1,0 +1,65 @@
+---
+/**
+ * AnalyticsHead — drop into every <head>: Starlight pages (via the
+ * `head` config in astro.config.mjs), and the standalone pages
+ * `index.astro` and `cloud.astro` which build their own <html>/<head>.
+ *
+ * Two scripts, both env-gated for safety:
+ *
+ *   1. Plausible — opt-in via PUBLIC_PLAUSIBLE_DOMAIN. Unset → tag
+ *      omitted, zero outbound requests, no console noise.
+ *   2. UTM capture — always emitted. Tiny inline script writes any
+ *      `utm_*` / `ref` / `gclid` from the landing URL to
+ *      sessionStorage (first-touch wins) so WaitlistForm can forward
+ *      the attribution.
+ *
+ * Companion: docs/launch/utm-link-pack.md and
+ * src/components/WaitlistForm.astro.
+ */
+const PLAUSIBLE_DOMAIN = import.meta.env.PUBLIC_PLAUSIBLE_DOMAIN ?? '';
+const PLAUSIBLE_SRC =
+  import.meta.env.PUBLIC_PLAUSIBLE_SRC ??
+  'https://plausible.io/js/script.tagged-events.outbound-links.js';
+---
+
+{PLAUSIBLE_DOMAIN && (
+  <>
+    <script
+      is:inline
+      defer
+      data-domain={PLAUSIBLE_DOMAIN}
+      src={PLAUSIBLE_SRC}
+    />
+    <script is:inline>
+      {`window.plausible=window.plausible||function(){(window.plausible.q=window.plausible.q||[]).push(arguments)};`}
+    </script>
+  </>
+)}
+
+<script is:inline>
+  {`
+(function(){
+  try {
+    var KEY='maina_attrib';
+    var params=new URLSearchParams(window.location.search);
+    var fields=['utm_source','utm_medium','utm_campaign','utm_content','utm_term','ref','gclid'];
+    var found={};
+    var hasAny=false;
+    fields.forEach(function(f){var v=params.get(f); if(v){found[f]=v.slice(0,128); hasAny=true;}});
+    var prior={};
+    try { prior=JSON.parse(sessionStorage.getItem(KEY)||'{}'); } catch(e) {}
+    if (hasAny) {
+      found.referrer = document.referrer || prior.referrer || '';
+      found.landing_path = window.location.pathname + window.location.search;
+      found.landing_at = new Date().toISOString();
+      sessionStorage.setItem(KEY, JSON.stringify(found));
+    } else if (!prior.landing_path) {
+      prior.referrer = document.referrer || '';
+      prior.landing_path = window.location.pathname + window.location.search;
+      prior.landing_at = new Date().toISOString();
+      sessionStorage.setItem(KEY, JSON.stringify(prior));
+    }
+  } catch(e) {}
+})();
+`}
+</script>

--- a/packages/docs/src/components/WaitlistForm.astro
+++ b/packages/docs/src/components/WaitlistForm.astro
@@ -132,6 +132,37 @@ const mailtoHref = `mailto:${WAITLIST.mailto}?subject=${mailtoSubject}&body=${ma
     const thankyou = document.querySelector('[data-waitlist-thankyou]');
     const fallback = form.querySelector('[data-waitlist-fallback]');
 
+    // Attribution captured on landing by the head-injected utm-capture
+    // script (see astro.config.mjs). First-touch wins; all values are
+    // string-typed and <=128 chars. Returns {} when none was captured.
+    function readAttribution() {
+      try {
+        return JSON.parse(sessionStorage.getItem('maina_attrib') || '{}');
+      } catch (e) {
+        return {};
+      }
+    }
+
+    // Rewrite the form's mailto action so the source attribution is in
+    // the email body too — works for the JS-disabled path and for the
+    // fetch path's fallback.
+    function refreshMailtoAction() {
+      var a = readAttribution();
+      var parts = [];
+      Object.keys(a).forEach(function (k) {
+        if (a[k]) parts.push(k + ': ' + a[k]);
+      });
+      if (!parts.length) return;
+      var current = form.getAttribute('action') || '';
+      var marker = '%0A%0A--%20attribution%20--%0A';
+      var base = current.split(marker)[0];
+      form.setAttribute(
+        'action',
+        base + marker + encodeURIComponent(parts.join('\n')),
+      );
+    }
+    refreshMailtoAction();
+
     form.addEventListener('submit', function (ev) {
       const fd = new FormData(form);
       const email = String(fd.get('email') || '');
@@ -145,13 +176,38 @@ const mailtoHref = `mailto:${WAITLIST.mailto}?subject=${mailtoSubject}&body=${ma
       // the native action (mailto) fire.
       if (!endpoint || typeof fetch !== 'function') return;
       ev.preventDefault();
+      const attribution = readAttribution();
       const payload = {
         email,
         role,
         team_size: team,
         company: String(fd.get('company') || '').trim() || undefined,
         notes: String(fd.get('notes') || '').trim() || undefined,
+        utm_source: attribution.utm_source || undefined,
+        utm_medium: attribution.utm_medium || undefined,
+        utm_campaign: attribution.utm_campaign || undefined,
+        utm_content: attribution.utm_content || undefined,
+        utm_term: attribution.utm_term || undefined,
+        ref: attribution.ref || undefined,
+        gclid: attribution.gclid || undefined,
+        referrer: attribution.referrer || undefined,
+        landing_path: attribution.landing_path || undefined,
+        landing_at: attribution.landing_at || undefined,
       };
+      // Plausible custom event — fires whether or not the backend
+      // responds successfully, so /cloud waitlist conversion is
+      // measurable today via the mailto path too.
+      if (typeof window.plausible === 'function') {
+        window.plausible('Waitlist Submit', {
+          props: {
+            role: role,
+            team_size: team,
+            utm_source: attribution.utm_source || '(none)',
+            utm_medium: attribution.utm_medium || '(none)',
+            utm_campaign: attribution.utm_campaign || '(none)',
+          },
+        });
+      }
       fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/packages/docs/src/pages/cloud.astro
+++ b/packages/docs/src/pages/cloud.astro
@@ -8,6 +8,7 @@ import DemoBooking from '../components/DemoBooking.astro';
 import CloudFaq from '../components/CloudFaq.astro';
 import CloudFinalCta from '../components/CloudFinalCta.astro';
 import Footer from '../components/Footer.astro';
+import AnalyticsHead from '../components/AnalyticsHead.astro';
 import { CLOUD_META } from '../data/cloud-landing';
 import { NAV } from '../data/landing';
 import '../styles/landing.css';
@@ -71,6 +72,7 @@ const jsonLd = {
     )}
     <link rel="icon" href={`${base}/favicon.svg`} type="image/svg+xml" />
     <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+    <AnalyticsHead />
   </head>
   <body>
     <nav class="nav">

--- a/packages/docs/src/pages/index.astro
+++ b/packages/docs/src/pages/index.astro
@@ -13,6 +13,7 @@ import Comparison from '../components/Comparison.astro';
 import FinalCta from '../components/FinalCta.astro';
 import Faq from '../components/Faq.astro';
 import Footer from '../components/Footer.astro';
+import AnalyticsHead from '../components/AnalyticsHead.astro';
 import { META, NAV } from '../data/landing';
 import cliPackage from '../../../cli/package.json';
 import '../styles/landing.css';
@@ -80,6 +81,7 @@ const jsonLd = {
     )}
     <link rel="icon" href={`${base}/favicon.svg`} type="image/svg+xml" />
     <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+    <AnalyticsHead />
   </head>
   <body>
     <nav class="nav">


### PR DESCRIPTION
## Summary

Closes the **instrumentation** half of MAI-4 (`Ship mainahq.com landing page with waitlist and analytics`). The page is already live, the waitlist UI is already shipped (#205), the brand is in place — what was missing was the ability to **measure** anything.

Three pieces, all env-gated so they no-op in local dev / unconfigured previews:

1. **Plausible** in the Starlight `head`, opt-in via `PUBLIC_PLAUSIBLE_DOMAIN`. Pageviews + outbound-link clicks + tagged custom events (`Waitlist Submit`). No cookies, no PII, GDPR-clean — fits the *"no telemetry by default"* brand line. Each custom event carries `role`, `team_size`, `utm_source/medium/campaign` as props so channel rollups work inside Plausible.
2. **UTM capture** — small inline script in the head writes any `utm_*` / `ref` / `gclid` from the landing URL to `sessionStorage` (first-touch, ≤128 chars per field) alongside `referrer`, `landing_path`, `landing_at`. Persists across internal nav, so the waitlist submission carries the original source.
3. **`WaitlistForm.astro` forwarding** — JSON payload to `/api/waitlist` now includes the attribution fields, AND the `mailto:` fallback action is rewritten on load to append a `-- attribution --` block, so source data still reaches `beta@mainahq.com` while the Cloudflare Worker is being wired up.

Plus `docs/launch/utm-link-pack.md` — copy-paste link pack for HN / X / Lobsters / Reddit / dev.to / newsletters / CEO outreach. Uses canonical `utm_source` slugs so the Plausible and waitlist-store rollups stay clean.

## Why this shape (env-driven Plausible vs. PostHog)

- `PUBLIC_PLAUSIBLE_DOMAIN` unset → zero analytics tag, zero outbound requests. Same fast-path the brand promises in product.
- Plausible's tagged-events script ships in ~1 KB and supports cookie-free attribution out of the box; PostHog is the right call for product telemetry (and already in `packages/core`) but is heavier than the marketing surface needs.
- If the team would rather use PostHog here too, swap the two `analyticsHead` script tags — the rest of this PR (UTM capture, attribution forwarding, link pack) is vendor-agnostic.

## What unblocks once this merges

- Set `PUBLIC_PLAUSIBLE_DOMAIN=mainahq.com` (+ optional `PUBLIC_PLAUSIBLE_SRC` if the project uses a self-hosted instance) in Cloudflare Pages env → pageview + click + waitlist-conversion data flowing within minutes.
- Use the link pack on every public surface — no further frontend change needed per channel.

## Still needed (tracked separately)

- **MAI-12** — CTO routes `mainahq.com/api/waitlist` to the Cloudflare Worker in `mainahq/maina-cloud` so structured rows land in a queryable store. Today the mailto fallback already carries the attribution to inbox, so this PR is useful even before MAI-12 lands.

## Test plan

- [ ] `bun --filter @mainahq/docs build` succeeds with `PUBLIC_PLAUSIBLE_DOMAIN` unset (no `<script src="plausible…">` in the rendered HTML).
- [ ] `PUBLIC_PLAUSIBLE_DOMAIN=mainahq.com bun --filter @mainahq/docs build` emits exactly one Plausible tag with `data-domain="mainahq.com"`.
- [ ] Visit `/cloud?utm_source=hn&utm_medium=post&utm_campaign=show-hn-launch` in a built preview, navigate to `/`, return to `/cloud`, submit the form: confirm `sessionStorage.maina_attrib` retains the original UTMs across nav, and confirm the JSON payload + mailto body both carry the attribution block.
- [ ] Console has no errors when the head-injected scripts run (Safari, Chrome, Firefox; private-browsing modes where `sessionStorage` is restricted should also no-op cleanly — both scripts are wrapped in `try/catch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added UTM link pack documentation with standardized link construction guidelines and channel-specific examples.

* **New Features**
  * Implemented source attribution tracking with UTM parameters captured on initial page load and persisted across navigation.
  * Enhanced waitlist form with attribution data collection and analytics event tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mainahq/maina/pull/278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->