### PR TITLE
feat(docs): point waitlist form to api.mainahq.com (MAI-12)

### DIFF
--- a/packages/docs/src/components/WaitlistForm.astro
+++ b/packages/docs/src/components/WaitlistForm.astro
@@ -8,11 +8,12 @@
  * the form with a thank-you panel. On 4xx/5xx or network error, the
  * form shows a fallback `mailto:` link.
  *
- * Backend decision (2026-04-21): a `@workkit`-built Cloudflare Worker
- * landing in the private `mainahq/maina-cloud` repo owns POST
- * `/api/waitlist`. Until the Worker ships, POSTs 404 and the mailto
- * fallback covers submission end-to-end. No frontend change is
- * needed when the Worker goes live.
+ * Backend: the `@workkit`-built Cloudflare Worker in the private
+ * `mainahq/maina-cloud` repo owns POST `/api/waitlist`. Apex
+ * `mainahq.com` is served by GitHub Pages / Fastly (no PUT/POST
+ * support), so the form posts cross-origin to the Worker's custom
+ * domain `api.mainahq.com`. CORS on the Worker pins
+ * `Access-Control-Allow-Origin: https://mainahq.com` (MAI-12).
  */
 import { WAITLIST } from '../data/cloud-landing';
 
@@ -41,7 +42,7 @@ const mailtoHref = `mailto:${WAITLIST.mailto}?subject=${mailtoSubject}&body=${ma
     action={mailtoHref}
     method="post"
     enctype="text/plain"
-    data-waitlist-endpoint="/api/waitlist"
+    data-waitlist-endpoint="https://api.mainahq.com/api/waitlist"
     novalidate
   >
     <div class="waitlist__field">


### PR DESCRIPTION
## Summary
- Apex `mainahq.com` is served by GitHub Pages / Fastly and 405s POST, so the existing same-origin `/api/waitlist` endpoint silently falls back to mailto.
- The Cloudflare Worker in `mainahq/maina-cloud` is live on `api.mainahq.com` with CORS pinned to `https://mainahq.com`. Point the form's `data-waitlist-endpoint` at that absolute URL so the JSON path actually reaches the store.
- Closes the view → waitlist → CEO outreach measurement loop blocking MAI-4's funnel readout.
- One-line src change plus a refreshed header comment that explains the cross-origin posture for future readers.

## Test plan
- [x] `bun run typecheck` (astro check) — 0 errors, 0 warnings.
- [x] Smoke `curl -X POST https://api.mainahq.com/api/waitlist` from the same origin shape used by the form — 202.
- [x] OPTIONS preflight returns `Access-Control-Allow-Origin: https://mainahq.com` (verified live).
- [ ] After deploy/publish: load `mainahq.com/cloud`, submit form, confirm thank-you panel appears + row written to `waitlist_signups`.